### PR TITLE
Add game text translation and font (CHAR) PNG editing (V6 engine only) - v1.3.0.0

### DIFF
--- a/ScummEditor/Encoders/CharsetPngCodec.cs
+++ b/ScummEditor/Encoders/CharsetPngCodec.cs
@@ -1,0 +1,583 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Text;
+using ScummEditor.Structures;
+using ScummEditor.Structures.DataFile;
+
+namespace ScummEditor.Encoders
+{
+    /*
+    Exports a CHAR (charset/font) block to an editable PNG atlas and imports it back,
+    so designers can draw missing glyphs (accents) in Photoshop.
+
+    Atlas conventions:
+      - Always 16 x 16 = 256 slots, even when the font declares fewer chars - drawing in a
+        slot beyond numChars extends the font on import (e.g. adding 'ã' at slot 0xE3 to a
+        185-char font). Slot id = row * 16 + column, which IS the text byte / glyph index.
+      - Every cell has the glyph origin at (8, 8); the glyph's x/y offsets are baked into
+        its position. On import the offsets are recovered from the pixel bounding box
+        relative to that origin, so a glyph drawn anywhere in the cell keeps its alignment.
+      - The PNG is 8bpp indexed and each pixel byte is the raw glyph pixel value
+        (0 = transparent, 1..2^bpp-1 = ink), exactly like the room-image export pipeline.
+        The file must stay in indexed mode when edited.
+      - A companion guide PNG (same size) shows the grid, the hex slot ids, the origin
+        marks and the current glyphs, to be used as a reference layer in Photoshop.
+
+    Import safety: a cell whose pixels are identical to what export produces for the
+    current font keeps the original glyph bytes verbatim (so blank-but-present glyphs like
+    the space survive). When nothing changed at all, RawContent is left untouched.
+    */
+    public static class CharsetPngCodec
+    {
+        private const int Columns = 16;
+        private const int Rows = 16;     // always 256 slots so fonts can be extended
+        private const int Margin = 8;    // glyph origin inside each cell = (Margin, Margin)
+        private const int GridIndex = 255; // palette slot used for the cell divider lines (ignored on import)
+        private const int OffsetBase = 0x15;
+        private const int TableStart = 0x19;
+
+        // ---------------------------------------------------------------------
+        // Export
+        // ---------------------------------------------------------------------
+
+        public static void ExportPng(Charset charset, string pngPath, string guidePath)
+        {
+            int cellW, cellH;
+            CellSize(charset, out cellW, out cellH);
+            int width = Columns * cellW, height = Rows * cellH;
+
+            var matrix = new byte[width, height];
+
+            // divider lines on the top/left edge of every cell (GridIndex pixels are ignored on import)
+            for (int x = 0; x < width; x += cellW)
+                for (int y = 0; y < height; y++) matrix[x, y] = GridIndex;
+            for (int y = 0; y < height; y += cellH)
+                for (int x = 0; x < width; x++) matrix[x, y] = GridIndex;
+
+            for (int slot = 0; slot < charset.Glyphs.Count && slot < 256; slot++)
+            {
+                DrawGlyph(charset, charset.Glyphs[slot], matrix,
+                    (slot % Columns) * cellW, (slot / Columns) * cellH);
+            }
+
+            // No tRNS chunk: GDI+ reloads a paletted PNG with transparency as 32bpp ARGB,
+            // which would break the lossless indexed round-trip. Background stays opaque black.
+            using (Bitmap bitmap = IndexedImageHelper.FromIndexMatrix(matrix, BuildEditPalette(charset.BitsPerPixel), -1))
+            {
+                bitmap.Save(pngPath, ImageFormat.Png);
+            }
+
+            using (Bitmap guide = BuildGuide(charset, cellW, cellH))
+            {
+                guide.Save(guidePath, ImageFormat.Png);
+            }
+        }
+
+        /// <summary>
+        /// Palette for the editable atlas: 0 = background, 1..maxVal = ink shades,
+        /// 255 = cell divider lines (ignored on import), rest = magenta (invalid).
+        /// </summary>
+        public static Color[] BuildEditPalette(int bitsPerPixel)
+        {
+            int maxVal = (1 << bitsPerPixel) - 1;
+            var palette = new Color[256];
+            palette[0] = Color.Black;
+            for (int v = 1; v < 256; v++)
+            {
+                if (v <= maxVal)
+                {
+                    int level = bitsPerPixel == 1 ? 255 : 255 - (255 * v / maxVal); // same ramp as the glyph viewer
+                    if (level < 40) level = 40;                                     // keep every ink value visible on black
+                    palette[v] = Color.FromArgb(level, level, level);
+                }
+                else
+                {
+                    palette[v] = Color.Magenta; // painting with these would be invalid
+                }
+            }
+            palette[GridIndex] = Color.FromArgb(60, 80, 160); // divider lines
+            return palette;
+        }
+
+        private static void CellSize(Charset charset, out int cellW, out int cellH)
+        {
+            int maxX = 8, maxY = Math.Max(8, charset.FontHeight);
+            foreach (Glyph g in charset.Glyphs)
+            {
+                if (!g.Present) continue;
+                if (g.XOffset < -Margin || g.YOffset < -Margin)
+                    throw new InvalidOperationException(
+                        "Fonte com offsets de glifo menores que -8 não é suportada pela exportação PNG.");
+                if (g.XOffset + g.Width > maxX) maxX = g.XOffset + g.Width;
+                if (g.YOffset + g.Height > maxY) maxY = g.YOffset + g.Height;
+            }
+            cellW = Margin + maxX + Margin;
+            cellH = Margin + maxY + Margin;
+        }
+
+        private static void DrawGlyph(Charset charset, Glyph glyph, byte[,] matrix, int cellX, int cellY)
+        {
+            if (glyph == null || !glyph.Present || glyph.Width <= 0 || glyph.Height <= 0) return;
+
+            int width = matrix.GetLength(0), height = matrix.GetLength(1);
+            byte[,] values = ReadGlyphValues(charset, glyph);
+            for (int y = 0; y < glyph.Height; y++)
+            {
+                for (int x = 0; x < glyph.Width; x++)
+                {
+                    if (values[x, y] == 0) continue;
+                    int px = cellX + Margin + glyph.XOffset + x;
+                    int py = cellY + Margin + glyph.YOffset + y;
+                    if (px >= 0 && px < width && py >= 0 && py < height) matrix[px, py] = values[x, y];
+                }
+            }
+        }
+
+        private static Bitmap BuildGuide(Charset charset, int cellW, int cellH)
+        {
+            var bitmap = new Bitmap(Columns * cellW, Rows * cellH, PixelFormat.Format24bppRgb);
+            using (Graphics gfx = Graphics.FromImage(bitmap))
+            using (var extensionBrush = new SolidBrush(Color.FromArgb(255, 250, 220)))
+            using (var gridPen = new Pen(Color.FromArgb(190, 190, 190)))
+            using (var originPen = new Pen(Color.FromArgb(120, 170, 255)))
+            using (var glyphBrush = new SolidBrush(Color.FromArgb(150, 150, 150)))
+            using (var idFont = new Font("Consolas", 6f))
+            using (var idBrush = new SolidBrush(Color.Red))
+            {
+                gfx.Clear(Color.White);
+
+                for (int slot = 0; slot < 256; slot++)
+                {
+                    int cx = (slot % Columns) * cellW;
+                    int cy = (slot / Columns) * cellH;
+
+                    // tint the cells beyond the current numChars (extension area)
+                    if (slot >= charset.NumChars)
+                        gfx.FillRectangle(extensionBrush, cx, cy, cellW, cellH);
+
+                    gfx.DrawRectangle(gridPen, cx, cy, cellW - 1, cellH - 1);
+
+                    // origin marks: the glyph origin is at (Margin, Margin) in each cell
+                    gfx.DrawLine(originPen, cx + Margin, cy + Margin - 3, cx + Margin, cy + Margin + 3);
+                    gfx.DrawLine(originPen, cx + Margin - 3, cy + Margin, cx + Margin + 3, cy + Margin);
+
+                    // current glyph, as editing context
+                    if (slot < charset.Glyphs.Count)
+                    {
+                        Glyph glyph = charset.Glyphs[slot];
+                        if (glyph.Present && glyph.Width > 0 && glyph.Height > 0)
+                        {
+                            byte[,] values = ReadGlyphValues(charset, glyph);
+                            for (int y = 0; y < glyph.Height; y++)
+                                for (int x = 0; x < glyph.Width; x++)
+                                    if (values[x, y] != 0)
+                                        gfx.FillRectangle(glyphBrush,
+                                            cx + Margin + glyph.XOffset + x, cy + Margin + glyph.YOffset + y, 1, 1);
+                        }
+                    }
+
+                    // slot id (hex) - this is the byte value used in the game texts
+                    gfx.DrawString(slot.ToString("X2"), idFont, idBrush, cx, cy);
+                }
+            }
+            return bitmap;
+        }
+
+        // ---------------------------------------------------------------------
+        // Batch (all charsets of the game at once)
+        // ---------------------------------------------------------------------
+
+        /// <summary>Charsets of the game in tree (file) order - the index defines the file names.</summary>
+        public static List<Charset> CollectCharsets(ScummV6DataFile dataFile)
+        {
+            var result = new List<Charset>();
+            Collect(dataFile, result);
+            return result;
+        }
+
+        private static void Collect(BlockBase block, List<Charset> result)
+        {
+            var charset = block as Charset;
+            if (charset != null) result.Add(charset);
+            foreach (BlockBase child in block.Childrens) Collect(child, result);
+        }
+
+        /// <summary>Exports every charset as charset_N.png + charset_N.guide.png into a folder.</summary>
+        public static string ExportAll(ScummV6DataFile dataFile, string folder)
+        {
+            List<Charset> charsets = CollectCharsets(dataFile);
+            for (int i = 0; i < charsets.Count; i++)
+            {
+                ExportPng(charsets[i],
+                    Path.Combine(folder, "charset_" + i + ".png"),
+                    Path.Combine(folder, "charset_" + i + ".guide.png"));
+            }
+            return charsets.Count + " fontes exportadas para:\n" + folder
+                + "\n\nArquivos: charset_0.png ... charset_" + (charsets.Count - 1)
+                + ".png (+ os .guide.png de referência).";
+        }
+
+        /// <summary>Imports every charset_N.png found in the folder back into the game's charsets.</summary>
+        public static string ImportAll(ScummV6DataFile dataFile, string folder)
+        {
+            List<Charset> charsets = CollectCharsets(dataFile);
+            var report = new StringBuilder();
+            int imported = 0, missing = 0, failed = 0;
+
+            for (int i = 0; i < charsets.Count; i++)
+            {
+                string file = "charset_" + i + ".png";
+                string path = Path.Combine(folder, file);
+                if (!File.Exists(path))
+                {
+                    missing++;
+                    report.AppendLine(file + ": não encontrado (pulado)");
+                    continue;
+                }
+
+                try
+                {
+                    string result = ImportPng(charsets[i], path);
+                    imported++;
+                    report.AppendLine(file + ": " + result.Replace(Environment.NewLine, " "));
+                }
+                catch (Exception ex)
+                {
+                    failed++;
+                    report.AppendLine(file + ": ERRO - " + ex.Message);
+                }
+            }
+
+            report.AppendLine();
+            report.Append(string.Format("{0} fonte(s) processada(s), {1} sem arquivo, {2} com erro.",
+                imported, missing, failed));
+            return report.ToString();
+        }
+
+        // ---------------------------------------------------------------------
+        // Import
+        // ---------------------------------------------------------------------
+
+        private class SlotPlan
+        {
+            public bool Present;
+            public Glyph KeepOriginal; // non-null: copy the original glyph bytes verbatim
+            public byte[,] Values;     // new glyph pixels (bbox-cropped)
+            public int W, H, XOff, YOff;
+        }
+
+        public static string ImportPng(Charset charset, string pngPath)
+        {
+            byte[,] pixels;
+            int width, height;
+            using (var loaded = (Bitmap)Image.FromFile(pngPath))
+            {
+                if (!IndexedImageHelper.IsIndexed(loaded))
+                    throw new InvalidDataException(
+                        "O PNG precisa estar em modo indexado (8 bits). Use o arquivo exportado pelo editor e mantenha o modo de cor.");
+                pixels = IndexedImageHelper.GetIndexMatrix(loaded);
+                width = loaded.Width;
+                height = loaded.Height;
+            }
+
+            if (width % Columns != 0 || height % Rows != 0)
+                throw new InvalidDataException(string.Format(
+                    "Dimensões {0}x{1} inválidas: precisam ser múltiplas de {2}x{3} (grade de 256 slots).",
+                    width, height, Columns, Rows));
+            int cellW = width / Columns, cellH = height / Rows;
+            int maxVal = (1 << charset.BitsPerPixel) - 1;
+
+            // the divider lines are decoration only - drop them before any analysis
+            for (int y = 0; y < height; y++)
+                for (int x = 0; x < width; x++)
+                    if (pixels[x, y] == GridIndex) pixels[x, y] = 0;
+
+            // Stored glyph boxes are usually larger than the ink (empty right column = cursor
+            // advance, empty top rows = line position). New glyphs get the font's typical
+            // (modal) padding so a glyph drawn like its neighbours also measures like them.
+            int slackRight, slackBottom;
+            ComputeModalSlacks(charset, out slackRight, out slackBottom);
+
+            var plans = new SlotPlan[256];
+            var badValues = new List<string>();
+            int changed = 0, added = 0, removed = 0;
+
+            for (int slot = 0; slot < 256; slot++)
+            {
+                int cellX = (slot % Columns) * cellW;
+                int cellY = (slot / Columns) * cellH;
+
+                // pixel bounding box of the cell
+                int left = int.MaxValue, top = int.MaxValue, right = -1, bottom = -1;
+                for (int y = 0; y < cellH; y++)
+                {
+                    for (int x = 0; x < cellW; x++)
+                    {
+                        byte v = pixels[cellX + x, cellY + y];
+                        if (v == 0) continue;
+                        if (v > maxVal && badValues.Count < 8)
+                            badValues.Add(string.Format("slot 0x{0:X2}: valor {1} (máximo {2})", slot, v, maxVal));
+                        if (x < left) left = x;
+                        if (y < top) top = y;
+                        if (x > right) right = x;
+                        if (y > bottom) bottom = y;
+                    }
+                }
+                bool anyPixel = right >= 0;
+
+                Glyph original = slot < charset.Glyphs.Count ? charset.Glyphs[slot] : null;
+                bool origPresent = original != null && original.Present;
+
+                if (CellMatchesOriginal(charset, original, pixels, cellX, cellY, cellW, cellH))
+                {
+                    if (origPresent)
+                        plans[slot] = new SlotPlan { Present = true, KeepOriginal = original };
+                    continue; // unchanged (absent stays absent, blank-but-present keeps its bytes)
+                }
+
+                if (!anyPixel)
+                {
+                    if (origPresent) removed++;
+                    continue; // cleared cell -> glyph absent
+                }
+
+                // glyph box in cell coordinates
+                int boxL, boxT, boxR, boxB;
+                if (origPresent && original.Width > 0 && original.Height > 0)
+                {
+                    // edited glyph: keep the original box (metrics/advance), grow only if the ink leaks out
+                    boxL = Margin + original.XOffset;
+                    boxT = Margin + original.YOffset;
+                    boxR = boxL + original.Width - 1;
+                    boxB = boxT + original.Height - 1;
+                    if (left < boxL) boxL = left;
+                    if (top < boxT) boxT = top;
+                    if (right > boxR) boxR = right;
+                    if (bottom > boxB) boxB = bottom;
+                }
+                else
+                {
+                    // new glyph: box anchored at the origin, plus the font's modal padding
+                    boxL = Math.Min(left, Margin);
+                    boxT = Math.Min(top, Margin);
+                    boxR = right + slackRight;
+                    boxB = bottom + slackBottom;
+                }
+
+                int w = boxR - boxL + 1, h = boxB - boxT + 1;
+                int xoff = boxL - Margin, yoff = boxT - Margin;
+                if (w > 255 || h > 255 || xoff < -128 || xoff > 127 || yoff < -128 || yoff > 127)
+                    throw new InvalidDataException(string.Format(
+                        "slot 0x{0:X2}: glifo {1}x{2} com offset ({3},{4}) fora dos limites do formato.",
+                        slot, w, h, xoff, yoff));
+
+                var values = new byte[w, h];
+                for (int y = 0; y < h; y++)
+                {
+                    for (int x = 0; x < w; x++)
+                    {
+                        int px = boxL + x, py = boxT + y;
+                        values[x, y] = px >= 0 && px < cellW && py >= 0 && py < cellH
+                            ? pixels[cellX + px, cellY + py]
+                            : (byte)0;
+                    }
+                }
+
+                plans[slot] = new SlotPlan { Present = true, Values = values, W = w, H = h, XOff = xoff, YOff = yoff };
+                if (origPresent) changed++; else added++;
+            }
+
+            if (badValues.Count > 0)
+                throw new InvalidDataException("Pixels com valores inválidos para " + charset.BitsPerPixel
+                    + " bpp:\n  " + string.Join("\n  ", badValues.ToArray()));
+
+            if (changed + added + removed == 0)
+                return "Nenhuma alteração encontrada - a fonte não foi modificada.";
+
+            RebuildRawContent(charset, plans);
+
+            var report = new StringBuilder();
+            report.AppendLine(string.Format("Glifos alterados: {0}, adicionados: {1}, removidos: {2}.", changed, added, removed));
+            report.Append(string.Format("numChars: {0} (use 'Save Changes' para gravar no jogo).", charset.NumChars));
+            return report.ToString();
+        }
+
+        /// <summary>
+        /// Most common (modal) padding between the ink and the stored box edge across the font's
+        /// glyphs: right padding doubles as cursor advance, bottom padding as line spacing.
+        /// </summary>
+        private static void ComputeModalSlacks(Charset charset, out int slackRight, out int slackBottom)
+        {
+            var histRight = new int[16];
+            var histBottom = new int[16];
+            foreach (Glyph g in charset.Glyphs)
+            {
+                if (!g.Present || g.Width <= 0 || g.Height <= 0) continue;
+                byte[,] values = ReadGlyphValues(charset, g);
+                int right = -1, bottom = -1;
+                for (int y = 0; y < g.Height; y++)
+                    for (int x = 0; x < g.Width; x++)
+                        if (values[x, y] != 0) { if (x > right) right = x; if (y > bottom) bottom = y; }
+                if (right < 0) continue; // blank glyph
+
+                int sr = g.Width - 1 - right;
+                int sb = g.Height - 1 - bottom;
+                if (sr < histRight.Length) histRight[sr]++;
+                if (sb < histBottom.Length) histBottom[sb]++;
+            }
+            slackRight = ModeOf(histRight);
+            slackBottom = ModeOf(histBottom);
+        }
+
+        private static int ModeOf(int[] histogram)
+        {
+            int best = 0;
+            for (int i = 1; i < histogram.Length; i++)
+                if (histogram[i] > histogram[best]) best = i;
+            return best;
+        }
+
+        /// <summary>True when the cell pixels are exactly what ExportPng would produce for this glyph.</summary>
+        private static bool CellMatchesOriginal(Charset charset, Glyph original, byte[,] pixels,
+                                                int cellX, int cellY, int cellW, int cellH)
+        {
+            var expected = new byte[cellW, cellH];
+            if (original != null && original.Present && original.Width > 0 && original.Height > 0)
+            {
+                byte[,] values = ReadGlyphValues(charset, original);
+                for (int y = 0; y < original.Height; y++)
+                {
+                    for (int x = 0; x < original.Width; x++)
+                    {
+                        if (values[x, y] == 0) continue;
+                        int px = Margin + original.XOffset + x;
+                        int py = Margin + original.YOffset + y;
+                        if (px < 0 || px >= cellW || py < 0 || py >= cellH) return false; // does not fit -> not comparable
+                        expected[px, py] = values[x, y];
+                    }
+                }
+            }
+
+            for (int y = 0; y < cellH; y++)
+                for (int x = 0; x < cellW; x++)
+                    if (pixels[cellX + x, cellY + y] != expected[x, y]) return false;
+            return true;
+        }
+
+        private static void RebuildRawContent(Charset charset, SlotPlan[] plans)
+        {
+            int newNumChars = charset.NumChars;
+            for (int slot = 0; slot < 256; slot++)
+                if (plans[slot] != null && plans[slot].Present && slot >= newNumChars) newNumChars = slot + 1;
+
+            byte[] old = charset.RawContent;
+            int bpp = charset.BitsPerPixel;
+            int tableBytes = newNumChars * 4;
+            int dataStartRel = TableStart + tableBytes - OffsetBase;
+
+            var blob = new List<byte>();
+            var offsets = new uint[newNumChars];
+            for (int slot = 0; slot < newNumChars; slot++)
+            {
+                SlotPlan plan = slot < plans.Length ? plans[slot] : null;
+                if (plan == null || !plan.Present) continue;
+
+                offsets[slot] = (uint)(dataStartRel + blob.Count);
+                if (plan.KeepOriginal != null)
+                {
+                    Glyph g = plan.KeepOriginal;
+                    int length = 4 + (g.Width * g.Height * bpp + 7) / 8;
+                    if (g.DataOffset + length > old.Length) length = old.Length - g.DataOffset;
+                    for (int i = 0; i < length; i++) blob.Add(old[g.DataOffset + i]);
+                }
+                else
+                {
+                    blob.Add((byte)plan.W);
+                    blob.Add((byte)plan.H);
+                    blob.Add((byte)(sbyte)plan.XOff);
+                    blob.Add((byte)(sbyte)plan.YOff);
+                    WriteGlyphBits(blob, plan.Values, plan.W, plan.H, bpp);
+                }
+            }
+
+            var raw = new byte[TableStart + tableBytes + blob.Count];
+            Array.Copy(old, raw, Math.Min(TableStart, old.Length));
+            raw[0x17] = (byte)(newNumChars & 0xFF);
+            raw[0x18] = (byte)(newNumChars >> 8);
+            for (int i = 0; i < newNumChars; i++)
+            {
+                uint off = offsets[i];
+                int p = TableStart + i * 4;
+                raw[p] = (byte)off;
+                raw[p + 1] = (byte)(off >> 8);
+                raw[p + 2] = (byte)(off >> 16);
+                raw[p + 3] = (byte)(off >> 24);
+            }
+            blob.CopyTo(raw, TableStart + tableBytes);
+
+            // The leading dword tracks the data size; preserve its original relation to the length.
+            uint origInternal = (uint)(old[0] | (old[1] << 8) | (old[2] << 16) | (old[3] << 24));
+            uint newInternal = (uint)(origInternal + (raw.Length - old.Length));
+            raw[0] = (byte)newInternal;
+            raw[1] = (byte)(newInternal >> 8);
+            raw[2] = (byte)(newInternal >> 16);
+            raw[3] = (byte)(newInternal >> 24);
+
+            charset.RawContent = raw;
+            charset.Reparse();
+        }
+
+        // ---------------------------------------------------------------------
+        // Glyph pixel helpers
+        // ---------------------------------------------------------------------
+
+        private static byte[,] ReadGlyphValues(Charset charset, Glyph glyph)
+        {
+            byte[] raw = charset.RawContent;
+            int bpp = charset.BitsPerPixel;
+            var values = new byte[glyph.Width, glyph.Height];
+            int bitPos = (glyph.DataOffset + 4) * 8;
+
+            for (int y = 0; y < glyph.Height; y++)
+            {
+                for (int x = 0; x < glyph.Width; x++)
+                {
+                    int value = 0;
+                    for (int i = 0; i < bpp; i++)
+                    {
+                        int bytePos = bitPos >> 3;
+                        int bit = 7 - (bitPos & 7);
+                        int b = bytePos < raw.Length ? ((raw[bytePos] >> bit) & 1) : 0;
+                        value = (value << 1) | b;
+                        bitPos++;
+                    }
+                    values[x, y] = (byte)value;
+                }
+            }
+            return values;
+        }
+
+        private static void WriteGlyphBits(List<byte> output, byte[,] values, int w, int h, int bpp)
+        {
+            int acc = 0, bits = 0;
+            for (int y = 0; y < h; y++)
+            {
+                for (int x = 0; x < w; x++)
+                {
+                    acc = (acc << bpp) | (values[x, y] & ((1 << bpp) - 1));
+                    bits += bpp;
+                    while (bits >= 8)
+                    {
+                        output.Add((byte)(acc >> (bits - 8)));
+                        bits -= 8;
+                        acc &= (1 << bits) - 1;
+                    }
+                }
+            }
+            if (bits > 0) output.Add((byte)(acc << (8 - bits)));
+        }
+    }
+}

--- a/ScummEditor/Encoders/GameTextCodec.cs
+++ b/ScummEditor/Encoders/GameTextCodec.cs
@@ -1,0 +1,308 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace ScummEditor.Encoders
+{
+    /*
+    Converts SCUMM message bytes to/from a translator-friendly display form.
+
+    In-game text bytes are glyph indexes into the active CHAR (charset) resource, so there is
+    no fixed encoding: each translation project decides which byte holds which accented glyph.
+    The codec carries that decision as a character map (Unicode char <-> game byte). The map is
+    serialized into the "; charmap:" header line of the export file and is rebuilt from that
+    line on import - the file is the single source of truth, so the translation team can remap
+    free font slots by editing the header (and/or use literal {0xNN} tokens in the text, e.g.
+    "Cla{0xC1}e" to print a custom 'ss' ligature drawn at slot 0xC1).
+
+    Display form rules:
+      - ASCII 0x20..0x7E pass through ('{' and '}' are doubled: "{{", "}}").
+      - Mapped high bytes become their Unicode character (e.g. 0xE3 -> 'ã').
+      - Unmapped bytes become "{0xNN}".
+      - 0xFF/0xFE escape sequences become tokens:
+          {br} {keep} {wait} {e8}                      (codes 1, 2, 3, 8 - no argument)
+          {int:N} {verb:N} {name:N} {str:N} {anim:N}
+          {sound:N} {color:N} {unk13:N} {font:N}       (codes 4..14 - 16-bit argument)
+          {escNN:N}                                    (any other code)
+        A 0xFE prefix uses the same tokens with a "fe-" prefix, e.g. {fe-br}.
+    */
+    public class GameTextCodec
+    {
+        private readonly Dictionary<byte, char> _byteToChar = new Dictionary<byte, char>();
+        private readonly Dictionary<char, byte> _charToByte = new Dictionary<char, byte>();
+
+        // FF/FE escape codes without an argument; all the others carry a 16-bit LE argument.
+        private static readonly int[] NoArgCodes = { 1, 2, 3, 8 };
+
+        private static readonly Dictionary<int, string> EscapeNames = new Dictionary<int, string>
+        {
+            { 1, "br" }, { 2, "keep" }, { 3, "wait" }, { 8, "e8" },
+            { 4, "int" }, { 5, "verb" }, { 6, "name" }, { 7, "str" },
+            { 9, "anim" }, { 10, "sound" }, { 12, "color" }, { 13, "unk13" }, { 14, "font" }
+        };
+
+        private GameTextCodec()
+        {
+        }
+
+        private void Map(char ch, int b)
+        {
+            _byteToChar[(byte)b] = ch;
+            if (!_charToByte.ContainsKey(ch)) _charToByte.Add(ch, (byte)b);
+        }
+
+        // ---------------------------------------------------------------------
+        // The default map
+        // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// The single built-in map, written to the export header. It follows the convention of
+        /// the ScummBR Sam &amp; Max translation: accents the original LEC fonts already had stay
+        /// at their CP437 slots; the missing ones (ã, õ, uppercase accents...) live at their
+        /// Latin-1 positions. The translation team is free to edit the "; charmap:" line of the
+        /// exported file - the import always rebuilds the map from there.
+        /// </summary>
+        public static GameTextCodec Default()
+        {
+            var codec = new GameTextCodec();
+            codec.Map('Ç', 0x80); codec.Map('ü', 0x81); codec.Map('é', 0x82); codec.Map('â', 0x83);
+            codec.Map('à', 0x85); codec.Map('ç', 0x87); codec.Map('ê', 0x88); codec.Map('ë', 0x89);
+            codec.Map('É', 0x90); codec.Map('ô', 0x93); codec.Map('á', 0xA0);
+            codec.Map('À', 0xC0); codec.Map('Á', 0xC1); codec.Map('Â', 0xC2); codec.Map('Ã', 0xC3);
+            codec.Map('È', 0xC8); codec.Map('Ê', 0xCA); codec.Map('Í', 0xCD); codec.Map('Ó', 0xD3);
+            codec.Map('Ô', 0xD4); codec.Map('Õ', 0xD5); codec.Map('Ú', 0xDA);
+            codec.Map('ã', 0xE3); codec.Map('è', 0xE8); codec.Map('í', 0xED); codec.Map('ò', 0xF2);
+            codec.Map('ó', 0xF3); codec.Map('õ', 0xF5); codec.Map('ú', 0xFA); codec.Map('ý', 0xFD);
+            return codec;
+        }
+
+        /// <summary>
+        /// Builds a codec from a charmap line pasted by the user - either the full header line
+        /// ("; charmap: é=0x82 ...") or just the pairs. Blank input returns the default map.
+        /// </summary>
+        public static GameTextCodec ParsePastedCharmap(string pasted)
+        {
+            if (pasted == null) return Default();
+            string s = pasted.Trim();
+            if (s.StartsWith(";")) s = s.Substring(1).TrimStart();
+            if (s.StartsWith("charmap:", StringComparison.OrdinalIgnoreCase)) s = s.Substring(8).TrimStart();
+            if (s.Length == 0) return Default();
+            return FromMapSpec(s);
+        }
+
+        /// <summary>
+        /// Builds a codec from a serialized map ("Ç=0x80 é=0x82 ..."), validating it: the team
+        /// edits this line by hand, and a duplicated or reserved mapping would silently corrupt
+        /// the texts on import.
+        /// </summary>
+        public static GameTextCodec FromMapSpec(string spec)
+        {
+            var codec = new GameTextCodec();
+            foreach (string token in spec.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                int eq = token.IndexOf('=');
+                if (eq != 1) throw new FormatException("entrada de charmap inválida: '" + token + "' (esperado 'caractere=0xNN')");
+                char ch = token[0];
+                string hex = token.Substring(eq + 1);
+                if (hex.StartsWith("0x", StringComparison.OrdinalIgnoreCase)) hex = hex.Substring(2);
+                byte b;
+                if (!byte.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out b))
+                    throw new FormatException("byte inválido no charmap: '" + token + "'");
+
+                if (ch <= 0x7E)
+                    throw new FormatException("charmap não pode remapear caracteres ASCII: '" + token + "'");
+                if (b == 0x00 || b == 0xFE || b == 0xFF)
+                    throw new FormatException("byte reservado no charmap (0x00/0xFE/0xFF): '" + token + "'");
+                if (codec._charToByte.ContainsKey(ch))
+                    throw new FormatException("caractere duplicado no charmap: '" + ch + "'");
+                if (codec._byteToChar.ContainsKey(b))
+                    throw new FormatException("byte duplicado no charmap: '0x" + b.ToString("X2") + "'");
+
+                codec.Map(ch, b);
+            }
+            return codec;
+        }
+
+        /// <summary>Serializes the map for the export file header ("Ç=0x80 é=0x82 ...").</summary>
+        public string ToMapSpec()
+        {
+            var keys = new List<byte>(_byteToChar.Keys);
+            keys.Sort();
+            var sb = new StringBuilder();
+            foreach (byte b in keys)
+            {
+                if (sb.Length > 0) sb.Append(' ');
+                sb.Append(_byteToChar[b]).Append("=0x").Append(b.ToString("X2"));
+            }
+            return sb.ToString();
+        }
+
+        // ---------------------------------------------------------------------
+        // Bytes -> display text
+        // ---------------------------------------------------------------------
+
+        /// <summary>Decodes string content bytes (without the 0x00 terminator) to display form.</summary>
+        public string Decode(byte[] buf, int offset, int contentLength)
+        {
+            var sb = new StringBuilder();
+            int end = offset + contentLength;
+            int i = offset;
+            while (i < end)
+            {
+                byte b = buf[i];
+
+                if ((b == 0xFF || b == 0xFE) && i + 1 < end)
+                {
+                    byte code = buf[i + 1];
+                    string prefix = b == 0xFE ? "fe-" : "";
+                    string name;
+                    if (!EscapeNames.TryGetValue(code, out name)) name = "esc" + code;
+
+                    if (Array.IndexOf(NoArgCodes, (int)code) >= 0)
+                    {
+                        sb.Append('{').Append(prefix).Append(name).Append('}');
+                        i += 2;
+                    }
+                    else if (i + 3 < end)
+                    {
+                        int val = buf[i + 2] | (buf[i + 3] << 8);
+                        sb.Append('{').Append(prefix).Append(name).Append(':').Append(val).Append('}');
+                        i += 4;
+                    }
+                    else
+                    {
+                        sb.Append("{0x").Append(b.ToString("X2")).Append('}'); // truncated escape
+                        i++;
+                    }
+                }
+                else if (b == (byte)'{') { sb.Append("{{"); i++; }
+                else if (b == (byte)'}') { sb.Append("}}"); i++; }
+                else if (b >= 0x20 && b <= 0x7E) { sb.Append((char)b); i++; }
+                else
+                {
+                    char ch;
+                    if (_byteToChar.TryGetValue(b, out ch)) sb.Append(ch);
+                    else sb.Append("{0x").Append(b.ToString("X2")).Append('}');
+                    i++;
+                }
+            }
+            return sb.ToString();
+        }
+
+        // ---------------------------------------------------------------------
+        // Display text -> bytes
+        // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// Encodes display text back to game bytes (without terminator). Returns null and sets
+        /// <paramref name="error"/> when the text contains an unmapped character or a bad token.
+        /// </summary>
+        public byte[] Encode(string text, out string error)
+        {
+            error = null;
+            var bytes = new List<byte>(text.Length + 8);
+            int i = 0;
+            while (i < text.Length)
+            {
+                char ch = text[i];
+
+                if (ch == '{')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '{') { bytes.Add((byte)'{'); i += 2; continue; }
+
+                    int close = text.IndexOf('}', i + 1);
+                    if (close < 0) { error = "'{' sem '}' correspondente"; return null; }
+                    string token = text.Substring(i + 1, close - i - 1);
+                    if (!EncodeToken(token, bytes, out error)) return null;
+                    i = close + 1;
+                }
+                else if (ch == '}')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '}') { bytes.Add((byte)'}'); i += 2; continue; }
+                    error = "'}' sem '{' correspondente";
+                    return null;
+                }
+                else if (ch >= 0x20 && ch <= 0x7E) { bytes.Add((byte)ch); i++; }
+                else
+                {
+                    byte b;
+                    if (_charToByte.TryGetValue(ch, out b)) { bytes.Add(b); i++; }
+                    else
+                    {
+                        error = "caractere sem mapeamento no charmap: '" + ch + "' (U+" + ((int)ch).ToString("X4") + ")";
+                        return null;
+                    }
+                }
+            }
+            return bytes.ToArray();
+        }
+
+        private bool EncodeToken(string token, List<byte> bytes, out string error)
+        {
+            error = null;
+
+            // {0xNN} - literal byte
+            if (token.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                byte raw;
+                if (!byte.TryParse(token.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out raw))
+                {
+                    error = "token inválido: {" + token + "}";
+                    return false;
+                }
+                bytes.Add(raw);
+                return true;
+            }
+
+            byte prefix = 0xFF;
+            string body = token;
+            if (body.StartsWith("fe-")) { prefix = 0xFE; body = body.Substring(3); }
+
+            string name = body;
+            string argText = null;
+            int colon = body.IndexOf(':');
+            if (colon >= 0)
+            {
+                name = body.Substring(0, colon);
+                argText = body.Substring(colon + 1);
+            }
+
+            int code = -1;
+            foreach (KeyValuePair<int, string> kv in EscapeNames)
+                if (kv.Value == name) { code = kv.Key; break; }
+            if (code < 0 && name.StartsWith("esc"))
+            {
+                int n;
+                if (int.TryParse(name.Substring(3), out n) && n >= 0 && n <= 255) code = n;
+            }
+            if (code < 0)
+            {
+                error = "token desconhecido: {" + token + "}";
+                return false;
+            }
+
+            bool hasArg = Array.IndexOf(NoArgCodes, code) < 0;
+            if (hasArg != (argText != null))
+            {
+                error = "token {" + token + "} " + (hasArg ? "exige" : "não aceita") + " argumento";
+                return false;
+            }
+
+            bytes.Add(prefix);
+            bytes.Add((byte)code);
+            if (hasArg)
+            {
+                int val;
+                if (!int.TryParse(argText, out val) || val < 0 || val > 0xFFFF)
+                {
+                    error = "argumento inválido em {" + token + "}";
+                    return false;
+                }
+                bytes.Add((byte)(val & 0xFF));
+                bytes.Add((byte)(val >> 8));
+            }
+            return true;
+        }
+    }
+}

--- a/ScummEditor/Encoders/GameTextManager.cs
+++ b/ScummEditor/Encoders/GameTextManager.cs
@@ -1,0 +1,705 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using ScummEditor.Structures;
+using ScummEditor.Structures.DataFile;
+
+namespace ScummEditor.Encoders
+{
+    /// <summary>One translatable text with its stable id (e.g. "LF003.SCRP000.t005").</summary>
+    public class GameTextEntry
+    {
+        public string Id { get; set; }
+        public string Kind { get; set; }
+        public string Text { get; set; }
+    }
+
+    public class GameTextImportReport
+    {
+        public int LinesParsed { get; set; }
+        public int EntriesMatched { get; set; }
+        public int StringsChanged { get; set; }
+        public int BlocksRebuilt { get; set; }
+        public List<string> Errors = new List<string>();
+        public List<string> Warnings = new List<string>();
+        public List<string> GlyphNotes = new List<string>();
+
+        public bool HasChanges { get { return StringsChanged > 0; } }
+
+        public string Summary()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("Linhas de texto lidas: " + LinesParsed);
+            sb.AppendLine("Textos localizados no jogo: " + EntriesMatched);
+            sb.AppendLine("Textos alterados: " + StringsChanged);
+            sb.AppendLine("Blocos reconstruídos: " + BlocksRebuilt);
+            if (Errors.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("ERROS (" + Errors.Count + "):");
+                for (int i = 0; i < Errors.Count && i < 20; i++) sb.AppendLine("  " + Errors[i]);
+                if (Errors.Count > 20) sb.AppendLine("  ... e mais " + (Errors.Count - 20));
+            }
+            if (Warnings.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("Avisos (" + Warnings.Count + "):");
+                for (int i = 0; i < Warnings.Count && i < 20; i++) sb.AppendLine("  " + Warnings[i]);
+                if (Warnings.Count > 20) sb.AppendLine("  ... e mais " + (Warnings.Count - 20));
+            }
+            if (GlyphNotes.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("Fontes (CHAR) x caracteres usados:");
+                foreach (string n in GlyphNotes) sb.AppendLine("  " + n);
+            }
+            return sb.ToString();
+        }
+    }
+
+    /*
+    Exports every translatable game text to a flat .txt (one string per line, stable ids,
+    control codes as {tokens}) and imports it back, rebuilding the affected bytecode.
+
+    Text lives in:
+      - SCRP / LSCR / ENCD / EXCD script blocks (talkActor, print*, names, arrays...)
+      - OBCD VERB bytecode (the per-verb scripts), plus the OBNA object name
+
+    Importing a string with a different length shifts the rest of its block, so the importer
+    rebuilds the block: it splices the new string bytes, remaps every relative-jump operand
+    (if / ifNot / jump / wait retry) and the VERB offset table, then re-disassembles the result
+    and only accepts it when the instruction stream is provably identical (same string and jump
+    layout, fully decoded to the end). Block sizes / LOFF / index directories are recomputed by
+    the regular save pipeline (ScummV6GameData.PostProcessChanges).
+    */
+    public static class GameTextManager
+    {
+        // ---------------------------------------------------------------------
+        // Source enumeration (shared by export and import; ids must be stable)
+        // ---------------------------------------------------------------------
+
+        private class Source
+        {
+            public string Id;
+            public ScriptBlock Script;   // script-block source
+            public ObjectCode Obcd;      // OBCD source (verb bytecode, or name when IsName)
+            public bool IsName;
+        }
+
+        private static List<Source> EnumerateSources(ScummV6DataFile dataFile)
+        {
+            var list = new List<Source>();
+            List<DiskBlock> lflfs = dataFile.GetLFLFs();
+
+            for (int i = 0; i < lflfs.Count; i++)
+            {
+                string lf = "LF" + i.ToString("D3");
+                DiskBlock disk = lflfs[i];
+
+                RoomBlock room = disk.GetROOM();
+                if (room != null)
+                {
+                    int encd = 0, excd = 0, obcdOrdinal = 0;
+                    var usedLabels = new HashSet<string>(); // a room can repeat an object id (e.g. S&M obj 561)
+                    foreach (BlockBase child in room.Childrens)
+                    {
+                        var script = child as ScriptBlock;
+                        if (script != null)
+                        {
+                            if (script.BlockType == "ENCD")
+                                list.Add(new Source { Id = lf + ".ENCD" + (encd++).ToString("D3"), Script = script });
+                            else if (script.BlockType == "EXCD")
+                                list.Add(new Source { Id = lf + ".EXCD" + (excd++).ToString("D3"), Script = script });
+                            else if (script.BlockType == "LSCR")
+                                list.Add(new Source { Id = lf + ".LSCR" + Math.Max(script.ScriptId, 0).ToString("D3"), Script = script });
+                            continue;
+                        }
+
+                        var obcd = child as ObjectCode;
+                        if (obcd != null)
+                        {
+                            string obj = obcd.HasCodeHeader
+                                ? "OBJ" + obcd.ObjectId.ToString("D5")
+                                : "OBC" + obcdOrdinal.ToString("D3");
+                            obcdOrdinal++;
+                            string baseObj = obj;
+                            for (int dup = 2; !usedLabels.Add(obj); dup++) obj = baseObj + "x" + dup;
+
+                            if (obcd.VerbCodeOffset >= 0 && obcd.VerbCodeLength > 0)
+                                list.Add(new Source { Id = lf + "." + obj, Obcd = obcd });
+                            if (obcd.ObnaBodyOffset >= 0)
+                                list.Add(new Source { Id = lf + "." + obj + ".name", Obcd = obcd, IsName = true });
+                        }
+                    }
+                }
+
+                int scrp = 0;
+                foreach (BlockBase child in disk.Childrens)
+                {
+                    var script = child as ScriptBlock;
+                    if (script != null && script.BlockType == "SCRP")
+                        list.Add(new Source { Id = lf + ".SCRP" + (scrp++).ToString("D3"), Script = script });
+                }
+            }
+            return list;
+        }
+
+        private static byte[] VerbCodeSlice(ObjectCode obcd)
+        {
+            var slice = new byte[obcd.VerbCodeLength];
+            Array.Copy(obcd.RawContent, obcd.VerbCodeOffset, slice, 0, obcd.VerbCodeLength);
+            return slice;
+        }
+
+        private static int ObnaNameLength(ObjectCode obcd)
+        {
+            int n = 0;
+            while (n < obcd.ObnaBodyLength && obcd.RawContent[obcd.ObnaBodyOffset + n] != 0) n++;
+            return n;
+        }
+
+        // ---------------------------------------------------------------------
+        // Export
+        // ---------------------------------------------------------------------
+
+        public static List<GameTextEntry> Extract(ScummV6DataFile dataFile, GameTextCodec codec)
+        {
+            var entries = new List<GameTextEntry>();
+            foreach (Source source in EnumerateSources(dataFile))
+            {
+                if (source.IsName)
+                {
+                    string name = codec.Decode(source.Obcd.RawContent, source.Obcd.ObnaBodyOffset, ObnaNameLength(source.Obcd));
+                    if (!HasTranslatableContent(name)) continue; // empty/blank names are noise
+                    entries.Add(new GameTextEntry { Id = source.Id, Kind = "objectName", Text = name });
+                    continue;
+                }
+
+                byte[] buf = source.Script != null ? source.Script.RawContent : VerbCodeSlice(source.Obcd);
+                int start = source.Script != null ? source.Script.CodeOffset : 0;
+                Scumm6Disassembler.Result scan = Scumm6Disassembler.Disassemble(buf, start);
+
+                for (int k = 0; k < scan.Strings.Count; k++)
+                {
+                    Scumm6Disassembler.StringRef s = scan.Strings[k];
+                    if (s.Kind == "actorName") continue; // internal actor names are not translated
+
+                    string text = codec.Decode(buf, s.Offset, s.Length - (s.Terminated ? 1 : 0));
+                    if (!HasTranslatableContent(text)) continue; // empty or escape-tokens-only line
+                    entries.Add(new GameTextEntry
+                    {
+                        Id = source.Id + ".t" + k.ToString("D3"),
+                        Kind = s.Kind,
+                        Text = text
+                    });
+                }
+            }
+            return entries;
+        }
+
+        /// <summary>
+        /// True when the display text has something a translator can act on: any visible
+        /// character outside escape tokens. Whitespace and escape tokens ({br}, {sound:N}...)
+        /// are not content; literal braces ({{ / }}) and raw glyph bytes ({0xNN}) are.
+        /// Entries without content are skipped on export - the import keeps the original
+        /// string for every id missing from the file.
+        /// </summary>
+        private static bool HasTranslatableContent(string text)
+        {
+            int i = 0;
+            while (i < text.Length)
+            {
+                char c = text[i];
+                if (c == '{')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '{') return true; // literal '{'
+
+                    int close = text.IndexOf('}', i + 1);
+                    if (close < 0) return true; // malformed - keep it visible to the translator
+
+                    string token = text.Substring(i + 1, close - i - 1);
+                    if (token.StartsWith("0x", StringComparison.OrdinalIgnoreCase)) return true; // visible glyph
+                    i = close + 1;
+                    continue;
+                }
+                if (c == '}')
+                {
+                    if (i + 1 < text.Length && text[i + 1] == '}') return true; // literal '}'
+                    i++;
+                    continue;
+                }
+                if (!char.IsWhiteSpace(c)) return true;
+                i++;
+            }
+            return false;
+        }
+
+        public static int ExportToFile(ScummV6DataFile dataFile, string path, GameTextCodec codec, string gameLabel)
+        {
+            List<GameTextEntry> entries = Extract(dataFile, codec);
+
+            var sb = new StringBuilder();
+            sb.AppendLine("; ScummEditor game text export v1");
+            sb.AppendLine("; game: " + gameLabel);
+            sb.AppendLine("; charmap: " + codec.ToMapSpec());
+            sb.AppendLine("; total: " + entries.Count);
+            sb.AppendLine(";");
+            sb.AppendLine("; Edit only the text after \" = \". Do not change the IDs.");
+            sb.AppendLine("; Tokens like {br} {wait} {keep} {int:N} {sound:N} must be kept in the translation.");
+            sb.AppendLine("; The import rebuilds the character mapping from the '; charmap:' line above.");
+            sb.AppendLine("; To use a free font slot, add a \"char=0xNN\" pair to that charmap, or write {0xNN}");
+            sb.AppendLine("; directly in the text - e.g. an 'ss' ligature drawn at slot 0xC1 can be used as \"Cla{0xC1}e\".");
+            sb.AppendLine("; Save this file as UTF-8.");
+
+            string lastGroup = null;
+            foreach (GameTextEntry entry in entries)
+            {
+                string group = entry.Id.Substring(0, entry.Id.IndexOf('.'));
+                if (group != lastGroup)
+                {
+                    sb.AppendLine(";");
+                    sb.AppendLine("; ===== " + group + " =====");
+                    lastGroup = group;
+                }
+                sb.AppendLine(entry.Id + " = " + entry.Text);
+            }
+
+            File.WriteAllText(path, sb.ToString(), new UTF8Encoding(true));
+            return entries.Count;
+        }
+
+        // ---------------------------------------------------------------------
+        // Import
+        // ---------------------------------------------------------------------
+
+        public static GameTextImportReport ImportFromFile(ScummV6DataFile dataFile, string path)
+        {
+            var report = new GameTextImportReport();
+
+            // --- parse the file -------------------------------------------------
+            string[] lines = File.ReadAllLines(path, Encoding.UTF8);
+            GameTextCodec codec = null;
+            var fileTexts = new Dictionary<string, string>();
+
+            for (int n = 0; n < lines.Length; n++)
+            {
+                string line = lines[n];
+                if (line.Length == 0) continue;
+                if (line[0] == ';')
+                {
+                    string trimmed = line.Substring(1).TrimStart();
+                    if (codec == null && trimmed.StartsWith("charmap:"))
+                    {
+                        try { codec = GameTextCodec.FromMapSpec(trimmed.Substring(8).Trim()); }
+                        catch (FormatException ex) { report.Errors.Add("linha " + (n + 1) + ": " + ex.Message); }
+                    }
+                    continue;
+                }
+
+                int eq = line.IndexOf('=');
+                if (eq <= 0)
+                {
+                    report.Errors.Add("linha " + (n + 1) + ": formato inválido (esperado 'ID = texto')");
+                    continue;
+                }
+                string id = line.Substring(0, eq).Trim();
+                string text = line.Substring(eq + 1);
+                if (text.StartsWith(" ")) text = text.Substring(1);
+
+                if (fileTexts.ContainsKey(id))
+                {
+                    report.Errors.Add("linha " + (n + 1) + ": ID duplicado '" + id + "'");
+                    continue;
+                }
+                fileTexts.Add(id, text);
+                report.LinesParsed++;
+            }
+
+            if (codec == null)
+            {
+                report.Errors.Add("arquivo sem uma linha '; charmap: ...' válida no cabeçalho - a importação depende dela para reconstruir o mapeamento de caracteres");
+                return report;
+            }
+
+            // --- walk the game, compare and rebuild -----------------------------
+            var matchedIds = new HashSet<string>();
+            var changedBytes = new List<byte[]>(); // new string contents, for glyph validation
+
+            foreach (Source source in EnumerateSources(dataFile))
+            {
+                if (source.IsName)
+                {
+                    string newText;
+                    if (!fileTexts.TryGetValue(source.Id, out newText)) continue;
+                    matchedIds.Add(source.Id);
+
+                    string error;
+                    byte[] newName = codec.Encode(newText, out error);
+                    if (newName == null) { report.Errors.Add(source.Id + ": " + error); continue; }
+
+                    ObjectCode obcd = source.Obcd;
+                    int nameLen = ObnaNameLength(obcd);
+                    if (SliceEquals(obcd.RawContent, obcd.ObnaBodyOffset, nameLen, newName)) continue;
+
+                    RebuildObjectName(obcd, newName);
+                    report.StringsChanged++;
+                    report.BlocksRebuilt++;
+                    changedBytes.Add(newName);
+                    continue;
+                }
+
+                // script or VERB bytecode source
+                byte[] buf = source.Script != null ? source.Script.RawContent : VerbCodeSlice(source.Obcd);
+                int start = source.Script != null ? source.Script.CodeOffset : 0;
+                Scumm6Disassembler.Result scan = Scumm6Disassembler.Disassemble(buf, start);
+
+                var replacements = new Dictionary<int, byte[]>();
+                for (int k = 0; k < scan.Strings.Count; k++)
+                {
+                    string id = source.Id + ".t" + k.ToString("D3");
+                    string newText;
+                    if (!fileTexts.TryGetValue(id, out newText)) continue;
+                    if (scan.Strings[k].Kind == "actorName") { matchedIds.Add(id); continue; } // never imported
+                    matchedIds.Add(id);
+
+                    string error;
+                    byte[] content = codec.Encode(newText, out error);
+                    if (content == null) { report.Errors.Add(id + ": " + error); continue; }
+
+                    Scumm6Disassembler.StringRef s = scan.Strings[k];
+                    int contentLen = s.Length - (s.Terminated ? 1 : 0);
+                    if (SliceEquals(buf, s.Offset, contentLen, content)) continue;
+
+                    replacements.Add(k, content);
+                    changedBytes.Add(content);
+                }
+                if (replacements.Count == 0) continue;
+
+                if (!scan.DecodedToEnd)
+                {
+                    report.Errors.Add(source.Id + ": o bytecode não decodifica até o fim; bloco não foi alterado");
+                    continue;
+                }
+
+                string rebuildError;
+                byte[] rebuilt = RebuildCode(buf, start, scan, replacements, out rebuildError);
+                if (rebuilt == null)
+                {
+                    report.Errors.Add(source.Id + ": " + rebuildError + "; bloco não foi alterado");
+                    continue;
+                }
+
+                if (source.Script != null)
+                {
+                    source.Script.RawContent = rebuilt;
+                }
+                else
+                {
+                    string verbError;
+                    if (!ReplaceVerbCode(source.Obcd, rebuilt, scan, replacements, out verbError))
+                    {
+                        report.Errors.Add(source.Id + ": " + verbError + "; bloco não foi alterado");
+                        continue;
+                    }
+                }
+
+                report.StringsChanged += replacements.Count;
+                report.BlocksRebuilt++;
+            }
+
+            report.EntriesMatched = matchedIds.Count;
+            foreach (KeyValuePair<string, string> kv in fileTexts)
+                if (!matchedIds.Contains(kv.Key) && report.Warnings.Count < 50)
+                    report.Warnings.Add("ID não encontrado no jogo: " + kv.Key);
+
+            ValidateGlyphs(dataFile, changedBytes, codec, report);
+            return report;
+        }
+
+        private static bool SliceEquals(byte[] buf, int offset, int length, byte[] other)
+        {
+            if (other.Length != length) return false;
+            for (int i = 0; i < length; i++)
+                if (buf[offset + i] != other[i]) return false;
+            return true;
+        }
+
+        // ---------------------------------------------------------------------
+        // Bytecode rebuild
+        // ---------------------------------------------------------------------
+
+        /// <summary>
+        /// Rebuilds a code buffer with some strings replaced, remapping every relative jump.
+        /// Returns null (with an error message) if anything cannot be remapped safely; the
+        /// result is re-disassembled and verified before being accepted.
+        /// </summary>
+        private static byte[] RebuildCode(byte[] buf, int codeStart, Scumm6Disassembler.Result scan,
+                                          Dictionary<int, byte[]> replacements, out string error)
+        {
+            error = null;
+            List<Scumm6Disassembler.StringRef> strings = scan.Strings;
+
+            // --- splice ---------------------------------------------------------
+            var output = new List<byte>(buf.Length + 64);
+            var newStarts = new int[strings.Count];
+            var newLengths = new int[strings.Count];
+            int prev = 0;
+            for (int k = 0; k < strings.Count; k++)
+            {
+                Scumm6Disassembler.StringRef s = strings[k];
+                for (int i = prev; i < s.Offset; i++) output.Add(buf[i]);
+
+                newStarts[k] = output.Count;
+                byte[] content;
+                if (replacements.TryGetValue(k, out content))
+                {
+                    output.AddRange(content);
+                }
+                else
+                {
+                    int contentLen = s.Length - (s.Terminated ? 1 : 0);
+                    for (int i = 0; i < contentLen; i++) output.Add(buf[s.Offset + i]);
+                }
+                if (s.Terminated) output.Add(0);
+                newLengths[k] = output.Count - newStarts[k];
+                prev = s.Offset + s.Length;
+            }
+            for (int i = prev; i < buf.Length; i++) output.Add(buf[i]);
+            byte[] result = output.ToArray();
+
+            // --- old -> new position map (valid outside string regions) ----------
+            // (local function via delegate to keep the project's C# style simple)
+            Func<int, int> map = null;
+            string mapError = null;
+            map = delegate(int pos)
+            {
+                int delta = 0;
+                for (int k = 0; k < strings.Count; k++)
+                {
+                    Scumm6Disassembler.StringRef s = strings[k];
+                    if (s.Offset + s.Length <= pos) { delta += newLengths[k] - s.Length; continue; }
+                    if (pos > s.Offset && mapError == null)
+                        mapError = "posição 0x" + pos.ToString("X4") + " cai dentro de uma string";
+                    break;
+                }
+                return pos + delta;
+            };
+
+            // --- jump fix-up ------------------------------------------------------
+            foreach (Scumm6Disassembler.JumpRef jump in scan.Jumps)
+            {
+                int opNew = map(jump.OperandOffset);
+                int targetNew = map(jump.Target);
+                if (mapError != null) { error = mapError; return null; }
+
+                int rel = targetNew - (opNew + 2);
+                if (rel < short.MinValue || rel > short.MaxValue)
+                {
+                    error = "salto excede +-32767 bytes após a tradução (encurte os textos deste bloco)";
+                    return null;
+                }
+                result[opNew] = (byte)(rel & 0xFF);
+                result[opNew + 1] = (byte)((rel >> 8) & 0xFF);
+            }
+
+            // --- verify: the rebuilt code must decode to an identical structure ---
+            Scumm6Disassembler.Result rescan = Scumm6Disassembler.Disassemble(result, codeStart);
+            if (!rescan.DecodedToEnd ||
+                rescan.Strings.Count != strings.Count ||
+                rescan.Jumps.Count != scan.Jumps.Count)
+            {
+                error = "verificação falhou: o código reconstruído não decodifica de forma idêntica";
+                return null;
+            }
+            for (int k = 0; k < strings.Count; k++)
+            {
+                if (rescan.Strings[k].Offset != newStarts[k] || rescan.Strings[k].Length != newLengths[k])
+                {
+                    error = "verificação falhou: strings desalinhadas após reconstrução";
+                    return null;
+                }
+            }
+            for (int j = 0; j < scan.Jumps.Count; j++)
+            {
+                if (rescan.Jumps[j].OperandOffset != map(scan.Jumps[j].OperandOffset) ||
+                    rescan.Jumps[j].Target != map(scan.Jumps[j].Target))
+                {
+                    error = "verificação falhou: saltos desalinhados após reconstrução";
+                    return null;
+                }
+            }
+            return result;
+        }
+
+        /// <summary>Splices a rebuilt VERB bytecode region back into the OBCD, remapping the verb offset table.</summary>
+        private static bool ReplaceVerbCode(ObjectCode obcd, byte[] newCode, Scumm6Disassembler.Result scan,
+                                            Dictionary<int, byte[]> replacements, out string error)
+        {
+            error = null;
+
+            // Rebuild the old->new map exactly like RebuildCode did.
+            var newLengths = new int[scan.Strings.Count];
+            for (int k = 0; k < scan.Strings.Count; k++)
+            {
+                byte[] content;
+                newLengths[k] = replacements.TryGetValue(k, out content)
+                    ? content.Length + (scan.Strings[k].Terminated ? 1 : 0)
+                    : scan.Strings[k].Length;
+            }
+            Func<int, int> map = delegate(int pos)
+            {
+                int delta = 0;
+                for (int k = 0; k < scan.Strings.Count; k++)
+                {
+                    Scumm6Disassembler.StringRef s = scan.Strings[k];
+                    if (s.Offset + s.Length <= pos) delta += newLengths[k] - s.Length;
+                    else break;
+                }
+                return pos + delta;
+            };
+
+            byte[] raw = obcd.RawContent;
+            int headerToCode = obcd.VerbCodeOffset - obcd.VerbBlockOffset; // 8-byte header + table size
+
+            // New offset-table values (offsets are relative to the VERB tag).
+            var newOffsets = new int[obcd.VerbEntries.Count];
+            for (int e = 0; e < obcd.VerbEntries.Count; e++)
+            {
+                int sliceRel = obcd.VerbBlockOffset + obcd.VerbEntries[e].Offset - obcd.VerbCodeOffset;
+                if (sliceRel < 0 || sliceRel >= obcd.VerbCodeLength)
+                {
+                    error = "offset do verbo " + obcd.VerbEntries[e].Id + " fora da região de código";
+                    return false;
+                }
+                int newOff = headerToCode + map(sliceRel);
+                if (newOff > 0xFFFF)
+                {
+                    error = "offset do verbo " + obcd.VerbEntries[e].Id + " excede 0xFFFF após a tradução";
+                    return false;
+                }
+                newOffsets[e] = newOff;
+            }
+
+            int newVerbSize = headerToCode + newCode.Length;
+            var rebuilt = new byte[raw.Length - obcd.VerbBlockSize + newVerbSize];
+
+            // [0 .. VERB) unchanged
+            Array.Copy(raw, 0, rebuilt, 0, obcd.VerbBlockOffset);
+            // VERB header + table (then patch size and table offsets)
+            Array.Copy(raw, obcd.VerbBlockOffset, rebuilt, obcd.VerbBlockOffset, headerToCode);
+            WriteUInt32BE(rebuilt, obcd.VerbBlockOffset + 4, (uint)newVerbSize);
+            for (int e = 0; e < newOffsets.Length; e++)
+            {
+                int p = obcd.VerbBlockOffset + 8 + e * 3 + 1;
+                rebuilt[p] = (byte)(newOffsets[e] & 0xFF);
+                rebuilt[p + 1] = (byte)(newOffsets[e] >> 8);
+            }
+            // new bytecode
+            Array.Copy(newCode, 0, rebuilt, obcd.VerbCodeOffset, newCode.Length);
+            // everything after the old VERB block (OBNA etc.) unchanged
+            int oldTail = obcd.VerbBlockOffset + obcd.VerbBlockSize;
+            Array.Copy(raw, oldTail, rebuilt, obcd.VerbCodeOffset + newCode.Length, raw.Length - oldTail);
+
+            obcd.RawContent = rebuilt;
+            obcd.Reparse();
+
+            if (obcd.VerbCodeLength != newCode.Length)
+            {
+                error = "verificação falhou: VERB reconstruído não re-parseia";
+                return false;
+            }
+            return true;
+        }
+
+        private static void RebuildObjectName(ObjectCode obcd, byte[] newName)
+        {
+            byte[] raw = obcd.RawContent;
+            int nameLen = ObnaNameLength(obcd);
+            bool hadTerminator = nameLen < obcd.ObnaBodyLength; // original had a 0x00
+            int tailStart = obcd.ObnaBodyOffset + nameLen + (hadTerminator ? 1 : 0);
+            int tailLen = obcd.ObnaBodyOffset + obcd.ObnaBodyLength - tailStart;
+
+            int newBodyLen = newName.Length + (hadTerminator ? 1 : 0) + tailLen;
+            var rebuilt = new byte[raw.Length - obcd.ObnaBodyLength + newBodyLen];
+
+            Array.Copy(raw, 0, rebuilt, 0, obcd.ObnaBodyOffset);
+            Array.Copy(newName, 0, rebuilt, obcd.ObnaBodyOffset, newName.Length);
+            int p = obcd.ObnaBodyOffset + newName.Length;
+            if (hadTerminator) rebuilt[p++] = 0;
+            Array.Copy(raw, tailStart, rebuilt, p, tailLen);
+            int afterBody = obcd.ObnaBodyOffset + obcd.ObnaBodyLength;
+            Array.Copy(raw, afterBody, rebuilt, p + tailLen, raw.Length - afterBody);
+
+            WriteUInt32BE(rebuilt, obcd.ObnaBlockOffset + 4, (uint)(8 + newBodyLen));
+            obcd.RawContent = rebuilt;
+            obcd.Reparse();
+        }
+
+        private static void WriteUInt32BE(byte[] buf, int p, uint value)
+        {
+            buf[p] = (byte)(value >> 24);
+            buf[p + 1] = (byte)(value >> 16);
+            buf[p + 2] = (byte)(value >> 8);
+            buf[p + 3] = (byte)value;
+        }
+
+        // ---------------------------------------------------------------------
+        // Glyph validation: warn when an imported byte has no glyph in the fonts
+        // ---------------------------------------------------------------------
+
+        private static void ValidateGlyphs(ScummV6DataFile dataFile, List<byte[]> changedContents,
+                                           GameTextCodec codec, GameTextImportReport report)
+        {
+            var used = new HashSet<byte>();
+            foreach (byte[] content in changedContents)
+            {
+                int i = 0;
+                while (i < content.Length)
+                {
+                    byte b = content[i];
+                    if (b == 0xFF || b == 0xFE)
+                    {
+                        // skip escape (and its argument) so control bytes are not treated as glyphs
+                        if (i + 1 >= content.Length) break;
+                        byte code = content[i + 1];
+                        i += (code == 1 || code == 2 || code == 3 || code == 8) ? 2 : 4;
+                        continue;
+                    }
+                    if (b >= 0x80) used.Add(b);
+                    i++;
+                }
+            }
+            if (used.Count == 0) return;
+
+            var charsets = new List<Charset>();
+            CollectCharsets(dataFile, charsets);
+            if (charsets.Count == 0) return;
+
+            var sorted = new List<byte>(used);
+            sorted.Sort();
+            foreach (byte b in sorted)
+            {
+                int present = 0;
+                for (int c = 0; c < charsets.Count; c++)
+                    if (b < charsets[c].Glyphs.Count && charsets[c].Glyphs[b].Present) present++;
+
+                string label = "0x" + b.ToString("X2");
+                string mapped = codec.Decode(new[] { b }, 0, 1);
+                if (mapped.Length == 1) label += " ('" + mapped + "')";
+
+                if (present == 0)
+                    report.Warnings.Add("byte " + label + " não tem glifo em NENHUMA fonte do jogo - vai renderizar errado");
+                else if (present < charsets.Count)
+                    report.GlyphNotes.Add(label + ": glifo presente em " + present + " de " + charsets.Count + " fontes");
+            }
+        }
+
+        private static void CollectCharsets(BlockBase block, List<Charset> result)
+        {
+            var charset = block as Charset;
+            if (charset != null) result.Add(charset);
+            foreach (BlockBase child in block.Childrens) CollectCharsets(child, result);
+        }
+    }
+}

--- a/ScummEditor/Encoders/Scumm6Disassembler.cs
+++ b/ScummEditor/Encoders/Scumm6Disassembler.cs
@@ -22,6 +22,24 @@ namespace ScummEditor.Encoders
             public bool DecodedToEnd { get; set; }
             public List<int> UnknownOpcodes { get; set; }
             public int BytesDecoded { get; set; }
+            public List<StringRef> Strings { get; set; }
+            public List<JumpRef> Jumps { get; set; }
+        }
+
+        /// <summary>An inline message found in the bytecode (positions relative to the scanned buffer).</summary>
+        public class StringRef
+        {
+            public int Offset { get; set; }        // first byte of the string data
+            public int Length { get; set; }        // total bytes consumed, including the 0x00 terminator when present
+            public bool Terminated { get; set; }   // false only when the string ran into the end of the buffer
+            public string Kind { get; set; }       // talk / print* / actorName / verbName / objectName / array
+        }
+
+        /// <summary>A relative-jump operand (positions relative to the scanned buffer).</summary>
+        public class JumpRef
+        {
+            public int OperandOffset { get; set; } // position of the int16le relative offset
+            public int Target { get; set; }        // absolute target (operand end + relative value)
         }
 
         private byte[] _code;
@@ -30,6 +48,8 @@ namespace ScummEditor.Encoders
         private readonly List<Line> _lines = new List<Line>();
         private readonly HashSet<int> _jumpTargets = new HashSet<int>();
         private readonly List<int> _unknown = new List<int>();
+        private readonly List<StringRef> _strings = new List<StringRef>();
+        private readonly List<JumpRef> _jumps = new List<JumpRef>();
         private bool _stopped;
 
         private struct Line
@@ -40,9 +60,18 @@ namespace ScummEditor.Encoders
 
         public static Result Disassemble(byte[] code, int startOffset)
         {
+            return Disassemble(code, startOffset, null);
+        }
+
+        /// <summary>Disassembles with extra named labels rendered at the given offsets (e.g. verb entry points).</summary>
+        public static Result Disassemble(byte[] code, int startOffset, IDictionary<int, string> namedLabels)
+        {
             var d = new Scumm6Disassembler();
+            d._namedLabels = namedLabels;
             return d.Run(code, startOffset);
         }
+
+        private IDictionary<int, string> _namedLabels;
 
         private Result Run(byte[] code, int startOffset)
         {
@@ -69,7 +98,9 @@ namespace ScummEditor.Encoders
                 Listing = Render(),
                 DecodedToEnd = !_stopped && _pos >= _code.Length,
                 UnknownOpcodes = _unknown,
-                BytesDecoded = _pos - startOffset
+                BytesDecoded = _pos - startOffset,
+                Strings = _strings,
+                Jumps = _jumps
             };
         }
 
@@ -223,51 +254,38 @@ namespace ScummEditor.Encoders
 
         private string Jump(int offset)
         {
+            int operandOffset = _pos;
             int rel = ReadSignedWord();
             int target = _pos + rel;
             _jumpTargets.Add(target);
+            _jumps.Add(new JumpRef { OperandOffset = operandOffset, Target = target });
             return "L" + target.ToString("X4");
         }
 
-        // Reads an inline SCUMM message string, returning a quoted C-like literal.
-        private string ReadString()
+        // Strings in listings are rendered with the same friendly tokens used by the game
+        // text export: {br} {wait} {sound:N}... plus accented characters via the charmap.
+        private static readonly GameTextCodec ListingCodec = GameTextCodec.Default();
+
+        // Reads an inline SCUMM message string, returning a quoted literal.
+        private string ReadString(string kind = "msg")
         {
-            var sb = new StringBuilder("\"");
+            int start = _pos;
+            bool terminated = false;
             while (_pos < _code.Length)
             {
                 byte b = ReadByte();
-                if (b == 0) break;
+                if (b == 0) { terminated = true; break; }
 
                 if (b == 0xFF || b == 0xFE)
                 {
                     byte code = ReadByte();
-                    switch (code)
-                    {
-                        case 1: sb.Append("\\n"); break;
-                        case 2: sb.Append("\\keep"); break;
-                        case 3: sb.Append("\\wait"); break;
-                        case 8: sb.Append("\\escape"); break;
-                        default:
-                            int val = ReadWord();
-                            sb.Append("\\x" + code.ToString("X2") + "[" + val + "]");
-                            break;
-                    }
-                }
-                else if (b == (byte)'"' || b == (byte)'\\')
-                {
-                    sb.Append('\\').Append((char)b);
-                }
-                else if (b >= 0x20 && b < 0x7F)
-                {
-                    sb.Append((char)b);
-                }
-                else
-                {
-                    sb.Append("\\x" + b.ToString("X2"));
+                    if (code != 1 && code != 2 && code != 3 && code != 8) ReadWord(); // 16-bit argument
                 }
             }
-            sb.Append('"');
-            return sb.ToString();
+
+            int contentLength = _pos - start - (terminated ? 1 : 0);
+            _strings.Add(new StringRef { Offset = start, Length = _pos - start, Terminated = terminated, Kind = kind });
+            return "\"" + ListingCodec.Decode(_code, start, contentLength).Replace("\"", "\\\"") + "\"";
         }
 
         // -------------------------------------------------------------------------
@@ -276,13 +294,30 @@ namespace ScummEditor.Encoders
 
         private string Render()
         {
+            // Labels can point at an expression-push instruction, which emits no line of its
+            // own (it becomes part of the next statement). Anchor such labels on the first
+            // emitted line at or after the label offset, annotating the real offset.
+            var namedOffsets = new List<int>();
+            if (_namedLabels != null) foreach (int k in _namedLabels.Keys) namedOffsets.Add(k);
+            namedOffsets.Sort();
+            var targets = new List<int>(_jumpTargets);
+            targets.Sort();
+
             var sb = new StringBuilder();
+            int ni = 0, ti = 0;
             foreach (Line line in _lines)
             {
-                if (_jumpTargets.Contains(line.Offset))
-                    sb.AppendLine("L" + line.Offset.ToString("X4") + ":");
+                for (; ni < namedOffsets.Count && namedOffsets[ni] <= line.Offset; ni++)
+                    sb.AppendLine(_namedLabels[namedOffsets[ni]] + ":"
+                        + (namedOffsets[ni] == line.Offset ? "" : "    ; @" + namedOffsets[ni].ToString("X4")));
+                for (; ti < targets.Count && targets[ti] <= line.Offset; ti++)
+                    sb.AppendLine("L" + targets[ti].ToString("X4") + ":");
                 sb.AppendLine("    " + line.Offset.ToString("X4") + "  " + line.Text);
             }
+            for (; ni < namedOffsets.Count; ni++)
+                sb.AppendLine(_namedLabels[namedOffsets[ni]] + ":    ; @" + namedOffsets[ni].ToString("X4"));
+            for (; ti < targets.Count; ti++)
+                sb.AppendLine("L" + targets[ti].ToString("X4") + ":");
             return sb.ToString();
         }
 
@@ -396,7 +431,7 @@ namespace ScummEditor.Encoders
                 case 0x94: { string b = Pop(); string a = Pop(); Push("getVerbFromXY(" + a + ", " + b + ")"); break; }
                 case 0x95: Emit(offset, "beginOverride();"); break;
                 case 0x96: Emit(offset, "endOverride();"); break;
-                case 0x97: { string name = ReadString(); StmtCallWithExtra(offset, "setObjectName", 1, name); break; }
+                case 0x97: { string name = ReadString("objectName"); StmtCallWithExtra(offset, "setObjectName", 1, name); break; }
                 case 0x98: Push("isSoundRunning(" + Pop() + ")"); break;
                 case 0x99: StmtCall(offset, "setBoxFlags", 2); break;
                 case 0x9A: Emit(offset, "createBoxMatrix();"); break;
@@ -417,8 +452,8 @@ namespace ScummEditor.Encoders
                 case 0xB1: StmtCall(offset, "delaySeconds", 1); break;
                 case 0xB2: StmtCall(offset, "delayMinutes", 1); break;
                 case 0xB3: Emit(offset, "stopSentence();"); break;
-                case 0xBA: { string s = ReadString(); StmtCallWithExtra(offset, "talkActor", 1, s); break; }
-                case 0xBB: Emit(offset, "talkEgo(" + ReadString() + ");"); break;
+                case 0xBA: { string s = ReadString("talk"); StmtCallWithExtra(offset, "talkActor", 1, s); break; }
+                case 0xBB: Emit(offset, "talkEgo(" + ReadString("talk") + ");"); break;
                 case 0xBD: Emit(offset, "dummy();"); break;
                 case 0xBE: { string a = PopStackList(); string s = Pop(); Emit(offset, "startObjectQuick(" + s + ", " + a + ");"); break; }
                 case 0xBF: { string a = PopStackList(); string s = Pop(); Emit(offset, "startScriptQuick2(" + s + ", " + a + ");"); break; }
@@ -446,8 +481,8 @@ namespace ScummEditor.Encoders
                 case 0x6B: SubOp(offset, "cursorCommand", CursorCommand); break;
                 case 0x9B: SubOp(offset, "resourceRoutines", ResourceRoutines); break;
                 case 0x9C: SubOp(offset, "roomOps", RoomOps); break;
-                case 0x9D: SubOpMaybeString(offset, "actorOps", 0x58, ActorOps); break;   // SO_ACTOR_NAME -> inline string
-                case 0x9E: SubOpMaybeString(offset, "verbOps", 0x7D, VerbOps); break;      // SO_VERB_NAME -> inline string
+                case 0x9D: SubOpMaybeString(offset, "actorOps", 0x58, ActorOps, "actorName"); break; // SO_ACTOR_NAME -> inline string
+                case 0x9E: SubOpMaybeString(offset, "verbOps", 0x7D, VerbOps, "verbName"); break;    // SO_VERB_NAME -> inline string
                 case 0xA4: ArrayOps(offset); break;
                 case 0xA5: SubOp(offset, "saveRestoreVerbs", SaveRestoreVerbs); break;
                 case 0xA9: WaitOp(offset); break;
@@ -592,13 +627,13 @@ namespace ScummEditor.Encoders
         }
 
         // Sub-opcode group where one sub-op (the "name" op) carries an inline string.
-        private void SubOpMaybeString(int offset, string group, byte stringSub, Dictionary<int, string> table)
+        private void SubOpMaybeString(int offset, string group, byte stringSub, Dictionary<int, string> table, string stringKind)
         {
             byte sub = ReadByte();
             string name = SubName(table, sub);
             if (sub == stringSub)
             {
-                Emit(offset, group + "." + name + "(" + ReadString() + ");");
+                Emit(offset, group + "." + name + "(" + ReadString(stringKind) + ");");
             }
             else
             {
@@ -611,7 +646,7 @@ namespace ScummEditor.Encoders
             byte sub = ReadByte();
             if (sub == 0x4B) // textstring -> inline message
             {
-                Emit(offset, group + ".text(" + ReadString() + ");");
+                Emit(offset, group + ".text(" + ReadString(group) + ");");
             }
             else
             {
@@ -626,7 +661,7 @@ namespace ScummEditor.Encoders
             string arrayName = Var(array);
             if (sub == 0xCD) // assignString -> inline string
             {
-                Emit(offset, arrayName + " = " + ReadString() + ";");
+                Emit(offset, arrayName + " = " + ReadString("array") + ";");
             }
             else
             {

--- a/ScummEditor/FilePacker.Designer.cs
+++ b/ScummEditor/FilePacker.Designer.cs
@@ -36,6 +36,11 @@
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.exportAllRoomBackgroundImagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ImportGameGraphics = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+            this.exportGameTextsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importGameTextsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportGameFontsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importGameFontsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -86,6 +91,11 @@
             this.toolStripSeparator4,
             this.exportAllRoomBackgroundImagesToolStripMenuItem,
             this.ImportGameGraphics,
+            this.toolStripSeparator5,
+            this.exportGameTextsToolStripMenuItem,
+            this.importGameTextsToolStripMenuItem,
+            this.exportGameFontsToolStripMenuItem,
+            this.importGameFontsToolStripMenuItem,
             this.toolStripSeparator3,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
@@ -128,9 +138,42 @@
             this.ImportGameGraphics.Size = new System.Drawing.Size(191, 22);
             this.ImportGameGraphics.Text = "Import game graphics";
             this.ImportGameGraphics.Click += new System.EventHandler(this.ImportGameGraphics_Click);
-            // 
+            //
+            // toolStripSeparator5
+            //
+            this.toolStripSeparator5.Name = "toolStripSeparator5";
+            this.toolStripSeparator5.Size = new System.Drawing.Size(188, 6);
+            //
+            // exportGameTextsToolStripMenuItem
+            //
+            this.exportGameTextsToolStripMenuItem.Name = "exportGameTextsToolStripMenuItem";
+            this.exportGameTextsToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.exportGameTextsToolStripMenuItem.Text = "Export game texts...";
+            this.exportGameTextsToolStripMenuItem.Click += new System.EventHandler(this.exportGameTextsToolStripMenuItem_Click);
+            //
+            // importGameTextsToolStripMenuItem
+            //
+            this.importGameTextsToolStripMenuItem.Name = "importGameTextsToolStripMenuItem";
+            this.importGameTextsToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.importGameTextsToolStripMenuItem.Text = "Import game texts...";
+            this.importGameTextsToolStripMenuItem.Click += new System.EventHandler(this.importGameTextsToolStripMenuItem_Click);
+            //
+            // exportGameFontsToolStripMenuItem
+            //
+            this.exportGameFontsToolStripMenuItem.Name = "exportGameFontsToolStripMenuItem";
+            this.exportGameFontsToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.exportGameFontsToolStripMenuItem.Text = "Export game fonts...";
+            this.exportGameFontsToolStripMenuItem.Click += new System.EventHandler(this.exportGameFontsToolStripMenuItem_Click);
+            //
+            // importGameFontsToolStripMenuItem
+            //
+            this.importGameFontsToolStripMenuItem.Name = "importGameFontsToolStripMenuItem";
+            this.importGameFontsToolStripMenuItem.Size = new System.Drawing.Size(191, 22);
+            this.importGameFontsToolStripMenuItem.Text = "Import game fonts...";
+            this.importGameFontsToolStripMenuItem.Click += new System.EventHandler(this.importGameFontsToolStripMenuItem_Click);
+            //
             // toolStripSeparator3
-            // 
+            //
             this.toolStripSeparator3.Name = "toolStripSeparator3";
             this.toolStripSeparator3.Size = new System.Drawing.Size(188, 6);
             // 
@@ -388,6 +431,11 @@
         private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem HelpAbout;
         private System.Windows.Forms.ToolStripMenuItem ImportGameGraphics;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
+        private System.Windows.Forms.ToolStripMenuItem exportGameTextsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem importGameTextsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem exportGameFontsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem importGameFontsToolStripMenuItem;
         private System.Windows.Forms.ToolStripButton ImportGameGraphicsButton;
         private System.Windows.Forms.ToolStripButton AboutToolbar;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;

--- a/ScummEditor/FilePacker.cs
+++ b/ScummEditor/FilePacker.cs
@@ -182,5 +182,176 @@ namespace ScummEditor
         {
             SaveGame();
         }
+
+        private void exportGameTextsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (scummFile == null || scummFile.DataFile == null)
+            {
+                MessageBox.Show(this, "Open a game first.", "Export game texts");
+                return;
+            }
+
+            var dlg = new SaveFileDialog
+            {
+                Filter = "Text file (*.txt)|*.txt|All files (*.*)|*.*",
+                FileName = Path.GetFileNameWithoutExtension(scummFile.LoadedGameInfo.DataFile) + "-texts.txt"
+            };
+            if (dlg.ShowDialog(this) != DialogResult.OK) return;
+
+            GameTextCodec codec;
+            if (!TryPromptCharmap(out codec)) return;
+
+            try
+            {
+                int count = GameTextManager.ExportToFile(scummFile.DataFile, dlg.FileName, codec,
+                    Path.GetFileName(scummFile.LoadedGameInfo.DataFile));
+                MessageBox.Show(this, count + " textos exportados para:\n" + dlg.FileName,
+                    "Export game texts", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Falha ao exportar: " + ex.Message, "Export game texts",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        /// <summary>
+        /// Optional step of the text export: the translator may paste the "; charmap:" line of an
+        /// in-progress translation so the new export keeps its custom characters. Empty input
+        /// falls back to the default charmap; Cancel aborts the export (returns false).
+        /// </summary>
+        private bool TryPromptCharmap(out GameTextCodec codec)
+        {
+            codec = null;
+            string lastInput = string.Empty;
+
+            while (true)
+            {
+                using (var form = new Form())
+                {
+                    var label = new Label
+                    {
+                        Text = "Optional: paste the \"; charmap:\" line of an existing translation file so this " +
+                               "export keeps its custom characters. Leave empty to use the default charmap."
+                    };
+                    label.SetBounds(12, 9, 596, 42);
+
+                    var input = new TextBox { Text = lastInput };
+                    input.SetBounds(12, 54, 596, 20);
+
+                    var ok = new Button { Text = "OK", DialogResult = DialogResult.OK };
+                    ok.SetBounds(452, 84, 75, 26);
+                    var cancel = new Button { Text = "Cancel", DialogResult = DialogResult.Cancel };
+                    cancel.SetBounds(533, 84, 75, 26);
+
+                    form.Text = "Export game texts - charmap";
+                    form.FormBorderStyle = FormBorderStyle.FixedDialog;
+                    form.MinimizeBox = false;
+                    form.MaximizeBox = false;
+                    form.StartPosition = FormStartPosition.CenterParent;
+                    form.ClientSize = new Size(620, 120);
+                    form.Controls.AddRange(new Control[] { label, input, ok, cancel });
+                    form.AcceptButton = ok;
+                    form.CancelButton = cancel;
+
+                    if (form.ShowDialog(this) != DialogResult.OK) return false;
+                    lastInput = input.Text;
+                }
+
+                try
+                {
+                    codec = GameTextCodec.ParsePastedCharmap(lastInput);
+                    return true;
+                }
+                catch (FormatException ex)
+                {
+                    MessageBox.Show(this, "Charmap inválido: " + ex.Message, "Export game texts",
+                        MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+            }
+        }
+
+        private void importGameTextsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (scummFile == null || scummFile.DataFile == null)
+            {
+                MessageBox.Show(this, "Open a game first.", "Import game texts");
+                return;
+            }
+
+            var dlg = new OpenFileDialog { Filter = "Text file (*.txt)|*.txt|All files (*.*)|*.*" };
+            if (dlg.ShowDialog(this) != DialogResult.OK) return;
+
+            try
+            {
+                GameTextImportReport report = GameTextManager.ImportFromFile(scummFile.DataFile, dlg.FileName);
+
+                string message = report.Summary();
+                if (report.HasChanges)
+                    message += Environment.NewLine + "Use 'Save Changes' para gravar as alterações nos arquivos do jogo.";
+
+                MessageBox.Show(this, message, "Import game texts", MessageBoxButtons.OK,
+                    report.Errors.Count > 0 ? MessageBoxIcon.Warning : MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Falha ao importar: " + ex.Message, "Import game texts",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void exportGameFontsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (scummFile == null || scummFile.DataFile == null)
+            {
+                MessageBox.Show(this, "Open a game first.", "Export game fonts");
+                return;
+            }
+
+            var dlg = new FolderBrowserDialog
+            {
+                Description = "Pasta para salvar as fontes do jogo (charset_N.png + charset_N.guide.png)"
+            };
+            if (dlg.ShowDialog(this) != DialogResult.OK) return;
+
+            try
+            {
+                string report = CharsetPngCodec.ExportAll(scummFile.DataFile, dlg.SelectedPath);
+                MessageBox.Show(this, report, "Export game fonts", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Falha ao exportar: " + ex.Message, "Export game fonts",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void importGameFontsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (scummFile == null || scummFile.DataFile == null)
+            {
+                MessageBox.Show(this, "Open a game first.", "Import game fonts");
+                return;
+            }
+
+            var dlg = new FolderBrowserDialog
+            {
+                Description = "Pasta com os arquivos charset_N.png a importar"
+            };
+            if (dlg.ShowDialog(this) != DialogResult.OK) return;
+
+            try
+            {
+                string report = CharsetPngCodec.ImportAll(scummFile.DataFile, dlg.SelectedPath);
+                MessageBox.Show(this,
+                    report + Environment.NewLine + "Use 'Save Changes' para gravar as alterações nos arquivos do jogo.",
+                    "Import game fonts", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Falha ao importar: " + ex.Message, "Import game fonts",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
     }
 }

--- a/ScummEditor/Gui/CharsetControl.Designer.cs
+++ b/ScummEditor/Gui/CharsetControl.Designer.cs
@@ -16,15 +16,20 @@ namespace ScummEditor.Gui
         {
             this.scroll = new System.Windows.Forms.Panel();
             this.atlas = new System.Windows.Forms.PictureBox();
+            this.buttons = new System.Windows.Forms.Panel();
+            this.exportPngButton = new System.Windows.Forms.Button();
+            this.importPngButton = new System.Windows.Forms.Button();
             this.header = new System.Windows.Forms.Label();
             this.Contents.SuspendLayout();
             this.scroll.SuspendLayout();
+            this.buttons.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.atlas)).BeginInit();
             this.SuspendLayout();
             //
             // Contents
             //
             this.Contents.Controls.Add(this.scroll);
+            this.Contents.Controls.Add(this.buttons);
             this.Contents.Controls.Add(this.header);
             //
             // header
@@ -35,6 +40,35 @@ namespace ScummEditor.Gui
             this.header.Name = "header";
             this.header.TabIndex = 0;
             //
+            // buttons
+            //
+            this.buttons.Controls.Add(this.exportPngButton);
+            this.buttons.Controls.Add(this.importPngButton);
+            this.buttons.Dock = System.Windows.Forms.DockStyle.Top;
+            this.buttons.Height = 31;
+            this.buttons.Name = "buttons";
+            this.buttons.TabIndex = 1;
+            //
+            // exportPngButton
+            //
+            this.exportPngButton.Location = new System.Drawing.Point(3, 3);
+            this.exportPngButton.Name = "exportPngButton";
+            this.exportPngButton.Size = new System.Drawing.Size(120, 25);
+            this.exportPngButton.TabIndex = 0;
+            this.exportPngButton.Text = "Export PNG...";
+            this.exportPngButton.UseVisualStyleBackColor = true;
+            this.exportPngButton.Click += new System.EventHandler(this.exportPngButton_Click);
+            //
+            // importPngButton
+            //
+            this.importPngButton.Location = new System.Drawing.Point(129, 3);
+            this.importPngButton.Name = "importPngButton";
+            this.importPngButton.Size = new System.Drawing.Size(120, 25);
+            this.importPngButton.TabIndex = 1;
+            this.importPngButton.Text = "Import PNG...";
+            this.importPngButton.UseVisualStyleBackColor = true;
+            this.importPngButton.Click += new System.EventHandler(this.importPngButton_Click);
+            //
             // scroll
             //
             this.scroll.AutoScroll = true;
@@ -42,7 +76,7 @@ namespace ScummEditor.Gui
             this.scroll.Controls.Add(this.atlas);
             this.scroll.Dock = System.Windows.Forms.DockStyle.Fill;
             this.scroll.Name = "scroll";
-            this.scroll.TabIndex = 1;
+            this.scroll.TabIndex = 2;
             //
             // atlas
             //
@@ -60,6 +94,7 @@ namespace ScummEditor.Gui
             this.Contents.ResumeLayout(false);
             this.scroll.ResumeLayout(false);
             this.scroll.PerformLayout();
+            this.buttons.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.atlas)).EndInit();
             this.ResumeLayout(false);
         }
@@ -68,6 +103,9 @@ namespace ScummEditor.Gui
 
         private System.Windows.Forms.Panel scroll;
         private System.Windows.Forms.PictureBox atlas;
+        private System.Windows.Forms.Panel buttons;
+        private System.Windows.Forms.Button exportPngButton;
+        private System.Windows.Forms.Button importPngButton;
         private System.Windows.Forms.Label header;
     }
 }

--- a/ScummEditor/Gui/CharsetControl.cs
+++ b/ScummEditor/Gui/CharsetControl.cs
@@ -1,5 +1,9 @@
+using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.IO;
+using System.Windows.Forms;
+using ScummEditor.Encoders;
 using ScummEditor.Structures;
 using ScummEditor.Structures.DataFile;
 
@@ -8,12 +12,15 @@ namespace ScummEditor.Gui
     /// <summary>
     /// Viewer for CHAR (charset/font) blocks: shows the font header and an atlas of every
     /// glyph (rendered 2x, with its character index), so translators can see which characters
-    /// the font provides.
+    /// the font provides. The PNG buttons export/import an editable glyph atlas so missing
+    /// characters can be drawn in an image editor.
     /// </summary>
     public partial class CharsetControl : BlockBaseControl
     {
         private const int Columns = 16;
         private const int Scale = 2;
+
+        private Charset _charset;
 
         public CharsetControl()
         {
@@ -24,12 +31,66 @@ namespace ScummEditor.Gui
         {
             base.SetAndRefreshData(blockBase);
 
-            var charset = (Charset)blockBase;
+            _charset = (Charset)blockBase;
             header.Text = string.Format("{0} chars ({1} present)   ·   {2} bits/pixel   ·   font height {3}",
-                charset.NumChars, charset.PresentGlyphCount(), charset.BitsPerPixel, charset.FontHeight);
+                _charset.NumChars, _charset.PresentGlyphCount(), _charset.BitsPerPixel, _charset.FontHeight);
 
             if (atlas.Image != null) { atlas.Image.Dispose(); atlas.Image = null; }
-            atlas.Image = BuildAtlas(charset);
+            atlas.Image = BuildAtlas(_charset);
+        }
+
+        private void exportPngButton_Click(object sender, EventArgs e)
+        {
+            if (_charset == null) return;
+
+            var dlg = new SaveFileDialog
+            {
+                Filter = "PNG image (*.png)|*.png",
+                FileName = "charset.png"
+            };
+            if (dlg.ShowDialog(this) != DialogResult.OK) return;
+
+            try
+            {
+                string guidePath = GuidePathFor(dlg.FileName);
+                CharsetPngCodec.ExportPng(_charset, dlg.FileName, guidePath);
+                MessageBox.Show(this,
+                    "Fonte exportada para:\n" + dlg.FileName +
+                    "\n\nGuia com os IDs dos slots:\n" + guidePath +
+                    "\n\nDesenhe os glifos no PNG principal (modo indexado) usando o guia como camada de referência.",
+                    "Export PNG", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Falha ao exportar: " + ex.Message, "Export PNG",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void importPngButton_Click(object sender, EventArgs e)
+        {
+            if (_charset == null) return;
+
+            var dlg = new OpenFileDialog { Filter = "PNG image (*.png)|*.png" };
+            if (dlg.ShowDialog(this) != DialogResult.OK) return;
+
+            try
+            {
+                string report = CharsetPngCodec.ImportPng(_charset, dlg.FileName);
+                SetAndRefreshData(_charset); // refresh header and atlas
+                MessageBox.Show(this, report, "Import PNG", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Falha ao importar: " + ex.Message, "Import PNG",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private static string GuidePathFor(string pngPath)
+        {
+            return Path.Combine(Path.GetDirectoryName(pngPath) ?? string.Empty,
+                Path.GetFileNameWithoutExtension(pngPath) + ".guide.png");
         }
 
         private static Bitmap BuildAtlas(Charset charset)

--- a/ScummEditor/Gui/IndexDetailsControl.Designer.cs
+++ b/ScummEditor/Gui/IndexDetailsControl.Designer.cs
@@ -1,0 +1,78 @@
+namespace ScummEditor.Gui
+{
+    partial class IndexDetailsControl
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.summary = new System.Windows.Forms.Label();
+            this.grid = new System.Windows.Forms.DataGridView();
+            this.Contents.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.grid)).BeginInit();
+            this.SuspendLayout();
+            //
+            // Contents
+            //
+            this.Contents.Controls.Add(this.grid);
+            this.Contents.Controls.Add(this.summary);
+            //
+            // summary
+            //
+            this.summary.Dock = System.Windows.Forms.DockStyle.Top;
+            this.summary.AutoSize = false;
+            this.summary.Height = 20;
+            this.summary.Name = "summary";
+            this.summary.TabIndex = 0;
+            //
+            // grid
+            //
+            this.grid.AllowUserToAddRows = false;
+            this.grid.AllowUserToDeleteRows = false;
+            this.grid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.grid.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically;
+            this.grid.Name = "grid";
+            this.grid.ReadOnly = true;
+            this.grid.RowHeadersVisible = false;
+            this.grid.AllowUserToResizeRows = false;
+            this.grid.TabIndex = 1;
+            //
+            // IndexDetailsControl
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Name = "IndexDetailsControl";
+            this.Contents.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.grid)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.DataGridView grid;
+        private System.Windows.Forms.Label summary;
+    }
+}

--- a/ScummEditor/Gui/IndexDetailsControl.cs
+++ b/ScummEditor/Gui/IndexDetailsControl.cs
@@ -1,0 +1,124 @@
+using System.Windows.Forms;
+using ScummEditor.Structures;
+using ScummEditor.Structures.IndexFile;
+
+namespace ScummEditor.Gui
+{
+    /// <summary>
+    /// Read-only viewer for the decoded index-file blocks that are not resource directories:
+    /// MAXS (maximum values), DOBJ (object owners/states/classes), AARY (array definitions)
+    /// and RNAM (room names - only populated on SCUMM v5 games).
+    /// </summary>
+    public partial class IndexDetailsControl : BlockBaseControl
+    {
+        public IndexDetailsControl()
+        {
+            InitializeComponent();
+        }
+
+        public override void SetAndRefreshData(BlockBase blockBase)
+        {
+            base.SetAndRefreshData(blockBase);
+
+            grid.Columns.Clear();
+            grid.Rows.Clear();
+
+            if (blockBase is MaximumValues)
+            {
+                ShowMaximumValues((MaximumValues)blockBase);
+            }
+            else if (blockBase is DirectoryOfObjects)
+            {
+                ShowDirectoryOfObjects((DirectoryOfObjects)blockBase);
+            }
+            else if (blockBase is DirectoryOfArrays)
+            {
+                ShowDirectoryOfArrays((DirectoryOfArrays)blockBase);
+            }
+            else if (blockBase is RoomNamesV6)
+            {
+                ShowRoomNames((RoomNamesV6)blockBase);
+            }
+            else
+            {
+                summary.Text = string.Empty;
+            }
+        }
+
+        private void AddColumns(params string[] headers)
+        {
+            foreach (string header in headers)
+            {
+                var column = new DataGridViewTextBoxColumn
+                {
+                    HeaderText = header,
+                    AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells,
+                    SortMode = DataGridViewColumnSortMode.NotSortable,
+                    ReadOnly = true
+                };
+                grid.Columns.Add(column);
+            }
+        }
+
+        private void ShowMaximumValues(MaximumValues block)
+        {
+            summary.Text = "Engine limits declared by the game";
+            AddColumns("Field", "Value");
+
+            grid.Rows.Add("Variables", block.Variables);
+            grid.Rows.Add("Bit variables", block.BitVariables);
+            grid.Rows.Add("Local objects", block.LocalObjects);
+            grid.Rows.Add("Arrays", block.Arrays);
+            grid.Rows.Add("Verbs", block.Verbs);
+            grid.Rows.Add("Floating objects", block.FloatingObjects);
+            grid.Rows.Add("Inventory objects", block.InventoryObjects);
+            grid.Rows.Add("Rooms", block.Rooms);
+            grid.Rows.Add("Scripts", block.Scripts);
+            grid.Rows.Add("Sounds", block.Sounds);
+            grid.Rows.Add("Character sets", block.CharacterSets);
+            grid.Rows.Add("Costumes", block.Costumes);
+            grid.Rows.Add("Global objects", block.GlobalObjects);
+            grid.Rows.Add("New names (v5)", block.NewNames);
+        }
+
+        private void ShowDirectoryOfObjects(DirectoryOfObjects block)
+        {
+            summary.Text = string.Format("{0} object(s) - initial owner/state and class data", block.NumOfItems);
+            AddColumns("Object", "Owner", "State", "Class data");
+
+            for (int i = 0; i < block.Owners.Count; i++)
+            {
+                DirectoryObject item = block.Owners[i];
+                grid.Rows.Add(i, item.Owner, item.State, "0x" + item.ClassData.ToString("X8"));
+            }
+        }
+
+        private void ShowDirectoryOfArrays(DirectoryOfArrays block)
+        {
+            summary.Text = string.Format("{0} predefined array(s)", block.Items.Count);
+            AddColumns("Variable", "X size", "Y size", "Type");
+
+            foreach (DirectoryArray item in block.Items)
+            {
+                grid.Rows.Add(item.VariableNumber, item.XSize, item.YSize,
+                    item.Type == 1 ? "1 (bytes)" : item.Type == 0 ? "0 (words)" : item.Type.ToString());
+            }
+        }
+
+        private void ShowRoomNames(RoomNamesV6 block)
+        {
+            if (block.Rooms.Count == 0)
+            {
+                summary.Text = "No room names (SCUMM v6 games leave this block empty)";
+                return;
+            }
+
+            summary.Text = string.Format("{0} room name(s)", block.Rooms.Count);
+            AddColumns("Room", "Name");
+            foreach (RoomName room in block.Rooms)
+            {
+                grid.Rows.Add(room.RoomNumber, room.Name);
+            }
+        }
+    }
+}

--- a/ScummEditor/Gui/ObjectCodeControl.Designer.cs
+++ b/ScummEditor/Gui/ObjectCodeControl.Designer.cs
@@ -1,0 +1,96 @@
+namespace ScummEditor.Gui
+{
+    partial class ObjectCodeControl
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null)) components.Dispose();
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.split = new System.Windows.Forms.SplitContainer();
+            this.grid = new System.Windows.Forms.DataGridView();
+            this.code = new System.Windows.Forms.TextBox();
+            this.Contents.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.split)).BeginInit();
+            this.split.Panel1.SuspendLayout();
+            this.split.Panel2.SuspendLayout();
+            this.split.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.grid)).BeginInit();
+            this.SuspendLayout();
+            //
+            // Contents
+            //
+            this.Contents.Controls.Add(this.split);
+            //
+            // split
+            //
+            this.split.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.split.Name = "split";
+            this.split.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            //
+            // split.Panel1
+            //
+            this.split.Panel1.Controls.Add(this.grid);
+            //
+            // split.Panel2
+            //
+            this.split.Panel2.Controls.Add(this.code);
+            this.split.SplitterDistance = 170;
+            this.split.TabIndex = 0;
+            //
+            // grid
+            //
+            this.grid.AllowUserToAddRows = false;
+            this.grid.AllowUserToDeleteRows = false;
+            this.grid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.grid.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically;
+            this.grid.Name = "grid";
+            this.grid.ReadOnly = true;
+            this.grid.RowHeadersVisible = false;
+            this.grid.AllowUserToResizeRows = false;
+            this.grid.TabIndex = 0;
+            //
+            // code
+            //
+            this.code.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.code.Font = new System.Drawing.Font("Consolas", 9F);
+            this.code.HideSelection = false;
+            this.code.MaxLength = 0;
+            this.code.Multiline = true;
+            this.code.Name = "code";
+            this.code.ReadOnly = true;
+            this.code.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+            this.code.TabIndex = 0;
+            this.code.WordWrap = false;
+            //
+            // ObjectCodeControl
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Name = "ObjectCodeControl";
+            this.split.Panel1.ResumeLayout(false);
+            this.split.Panel2.ResumeLayout(false);
+            this.split.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.split)).EndInit();
+            this.split.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.grid)).EndInit();
+            this.Contents.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.SplitContainer split;
+        private System.Windows.Forms.DataGridView grid;
+        private System.Windows.Forms.TextBox code;
+    }
+}

--- a/ScummEditor/Gui/ObjectCodeControl.cs
+++ b/ScummEditor/Gui/ObjectCodeControl.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Forms;
+using ScummEditor.Encoders;
+using ScummEditor.Structures;
+using ScummEditor.Structures.DataFile;
+
+namespace ScummEditor.Gui
+{
+    /// <summary>
+    /// Read-only viewer for OBCD blocks. The top grid shows the decoded object fields (CDHD
+    /// header, OBNA name and the verb offset table); the bottom pane shows the disassembled
+    /// verb bytecode, with a label at each verb entry point.
+    /// </summary>
+    public partial class ObjectCodeControl : BlockBaseControl
+    {
+        public ObjectCodeControl()
+        {
+            InitializeComponent();
+        }
+
+        public override void SetAndRefreshData(BlockBase blockBase)
+        {
+            base.SetAndRefreshData(blockBase);
+
+            var obcd = (ObjectCode)blockBase;
+
+            // --- object fields -------------------------------------------------
+            grid.Columns.Clear();
+            grid.Rows.Clear();
+            AddColumns("Field", "Value");
+
+            if (obcd.HasCodeHeader)
+            {
+                grid.Rows.Add("Object id", obcd.ObjectId);
+                grid.Rows.Add("X", obcd.X);
+                grid.Rows.Add("Y", obcd.Y);
+                grid.Rows.Add("Width", obcd.Width);
+                grid.Rows.Add("Height", obcd.Height);
+                grid.Rows.Add("Flags", "0x" + obcd.Flags.ToString("X2"));
+                grid.Rows.Add("Parent", obcd.ParentObject);
+                grid.Rows.Add("Actor direction", obcd.ActorDirection);
+            }
+            grid.Rows.Add("Name", obcd.Name);
+            grid.Rows.Add("Verbs", obcd.NumVerbs);
+
+            var labels = new Dictionary<int, string>();
+            foreach (VerbEntry entry in obcd.VerbEntries)
+            {
+                int sliceRel = obcd.VerbBlockOffset + entry.Offset - obcd.VerbCodeOffset;
+                string name = entry.Id == 0xFF ? "verb_any" : "verb_0x" + entry.Id.ToString("X2");
+                bool inRange = sliceRel >= 0 && sliceRel < obcd.VerbCodeLength;
+
+                grid.Rows.Add(name, inRange ? sliceRel.ToString("X4") : "(out of range)");
+                if (inRange && !labels.ContainsKey(sliceRel)) labels.Add(sliceRel, name);
+            }
+
+            // --- verb bytecode disassembly --------------------------------------
+            var sb = new StringBuilder();
+            if (obcd.VerbCodeOffset < 0 || obcd.VerbCodeLength <= 0)
+            {
+                sb.AppendLine("// (no verb scripts)");
+            }
+            else
+            {
+                var slice = new byte[obcd.VerbCodeLength];
+                Array.Copy(obcd.RawContent, obcd.VerbCodeOffset, slice, 0, obcd.VerbCodeLength);
+                Scumm6Disassembler.Result result = Scumm6Disassembler.Disassemble(slice, 0, labels);
+
+                if (!result.DecodedToEnd)
+                    sb.AppendLine("// WARNING: disassembly stopped before the end of the script (unknown opcode).");
+                sb.Append(result.Listing);
+            }
+
+            // TextBox needs CRLF line endings to render line breaks correctly.
+            code.Text = sb.ToString().Replace("\r\n", "\n").Replace("\n", "\r\n");
+            code.Select(0, 0);
+        }
+
+        private void AddColumns(params string[] headers)
+        {
+            foreach (string header in headers)
+            {
+                var column = new DataGridViewTextBoxColumn
+                {
+                    HeaderText = header,
+                    AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells,
+                    SortMode = DataGridViewColumnSortMode.NotSortable,
+                    ReadOnly = true
+                };
+                grid.Columns.Add(column);
+            }
+        }
+    }
+}

--- a/ScummEditor/Gui/StructuredBlockControl.cs
+++ b/ScummEditor/Gui/StructuredBlockControl.cs
@@ -5,7 +5,7 @@ using ScummEditor.Structures.DataFile;
 namespace ScummEditor.Gui
 {
     /// <summary>
-    /// Generic read-only viewer for the structured data blocks (BOXD, BOXM, SCAL, OBCD).
+    /// Generic read-only viewer for the structured data blocks (BOXD, BOXM, SCAL, OFFS).
     /// One instance is shared across those block types; it rebuilds the grid for the
     /// selected block on each refresh.
     /// </summary>
@@ -35,9 +35,9 @@ namespace ScummEditor.Gui
             {
                 ShowScale((Scale)blockBase);
             }
-            else if (blockBase is ObjectCode)
+            else if (blockBase is PaletteOffset)
             {
-                ShowObjectCode((ObjectCode)blockBase);
+                ShowPaletteOffset((PaletteOffset)blockBase);
             }
             else
             {
@@ -104,27 +104,15 @@ namespace ScummEditor.Gui
             }
         }
 
-        private void ShowObjectCode(ObjectCode block)
+        private void ShowPaletteOffset(PaletteOffset block)
         {
-            summary.Text = string.IsNullOrEmpty(block.Name)
-                ? "Object code"
-                : string.Format("Object \"{0}\"", block.Name);
+            summary.Text = string.Format("{0} palette offset(s), relative to the OFFS block", block.Offsets.Count);
+            AddColumns("Palette", "Offset");
 
-            AddColumns("Field", "Value");
-
-            if (block.HasCodeHeader)
+            for (int i = 0; i < block.Offsets.Count; i++)
             {
-                grid.Rows.Add("Object id", block.ObjectId);
-                grid.Rows.Add("X", block.X);
-                grid.Rows.Add("Y", block.Y);
-                grid.Rows.Add("Width", block.Width);
-                grid.Rows.Add("Height", block.Height);
-                grid.Rows.Add("Flags", ToHex(block.Flags));
-                grid.Rows.Add("Parent", block.ParentObject);
-                grid.Rows.Add("Actor direction", block.ActorDirection);
+                grid.Rows.Add(i, block.Offsets[i]);
             }
-            grid.Rows.Add("Verbs", block.NumVerbs);
-            grid.Rows.Add("Name", block.Name);
         }
 
         private static string ToHex(byte value)

--- a/ScummEditor/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor/Gui/TreeNavigatorManager.cs
@@ -41,7 +41,9 @@ namespace ScummEditor.Gui
             _controlViewers.Add(typeof(BoxData).Name, structuredBlockControl);
             _controlViewers.Add(typeof(BoxMatrix).Name, structuredBlockControl);
             _controlViewers.Add(typeof(Scale).Name, structuredBlockControl);
-            _controlViewers.Add(typeof(ObjectCode).Name, structuredBlockControl);
+            _controlViewers.Add(typeof(PaletteOffset).Name, structuredBlockControl);
+
+            _controlViewers.Add(typeof(ObjectCode).Name, new ObjectCodeControl());
 
             _controlViewers.Add(typeof(SoundBlock).Name, new SoundBlockControl());
 
@@ -57,6 +59,12 @@ namespace ScummEditor.Gui
             _controlViewers.Add(typeof(DirectoryOfCostumes).Name, directoryOfItemsControlGeneric);
             _controlViewers.Add(typeof(DirectoryOfScripts).Name, directoryOfItemsControlGeneric);
             _controlViewers.Add(typeof(DirectoryOfSounds).Name, directoryOfItemsControlGeneric);
+
+            var indexDetailsControl = new IndexDetailsControl();
+            _controlViewers.Add(typeof(MaximumValues).Name, indexDetailsControl);
+            _controlViewers.Add(typeof(DirectoryOfObjects).Name, indexDetailsControl);
+            _controlViewers.Add(typeof(DirectoryOfArrays).Name, indexDetailsControl);
+            _controlViewers.Add(typeof(RoomNamesV6).Name, indexDetailsControl);
 
             _treeView = treeView;
             _displayPanel = displayPanel;
@@ -118,6 +126,7 @@ namespace ScummEditor.Gui
             CreateNode(scummV6IndexFile.DCOS, node);
             CreateNode(scummV6IndexFile.DCHR, node);
             CreateNode(scummV6IndexFile.DOBJ, node);
+            if (scummV6IndexFile.AARY != null) CreateNode(scummV6IndexFile.AARY, node);
         }
 
         private static TreeNode CreateNode(BlockBase blockBase, TreeNode parentNode, int index = -1)

--- a/ScummEditor/Properties/AssemblyInfo.cs
+++ b/ScummEditor/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.1.0")]
-[assembly: AssemblyFileVersion("1.1.1.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]
 // Application.ProductVersion (shown in the About window) reads this on modern .NET.
-[assembly: AssemblyInformationalVersion("1.1.1.0")]
+[assembly: AssemblyInformationalVersion("1.3.0.0")]

--- a/ScummEditor/Resources/History.txt
+++ b/ScummEditor/Resources/History.txt
@@ -1,3 +1,17 @@
+1.3.0.0
+-------
+* Game text translation support. "File > Export game texts" writes every translatable string of the game (dialogues, prints, verb names, object names) to a single .txt file: one line per text with a stable id, control codes as readable tokens ({br}, {wait}, {sound:N}...) and accented characters mapped through a charmap stored in the file header. "File > Import game texts" reads the file back and rebuilds the bytecode - jump offsets and the verb offset tables are remapped automatically when a translation is shorter or longer than the original, and every rebuilt script is re-disassembled and verified before being accepted.
+
+* The charmap is under the team's control: the import rebuilds the character mapping from the "; charmap:" header line, so free font slots can be mapped to new characters or used directly in the text as {0xNN} (e.g. custom ligatures like "Cla{0xC1}e"). On export the translator can optionally paste the charmap of an in-progress translation to keep its custom characters. Lines with nothing to translate (empty names, sound-only strings) are left out of the file, and imported texts are validated against the game fonts, reporting characters that have no glyph.
+
+* Charset (font) editing via PNG. Each CHAR block - or all of them at once through "File > Export/Import game fonts" - can be exported as an editable 8-bit indexed PNG atlas (256 slots separated by divider lines) plus a guide image showing the hex id, the origin mark and the current glyph of every slot. Drawing in an empty slot adds the glyph to the font, extending the character table when needed; untouched slots keep their original bytes, and edited glyphs preserve the font metrics (cursor advance / spacing).
+
+* New OBCD viewer: the object properties (code header, name) and the verb table are shown as fields, with the disassembled verb bytecode below and a label at each verb entry point.
+
+* Script listings now render messages with the same friendly tokens and accented characters used by the text export, instead of raw escape bytes.
+
+* Index file viewers for MAXS (engine limits), DOBJ (object owners/states/classes), AARY (array directory - previously missing from the tree) and RNAM (room names, populated on SCUMM v5 games); the palette offset block (OFFS) also gained a viewer.
+
 1.1.1.0
 -------
 * Decoded the room navigation and object-code blocks, each with its own viewer: BOXD (walk boxes), BOXM (box matrix), SCAL (scale slots) and OBCD (object code, showing the object name and verb count).

--- a/ScummEditor/Structures/DataFile/Charset.cs
+++ b/ScummEditor/Structures/DataFile/Charset.cs
@@ -163,6 +163,12 @@ namespace ScummEditor.Structures.DataFile
         {
             return (uint)(RawContent[p] | (RawContent[p + 1] << 8) | (RawContent[p + 2] << 16) | (RawContent[p + 3] << 24));
         }
+
+        /// <summary>Re-parses the structural info after RawContent is replaced (PNG import).</summary>
+        public void Reparse()
+        {
+            ParseForDisplay();
+        }
     }
 
     public class Glyph

--- a/ScummEditor/Structures/DataFile/ObjectCode.cs
+++ b/ScummEditor/Structures/DataFile/ObjectCode.cs
@@ -50,9 +50,23 @@ namespace ScummEditor.Structures.DataFile
 
         // VERB
         public int NumVerbs { get; set; }
+        /// <summary>Verb offset-table entries; offsets are relative to the VERB tag position.</summary>
+        public List<VerbEntry> VerbEntries { get; private set; }
+        /// <summary>Position of the VERB tag within RawContent, or -1 when absent.</summary>
+        public int VerbBlockOffset { get; private set; }
+        /// <summary>Total VERB block size (8-byte header + table + bytecode).</summary>
+        public int VerbBlockSize { get; private set; }
+        /// <summary>First bytecode position within RawContent (after the offset table), or -1.</summary>
+        public int VerbCodeOffset { get; private set; }
+        public int VerbCodeLength { get; private set; }
 
         // OBNA
         public string Name { get; set; }
+        /// <summary>Position of the OBNA tag within RawContent, or -1 when absent.</summary>
+        public int ObnaBlockOffset { get; private set; }
+        /// <summary>Position/length of the OBNA body (name bytes + terminator + padding).</summary>
+        public int ObnaBodyOffset { get; private set; }
+        public int ObnaBodyLength { get; private set; }
 
         public override void CalculateBlockSize()
         {
@@ -76,6 +90,11 @@ namespace ScummEditor.Structures.DataFile
         private void ParseForDisplay()
         {
             Name = string.Empty;
+            VerbEntries = new List<VerbEntry>();
+            VerbBlockOffset = -1;
+            VerbCodeOffset = -1;
+            ObnaBlockOffset = -1;
+            ObnaBodyOffset = -1;
 
             // Walk the sub-blocks (type:4, size:32be, body) embedded in OBCD.
             int p = 0;
@@ -94,9 +113,14 @@ namespace ScummEditor.Structures.DataFile
                         ParseCodeHeader(bodyStart, bodyLength);
                         break;
                     case "VERB":
+                        VerbBlockOffset = p;
+                        VerbBlockSize = (int)size;
                         ParseVerbTable(bodyStart, bodyLength);
                         break;
                     case "OBNA":
+                        ObnaBlockOffset = p;
+                        ObnaBodyOffset = bodyStart;
+                        ObnaBodyLength = bodyLength;
                         Name = ReadCString(bodyStart, bodyLength);
                         break;
                 }
@@ -127,10 +151,16 @@ namespace ScummEditor.Structures.DataFile
             while (p < end)
             {
                 byte entry = RawContent[p];
-                if (entry == 0x00) break; // end of offset table
+                if (entry == 0x00) { p++; break; } // end of offset table
+                if (p + 3 > end) { p = end; break; }
                 NumVerbs++;
+                VerbEntries.Add(new VerbEntry { Id = entry, Offset = ReadUInt16(p + 1) });
                 p += 3; // entry (8) + offset (16le)
             }
+
+            // Bytecode runs from the end of the table to the end of the VERB block.
+            VerbCodeOffset = p;
+            VerbCodeLength = end - p;
         }
 
         private string ReadCString(int p, int length)
@@ -155,5 +185,18 @@ namespace ScummEditor.Structures.DataFile
         {
             return (uint)((RawContent[p] << 24) | (RawContent[p + 1] << 16) | (RawContent[p + 2] << 8) | RawContent[p + 3]);
         }
+
+        /// <summary>Re-parses the structural info after RawContent is replaced (text import).</summary>
+        public void Reparse()
+        {
+            ParseForDisplay();
+        }
+    }
+
+    public class VerbEntry
+    {
+        public byte Id { get; set; }
+        /// <summary>Bytecode offset relative to the VERB tag position (as used by the engine).</summary>
+        public int Offset { get; set; }
     }
 }

--- a/ScummEditor/Structures/IndexFile/RoomNamesV6.cs
+++ b/ScummEditor/Structures/IndexFile/RoomNamesV6.cs
@@ -96,7 +96,7 @@ namespace ScummEditor.Structures.IndexFile
             BlankByte = binaryReader.ReadByte1();
             if (BlankByte != 0)
             {
-                throw new InvalidFileFormatException("Sequencia de caracteres não esperada.");
+                throw new InvalidFileFormatException("Sequencia de caracteres nï¿½o esperada.");
             }
         }
     }
@@ -116,6 +116,12 @@ namespace ScummEditor.Structures.IndexFile
 
                 _roomName = BinaryHelper.ConvertByteArrayToUTF8String(_roomNameData.Where(b => b != 255).Select(xb => (byte)(xb ^ 0xFF)).ToArray());
             }
+        }
+
+        /// <summary>Decoded room name (the on-disk bytes are XOR'ed with 0xFF).</summary>
+        public string Name
+        {
+            get { return _roomName; }
         }
     }
 }


### PR DESCRIPTION
- Game text export/import (File menu): every translatable string (dialogues, prints, verb names, object names) goes to a single .txt with stable ids, readable tokens ({br}, {wait}, {sound:N}...) and accents mapped via a charmap stored in the file header. Import rebuilds the bytecode, remapping jump offsets and verb offset tables when lengths change, and re-verifies every rebuilt script by re-disassembly before accepting it.
- Single charmap under the team's control: import reconstructs the mapping from the '; charmap:' header line (validated against duplicates/reserved bytes); free font slots can be mapped to new characters or used inline as {0xNN} (custom ligatures). Export optionally accepts a pasted charmap from an in-progress translation. Lines with no translatable content (empty names, sound-only strings) are excluded; imported texts are validated against the game fonts (missing glyph report). actorOps.setName strings are not exported.
- Charset (font) editing via PNG: per-CHAR buttons and batch File menu items export each font as an editable 8-bit indexed atlas (256 slots with divider lines) plus a guide image (hex slot id, origin mark, current glyphs). Drawing in empty slots adds glyphs and extends the font table when needed; untouched slots keep their original bytes; edited glyphs preserve metrics (cursor advance). Validated with byte-identical no-op round-trips on DOTT and Sam & Max.
- Scumm6Disassembler: scans string/jump positions (the base for the text rebuild), renders messages with the friendly tokens and accented characters, and supports named labels (verb entry points).
- New OBCD viewer: object fields and verb table in a grid, disassembled verb bytecode below.
- Index file viewers for MAXS, DOBJ, AARY (previously missing from the tree) and RNAM; OFFS viewer.
- Version 1.3.0.0 with History.txt changelog.