### PR TITLE
Speech (.SOU) and CD audio (CDDA.SOU) viewers + MIDI playback fix

### DIFF
--- a/ScummEditor/Encoders/SoundConverter.cs
+++ b/ScummEditor/Encoders/SoundConverter.cs
@@ -22,7 +22,9 @@ namespace ScummEditor.Encoders
         }
 
         private static readonly byte[] MThd = { (byte)'M', (byte)'T', (byte)'h', (byte)'d' };
-        private const string VocSignature = "Creative Voice File\x1A";
+        // The trailing \x1A EOF marker is not checked: some entries in the Sam & Max floppy
+        // effects file have it replaced by \x00.
+        private const string VocSignature = "Creative Voice File";
 
         public static SoundKind Classify(byte[] data)
         {
@@ -51,6 +53,29 @@ namespace ScummEditor.Encoders
             var midi = new byte[data.Length - start];
             Array.Copy(data, start, midi, 0, midi.Length);
             return midi;
+        }
+
+        /// <summary>
+        /// The Windows MCI sequencer only plays SMF format 0/1 files, and the SCUMM (iMUSE)
+        /// tracks are format 2 - which with a single track is structurally identical to
+        /// format 0. Returns a copy with the format word patched to 0 when that is the case;
+        /// otherwise returns the input unchanged. Use it for playback only - exports keep
+        /// the original bytes.
+        /// </summary>
+        public static byte[] MakeMidiPlayable(byte[] midi)
+        {
+            if (midi == null || midi.Length < 14) return midi;
+            if (midi[0] != 'M' || midi[1] != 'T' || midi[2] != 'h' || midi[3] != 'd') return midi;
+
+            int format = (midi[8] << 8) | midi[9];
+            int trackCount = (midi[10] << 8) | midi[11];
+            if (format != 2 || trackCount != 1) return midi;
+
+            var patched = new byte[midi.Length];
+            Array.Copy(midi, patched, midi.Length);
+            patched[8] = 0;
+            patched[9] = 0;
+            return patched;
         }
 
         /// <summary>

--- a/ScummEditor/Functions.cs
+++ b/ScummEditor/Functions.cs
@@ -94,9 +94,15 @@ namespace ScummEditor
 
                 result.IsTalkie = false;
                 var speechInfo = new FileInfo(speechPath);
-                if (speechInfo.Exists && speechInfo.Length >= TalkieMinimumSpeechBytes)
+                if (speechInfo.Exists)
                 {
-                    result.IsTalkie = true;
+                    // The file is exposed in the tree even when small (floppy editions ship an
+                    // effects-only MONSTER.SOU); only a big one marks the talkie edition.
+                    result.SpeechFilePath = speechPath;
+                    if (speechInfo.Length >= TalkieMinimumSpeechBytes)
+                    {
+                        result.IsTalkie = true;
+                    }
                 }
 
                 // Some releases ship the CD audio tracks ripped as CDDA.SOU instead of a speech
@@ -104,9 +110,13 @@ namespace ScummEditor
                 // is NOT speech - the game must not be reported as a talkie because of it.
                 result.HasCdAudio = false;
                 var cdAudioInfo = new FileInfo(Path.Combine(folder, "CDDA.SOU"));
-                if (cdAudioInfo.Exists && cdAudioInfo.Length >= TalkieMinimumSpeechBytes)
+                if (cdAudioInfo.Exists)
                 {
-                    result.HasCdAudio = true;
+                    result.CdAudioFilePath = cdAudioInfo.FullName;
+                    if (cdAudioInfo.Length >= TalkieMinimumSpeechBytes)
+                    {
+                        result.HasCdAudio = true;
+                    }
                 }
 
                 // Monkey Island 1 CD: the speech edition has its own entry in the game list.

--- a/ScummEditor/Gui/CdAudioSouControl.Designer.cs
+++ b/ScummEditor/Gui/CdAudioSouControl.Designer.cs
@@ -1,0 +1,114 @@
+namespace ScummEditor.Gui
+{
+    partial class CdAudioSouControl
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null)) components.Dispose();
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.info = new System.Windows.Forms.Label();
+            this.buttons = new System.Windows.Forms.Panel();
+            this.playButton = new System.Windows.Forms.Button();
+            this.exportButton = new System.Windows.Forms.Button();
+            this.exportAllButton = new System.Windows.Forms.Button();
+            this.grid = new System.Windows.Forms.DataGridView();
+            this.buttons.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.grid)).BeginInit();
+            this.SuspendLayout();
+            //
+            // info
+            //
+            this.info.Dock = System.Windows.Forms.DockStyle.Top;
+            this.info.AutoSize = false;
+            this.info.Height = 22;
+            this.info.Padding = new System.Windows.Forms.Padding(3, 4, 3, 0);
+            this.info.Name = "info";
+            this.info.TabIndex = 0;
+            //
+            // buttons
+            //
+            this.buttons.Controls.Add(this.playButton);
+            this.buttons.Controls.Add(this.exportButton);
+            this.buttons.Controls.Add(this.exportAllButton);
+            this.buttons.Dock = System.Windows.Forms.DockStyle.Top;
+            this.buttons.Height = 31;
+            this.buttons.Name = "buttons";
+            this.buttons.TabIndex = 1;
+            //
+            // playButton
+            //
+            this.playButton.Location = new System.Drawing.Point(3, 3);
+            this.playButton.Name = "playButton";
+            this.playButton.Size = new System.Drawing.Size(75, 25);
+            this.playButton.TabIndex = 0;
+            this.playButton.Text = "Play";
+            this.playButton.UseVisualStyleBackColor = true;
+            this.playButton.Click += new System.EventHandler(this.playButton_Click);
+            //
+            // exportButton
+            //
+            this.exportButton.Location = new System.Drawing.Point(84, 3);
+            this.exportButton.Name = "exportButton";
+            this.exportButton.Size = new System.Drawing.Size(110, 25);
+            this.exportButton.TabIndex = 1;
+            this.exportButton.Text = "Export WAV...";
+            this.exportButton.UseVisualStyleBackColor = true;
+            this.exportButton.Click += new System.EventHandler(this.exportButton_Click);
+            //
+            // exportAllButton
+            //
+            this.exportAllButton.Location = new System.Drawing.Point(200, 3);
+            this.exportAllButton.Name = "exportAllButton";
+            this.exportAllButton.Size = new System.Drawing.Size(130, 25);
+            this.exportAllButton.TabIndex = 2;
+            this.exportAllButton.Text = "Export all tracks...";
+            this.exportAllButton.UseVisualStyleBackColor = true;
+            this.exportAllButton.Click += new System.EventHandler(this.exportAllButton_Click);
+            //
+            // grid
+            //
+            this.grid.AllowUserToAddRows = false;
+            this.grid.AllowUserToDeleteRows = false;
+            this.grid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.grid.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically;
+            this.grid.Name = "grid";
+            this.grid.ReadOnly = true;
+            this.grid.RowHeadersVisible = false;
+            this.grid.AllowUserToResizeRows = false;
+            this.grid.MultiSelect = false;
+            this.grid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.grid.TabIndex = 2;
+            //
+            // CdAudioSouControl
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.grid);
+            this.Controls.Add(this.buttons);
+            this.Controls.Add(this.info);
+            this.Name = "CdAudioSouControl";
+            this.Size = new System.Drawing.Size(640, 420);
+            this.buttons.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.grid)).EndInit();
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label info;
+        private System.Windows.Forms.Panel buttons;
+        private System.Windows.Forms.Button playButton;
+        private System.Windows.Forms.Button exportButton;
+        private System.Windows.Forms.Button exportAllButton;
+        private System.Windows.Forms.DataGridView grid;
+    }
+}

--- a/ScummEditor/Gui/CdAudioSouControl.cs
+++ b/ScummEditor/Gui/CdAudioSouControl.cs
@@ -1,0 +1,191 @@
+using System;
+using System.IO;
+using System.Media;
+using System.Windows.Forms;
+using ScummEditor.Structures;
+
+namespace ScummEditor.Gui
+{
+    /// <summary>
+    /// Viewer for the ripped CD audio container (CDDA.SOU): lists the tracks from the
+    /// header table and decodes them to PCM WAV (play, export one, export all).
+    /// </summary>
+    public partial class CdAudioSouControl : UserControl
+    {
+        private CdAudioSouFile _file;
+        private SoundPlayer _player;
+
+        public CdAudioSouControl()
+        {
+            InitializeComponent();
+        }
+
+        public void SetData(CdAudioSouFile file)
+        {
+            _file = file;
+
+            Cursor previousCursor = Cursor.Current;
+            Cursor.Current = Cursors.WaitCursor;
+            try
+            {
+                _file.EnsureParsed();
+            }
+            finally
+            {
+                Cursor.Current = previousCursor;
+            }
+
+            if (_file.ParseError != null)
+            {
+                info.Text = Path.GetFileName(_file.FilePath) + "  -  " + _file.ParseError;
+            }
+            else
+            {
+                info.Text = string.Format("{0}  -  {1} CD audio tracks, 44100 Hz 16-bit stereo, total {2}",
+                    Path.GetFileName(_file.FilePath), _file.Tracks.Count, FormatDuration(_file.TotalDurationSeconds));
+            }
+
+            grid.Columns.Clear();
+            grid.Rows.Clear();
+            AddColumns("Track", "Offset", "Size", "Duration", "CD start frame");
+
+            foreach (CdAudioTrack track in _file.Tracks)
+            {
+                grid.Rows.Add(track.Number,
+                    "0x" + track.Offset.ToString("X8"),
+                    (track.ByteLength / 1048576.0).ToString("0.0") + " MB",
+                    FormatDuration(track.DurationSeconds),
+                    track.StartFrame);
+            }
+        }
+
+        private static string FormatDuration(double seconds)
+        {
+            var time = TimeSpan.FromSeconds(seconds);
+            return string.Format("{0}:{1:D2}", (int)time.TotalMinutes, time.Seconds);
+        }
+
+        private void AddColumns(params string[] headers)
+        {
+            foreach (string header in headers)
+            {
+                var column = new DataGridViewTextBoxColumn
+                {
+                    HeaderText = header,
+                    AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells,
+                    SortMode = DataGridViewColumnSortMode.NotSortable,
+                    ReadOnly = true
+                };
+                grid.Columns.Add(column);
+            }
+        }
+
+        private CdAudioTrack SelectedTrack()
+        {
+            if (_file == null || grid.CurrentRow == null) return null;
+            int index = grid.CurrentRow.Index;
+            if (index < 0 || index >= _file.Tracks.Count) return null;
+            return _file.Tracks[index];
+        }
+
+        private void playButton_Click(object sender, EventArgs e)
+        {
+            CdAudioTrack track = SelectedTrack();
+            if (track == null) return;
+
+            Cursor previousCursor = Cursor.Current;
+            Cursor.Current = Cursors.WaitCursor;
+            try
+            {
+                var wav = new MemoryStream();
+                _file.WriteTrackWav(track, wav);
+                wav.Position = 0;
+
+                if (_player != null) _player.Stop();
+                _player = new SoundPlayer(wav);
+                _player.Play();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Could not play the track: " + ex.Message, "Play",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            finally
+            {
+                Cursor.Current = previousCursor;
+            }
+        }
+
+        private void exportButton_Click(object sender, EventArgs e)
+        {
+            CdAudioTrack track = SelectedTrack();
+            if (track == null) return;
+
+            var dlg = new SaveFileDialog
+            {
+                Filter = "WAV audio (*.wav)|*.wav",
+                FileName = string.Format("track_{0:D2}.wav", track.Number)
+            };
+            if (dlg.ShowDialog(this) != DialogResult.OK) return;
+
+            Cursor previousCursor = Cursor.Current;
+            Cursor.Current = Cursors.WaitCursor;
+            try
+            {
+                _file.ExportTrackToWav(track, dlg.FileName);
+                MessageBox.Show(this, "Track exported to:\n" + dlg.FileName, "Export WAV",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Export failed: " + ex.Message, "Export WAV",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            finally
+            {
+                Cursor.Current = previousCursor;
+            }
+        }
+
+        private void exportAllButton_Click(object sender, EventArgs e)
+        {
+            if (_file == null || _file.Tracks.Count == 0) return;
+
+            var dlg = new FolderBrowserDialog
+            {
+                Description = "Folder to save one WAV per track (track_NN.wav)"
+            };
+            if (dlg.ShowDialog(this) != DialogResult.OK) return;
+
+            int exported = 0, failed = 0;
+            Cursor previousCursor = Cursor.Current;
+            Cursor.Current = Cursors.WaitCursor;
+            try
+            {
+                foreach (CdAudioTrack track in _file.Tracks)
+                {
+                    try
+                    {
+                        string path = Path.Combine(dlg.SelectedPath, string.Format("track_{0:D2}.wav", track.Number));
+                        _file.ExportTrackToWav(track, path);
+                        exported++;
+                    }
+                    catch (Exception)
+                    {
+                        failed++;
+                    }
+                }
+            }
+            finally
+            {
+                Cursor.Current = previousCursor;
+            }
+
+            MessageBox.Show(this,
+                string.Format("{0} tracks exported to:\n{1}{2}", exported, dlg.SelectedPath,
+                    failed > 0 ? "\n\n" + failed + " tracks failed." : ""),
+                "Export all tracks", MessageBoxButtons.OK,
+                failed > 0 ? MessageBoxIcon.Warning : MessageBoxIcon.Information);
+        }
+    }
+}

--- a/ScummEditor/Gui/ObjectCodeControl.Designer.cs
+++ b/ScummEditor/Gui/ObjectCodeControl.Designer.cs
@@ -33,7 +33,7 @@ namespace ScummEditor.Gui
             //
             this.split.Dock = System.Windows.Forms.DockStyle.Fill;
             this.split.Name = "split";
-            this.split.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            this.split.Orientation = System.Windows.Forms.Orientation.Vertical;
             //
             // split.Panel1
             //
@@ -42,7 +42,7 @@ namespace ScummEditor.Gui
             // split.Panel2
             //
             this.split.Panel2.Controls.Add(this.code);
-            this.split.SplitterDistance = 170;
+            this.split.SplitterDistance = 230;
             this.split.TabIndex = 0;
             //
             // grid
@@ -60,6 +60,7 @@ namespace ScummEditor.Gui
             //
             // code
             //
+            this.code.BackColor = System.Drawing.Color.White;
             this.code.Dock = System.Windows.Forms.DockStyle.Fill;
             this.code.Font = new System.Drawing.Font("Consolas", 9F);
             this.code.HideSelection = false;

--- a/ScummEditor/Gui/ScriptControl.Designer.cs
+++ b/ScummEditor/Gui/ScriptControl.Designer.cs
@@ -24,6 +24,7 @@ namespace ScummEditor.Gui
             //
             // code
             //
+            this.code.BackColor = System.Drawing.Color.White;
             this.code.Dock = System.Windows.Forms.DockStyle.Fill;
             this.code.Font = new System.Drawing.Font("Consolas", 9F);
             this.code.HideSelection = false;

--- a/ScummEditor/Gui/SoundBlockControl.cs
+++ b/ScummEditor/Gui/SoundBlockControl.cs
@@ -22,6 +22,9 @@ namespace ScummEditor.Gui
         [DllImport("winmm.dll", CharSet = CharSet.Auto)]
         private static extern int mciSendString(string command, StringBuilder returnValue, int returnLength, IntPtr callback);
 
+        [DllImport("winmm.dll", CharSet = CharSet.Auto)]
+        private static extern bool mciGetErrorString(int errorCode, StringBuilder errorText, int errorLength);
+
         private const string MciAlias = "scummEditorMidi";
 
         private SoundBlock _block;
@@ -164,12 +167,36 @@ namespace ScummEditor.Gui
                 return;
             }
 
+            // The MCI sequencer rejects the SMF format 2 used by the iMUSE tracks (error 296);
+            // a single-track format 2 is patched to format 0 for playback.
+            midi = SoundConverter.MakeMidiPlayable(midi);
+
             _tempMidiPath = Path.Combine(Path.GetTempPath(), "scummeditor_play.mid");
             File.WriteAllBytes(_tempMidiPath, midi);
 
-            mciSendString("open \"" + _tempMidiPath + "\" type sequencer alias " + MciAlias, null, 0, IntPtr.Zero);
-            mciSendString("play " + MciAlias, null, 0, IntPtr.Zero);
+            int openResult = mciSendString("open \"" + _tempMidiPath + "\" type sequencer alias " + MciAlias, null, 0, IntPtr.Zero);
+            if (openResult != 0)
+            {
+                lblStatus.Text = "MIDI playback failed: " + MciErrorText(openResult);
+                return;
+            }
+
+            int playResult = mciSendString("play " + MciAlias, null, 0, IntPtr.Zero);
+            if (playResult != 0)
+            {
+                mciSendString("close " + MciAlias, null, 0, IntPtr.Zero);
+                lblStatus.Text = "MIDI playback failed: " + MciErrorText(playResult);
+                return;
+            }
+
             _midiOpen = true;
+        }
+
+        private static string MciErrorText(int errorCode)
+        {
+            var text = new StringBuilder(256);
+            mciGetErrorString(errorCode, text, text.Capacity);
+            return "(" + errorCode + ") " + text;
         }
 
         private void StopPlayback()

--- a/ScummEditor/Gui/SpeechSouControl.Designer.cs
+++ b/ScummEditor/Gui/SpeechSouControl.Designer.cs
@@ -1,0 +1,114 @@
+namespace ScummEditor.Gui
+{
+    partial class SpeechSouControl
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null)) components.Dispose();
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.info = new System.Windows.Forms.Label();
+            this.buttons = new System.Windows.Forms.Panel();
+            this.playButton = new System.Windows.Forms.Button();
+            this.exportButton = new System.Windows.Forms.Button();
+            this.exportAllButton = new System.Windows.Forms.Button();
+            this.grid = new System.Windows.Forms.DataGridView();
+            this.buttons.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.grid)).BeginInit();
+            this.SuspendLayout();
+            //
+            // info
+            //
+            this.info.Dock = System.Windows.Forms.DockStyle.Top;
+            this.info.AutoSize = false;
+            this.info.Height = 22;
+            this.info.Padding = new System.Windows.Forms.Padding(3, 4, 3, 0);
+            this.info.Name = "info";
+            this.info.TabIndex = 0;
+            //
+            // buttons
+            //
+            this.buttons.Controls.Add(this.playButton);
+            this.buttons.Controls.Add(this.exportButton);
+            this.buttons.Controls.Add(this.exportAllButton);
+            this.buttons.Dock = System.Windows.Forms.DockStyle.Top;
+            this.buttons.Height = 31;
+            this.buttons.Name = "buttons";
+            this.buttons.TabIndex = 1;
+            //
+            // playButton
+            //
+            this.playButton.Location = new System.Drawing.Point(3, 3);
+            this.playButton.Name = "playButton";
+            this.playButton.Size = new System.Drawing.Size(75, 25);
+            this.playButton.TabIndex = 0;
+            this.playButton.Text = "Play";
+            this.playButton.UseVisualStyleBackColor = true;
+            this.playButton.Click += new System.EventHandler(this.playButton_Click);
+            //
+            // exportButton
+            //
+            this.exportButton.Location = new System.Drawing.Point(84, 3);
+            this.exportButton.Name = "exportButton";
+            this.exportButton.Size = new System.Drawing.Size(110, 25);
+            this.exportButton.TabIndex = 1;
+            this.exportButton.Text = "Export WAV...";
+            this.exportButton.UseVisualStyleBackColor = true;
+            this.exportButton.Click += new System.EventHandler(this.exportButton_Click);
+            //
+            // exportAllButton
+            //
+            this.exportAllButton.Location = new System.Drawing.Point(200, 3);
+            this.exportAllButton.Name = "exportAllButton";
+            this.exportAllButton.Size = new System.Drawing.Size(120, 25);
+            this.exportAllButton.TabIndex = 2;
+            this.exportAllButton.Text = "Export all WAVs...";
+            this.exportAllButton.UseVisualStyleBackColor = true;
+            this.exportAllButton.Click += new System.EventHandler(this.exportAllButton_Click);
+            //
+            // grid
+            //
+            this.grid.AllowUserToAddRows = false;
+            this.grid.AllowUserToDeleteRows = false;
+            this.grid.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.grid.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.grid.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically;
+            this.grid.Name = "grid";
+            this.grid.ReadOnly = true;
+            this.grid.RowHeadersVisible = false;
+            this.grid.AllowUserToResizeRows = false;
+            this.grid.MultiSelect = false;
+            this.grid.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.grid.TabIndex = 2;
+            //
+            // SpeechSouControl
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.grid);
+            this.Controls.Add(this.buttons);
+            this.Controls.Add(this.info);
+            this.Name = "SpeechSouControl";
+            this.Size = new System.Drawing.Size(640, 420);
+            this.buttons.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.grid)).EndInit();
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label info;
+        private System.Windows.Forms.Panel buttons;
+        private System.Windows.Forms.Button playButton;
+        private System.Windows.Forms.Button exportButton;
+        private System.Windows.Forms.Button exportAllButton;
+        private System.Windows.Forms.DataGridView grid;
+    }
+}

--- a/ScummEditor/Gui/SpeechSouControl.cs
+++ b/ScummEditor/Gui/SpeechSouControl.cs
@@ -1,0 +1,195 @@
+using System;
+using System.IO;
+using System.Media;
+using System.Windows.Forms;
+using ScummEditor.Encoders;
+using ScummEditor.Structures;
+
+namespace ScummEditor.Gui
+{
+    /// <summary>
+    /// Viewer for the speech/effects container (MONSTER.SOU / "game".SOU): lists every
+    /// entry with its offset, size, sample rate and duration, and decodes the Creative VOC
+    /// audio to WAV (play, export one, export all).
+    /// </summary>
+    public partial class SpeechSouControl : UserControl
+    {
+        private SpeechSouFile _file;
+        private SoundPlayer _player;
+
+        public SpeechSouControl()
+        {
+            InitializeComponent();
+        }
+
+        public void SetData(SpeechSouFile file)
+        {
+            _file = file;
+
+            Cursor previousCursor = Cursor.Current;
+            Cursor.Current = Cursors.WaitCursor;
+            try
+            {
+                _file.EnsureParsed();
+            }
+            finally
+            {
+                Cursor.Current = previousCursor;
+            }
+
+            string name = Path.GetFileName(_file.FilePath);
+            info.Text = string.Format("{0}  -  {1} entries, {2:0.0} MB",
+                name, _file.Entries.Count, _file.FileLength / 1048576.0);
+            if (_file.ParseError != null)
+            {
+                info.Text += "   (parse stopped: " + _file.ParseError + ")";
+            }
+
+            grid.Columns.Clear();
+            grid.Rows.Clear();
+            AddColumns("#", "Offset", "VOC bytes", "Sample rate", "Duration", "Lip-sync points");
+
+            foreach (SpeechSouEntry entry in _file.Entries)
+            {
+                grid.Rows.Add(entry.Index,
+                    "0x" + entry.Offset.ToString("X8"),
+                    entry.VocLength,
+                    entry.SampleRate > 0 ? entry.SampleRate + " Hz" : "?",
+                    entry.DurationSeconds.ToString("0.00") + " s",
+                    entry.LipSyncCount);
+            }
+        }
+
+        private void AddColumns(params string[] headers)
+        {
+            foreach (string header in headers)
+            {
+                var column = new DataGridViewTextBoxColumn
+                {
+                    HeaderText = header,
+                    AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells,
+                    SortMode = DataGridViewColumnSortMode.NotSortable,
+                    ReadOnly = true
+                };
+                grid.Columns.Add(column);
+            }
+        }
+
+        private SpeechSouEntry SelectedEntry()
+        {
+            if (_file == null || grid.CurrentRow == null) return null;
+            int index = grid.CurrentRow.Index;
+            if (index < 0 || index >= _file.Entries.Count) return null;
+            return _file.Entries[index];
+        }
+
+        private byte[] DecodeSelectedToWav(SpeechSouEntry entry)
+        {
+            byte[] voc = _file.ReadVocBytes(entry);
+            return SoundConverter.VocToWav(voc);
+        }
+
+        private void playButton_Click(object sender, EventArgs e)
+        {
+            SpeechSouEntry entry = SelectedEntry();
+            if (entry == null) return;
+
+            try
+            {
+                byte[] wav = DecodeSelectedToWav(entry);
+                if (wav == null)
+                {
+                    MessageBox.Show(this, "This entry uses an unsupported VOC codec and cannot be decoded.",
+                        "Play", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+
+                if (_player != null) _player.Stop();
+                _player = new SoundPlayer(new MemoryStream(wav));
+                _player.Play();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Could not play the entry: " + ex.Message, "Play",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void exportButton_Click(object sender, EventArgs e)
+        {
+            SpeechSouEntry entry = SelectedEntry();
+            if (entry == null) return;
+
+            var dlg = new SaveFileDialog
+            {
+                Filter = "WAV audio (*.wav)|*.wav",
+                FileName = string.Format("speech_{0:D5}.wav", entry.Index)
+            };
+            if (dlg.ShowDialog(this) != DialogResult.OK) return;
+
+            try
+            {
+                byte[] wav = DecodeSelectedToWav(entry);
+                if (wav == null)
+                {
+                    MessageBox.Show(this, "This entry uses an unsupported VOC codec and cannot be decoded.",
+                        "Export WAV", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+
+                File.WriteAllBytes(dlg.FileName, wav);
+                MessageBox.Show(this, "Entry exported to:\n" + dlg.FileName, "Export WAV",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Export failed: " + ex.Message, "Export WAV",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void exportAllButton_Click(object sender, EventArgs e)
+        {
+            if (_file == null || _file.Entries.Count == 0) return;
+
+            var dlg = new FolderBrowserDialog
+            {
+                Description = "Folder to save one WAV per entry (speech_NNNNN.wav)"
+            };
+            if (dlg.ShowDialog(this) != DialogResult.OK) return;
+
+            int exported = 0, failed = 0;
+            Cursor previousCursor = Cursor.Current;
+            Cursor.Current = Cursors.WaitCursor;
+            try
+            {
+                foreach (SpeechSouEntry entry in _file.Entries)
+                {
+                    try
+                    {
+                        byte[] wav = DecodeSelectedToWav(entry);
+                        if (wav == null) { failed++; continue; }
+
+                        string path = Path.Combine(dlg.SelectedPath, string.Format("speech_{0:D5}.wav", entry.Index));
+                        File.WriteAllBytes(path, wav);
+                        exported++;
+                    }
+                    catch (Exception)
+                    {
+                        failed++;
+                    }
+                }
+            }
+            finally
+            {
+                Cursor.Current = previousCursor;
+            }
+
+            MessageBox.Show(this,
+                string.Format("{0} entries exported to:\n{1}{2}", exported, dlg.SelectedPath,
+                    failed > 0 ? "\n\n" + failed + " entries could not be decoded." : ""),
+                "Export all WAVs", MessageBoxButtons.OK,
+                failed > 0 ? MessageBoxIcon.Warning : MessageBoxIcon.Information);
+        }
+    }
+}

--- a/ScummEditor/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor/Gui/TreeNavigatorManager.cs
@@ -14,6 +14,8 @@ namespace ScummEditor.Gui
     {
         private BlockBaseControl _blockBaseControl { get; set; }
         private Dictionary<string, BlockBaseControl> _controlViewers;
+        private readonly SpeechSouControl _speechSouControl = new SpeechSouControl();
+        private readonly CdAudioSouControl _cdAudioSouControl = new CdAudioSouControl();
         private readonly TreeView _treeView;
         private readonly Panel _displayPanel;
 
@@ -80,6 +82,31 @@ namespace ScummEditor.Gui
 
             if (ScummV6GameData.IndexFile != null) CreateScummIndexFileTree(ScummV6GameData.IndexFile);
             if (ScummV6GameData.DataFile != null) CreateScummDataFileTree(ScummV6GameData.DataFile);
+            CreateSouFileNodes(ScummV6GameData.LoadedGameInfo);
+        }
+
+        /// <summary>
+        /// Root nodes for the standalone audio containers next to the game files: the speech
+        /// file (MONSTER.SOU / "game".SOU) and the ripped CD audio (CDDA.SOU). The files are
+        /// parsed lazily, when their node is first selected.
+        /// </summary>
+        private void CreateSouFileNodes(GameInfo gameInfo)
+        {
+            if (gameInfo == null) return;
+
+            if (gameInfo.SpeechFilePath != null)
+            {
+                var node = _treeView.Nodes.Add("SpeechFile",
+                    "Speech File (" + System.IO.Path.GetFileName(gameInfo.SpeechFilePath) + ")");
+                node.Tag = new SpeechSouFile(gameInfo.SpeechFilePath);
+            }
+
+            if (gameInfo.CdAudioFilePath != null)
+            {
+                var node = _treeView.Nodes.Add("CdAudioFile",
+                    "CD Audio (" + System.IO.Path.GetFileName(gameInfo.CdAudioFilePath) + ")");
+                node.Tag = new CdAudioSouFile(gameInfo.CdAudioFilePath);
+            }
         }
 
         private void CreateScummDataFileTree(ScummV6DataFile dataFile)
@@ -151,6 +178,26 @@ namespace ScummEditor.Gui
         {
             _displayPanel.Controls.Clear();
             if (e.Node.Tag == null) return;
+
+            // The audio container nodes carry their own (non-block) objects and viewers.
+            var speechFile = e.Node.Tag as SpeechSouFile;
+            if (speechFile != null)
+            {
+                _speechSouControl.SetData(speechFile);
+                _displayPanel.Controls.Add(_speechSouControl);
+                _speechSouControl.Dock = DockStyle.Fill;
+                return;
+            }
+
+            var cdAudioFile = e.Node.Tag as CdAudioSouFile;
+            if (cdAudioFile != null)
+            {
+                _cdAudioSouControl.SetData(cdAudioFile);
+                _displayPanel.Controls.Add(_cdAudioSouControl);
+                _cdAudioSouControl.Dock = DockStyle.Fill;
+                return;
+            }
+
             var item = (BlockBase)e.Node.Tag;
 
             string name = item.GetType().Name;

--- a/ScummEditor/Properties/AssemblyInfo.cs
+++ b/ScummEditor/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]
 // Application.ProductVersion (shown in the About window) reads this on modern .NET.
-[assembly: AssemblyInformationalVersion("1.4.0.0")]
+[assembly: AssemblyInformationalVersion("1.5.0.0")]

--- a/ScummEditor/Resources/History.txt
+++ b/ScummEditor/Resources/History.txt
@@ -1,3 +1,11 @@
+1.5.0.0
+-------
+* Speech file viewer. The standalone speech/effects container of the talkie editions (MONSTER.SOU, or the FM Towns-style "game".SOU) now appears as a node in the tree and lists every voice/effect line with its lip-sync timestamp count, sample rate and duration. Each line can be played in the editor and exported to WAV (one entry or all at once). The file is parsed lazily and the audio is read on demand, so the hundreds-of-MB speech files open instantly.
+
+* CD audio viewer. Releases that ship the CD music ripped as CDDA.SOU now show a node listing each audio track with its start frame and duration; tracks can be played and exported to WAV (44100 Hz, 16-bit stereo), one or all at once.
+
+* MIDI sound blocks now play. The iMUSE tracks use the SMF format 2 that the Windows sequencer rejects; a single-track format 2 is patched to format 0 for playback (the exported bytes are untouched), and MCI errors are now reported instead of failing silently.
+
 1.4.0.0
 -------
 * Full SCUMM v5 support: The Secret of Monkey Island (CD VGA), Monkey Island 2: LeChuck's Revenge and Indiana Jones and the Fate of Atlantis now have the same feature set as the v6 games. Every block type is decoded with its viewer (scripts, objects, fonts, sounds, walk boxes, palettes - including the v5-only EPAL EGA dithering palette), and images, costumes and charsets round-trip byte-identically.

--- a/ScummEditor/Structures/CdAudioSouFile.cs
+++ b/ScummEditor/Structures/CdAudioSouFile.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace ScummEditor.Structures
+{
+    /// <summary>One CD audio track inside a CDDA.SOU container.</summary>
+    public class CdAudioTrack
+    {
+        public int Number { get; set; }
+        public long Offset { get; set; }
+        public long ByteLength { get; set; }
+        /// <summary>Absolute start frame on the original CD (75 frames per second).</summary>
+        public int StartFrame { get; set; }
+        public int FrameCount { get; set; }
+        public double DurationSeconds { get; set; }
+    }
+
+    /*
+    CDDA.SOU - ripped CD audio container shipped by digital releases of the CD games
+    (e.g. The Secret of Monkey Island CD):
+
+      0x000  " GSA" magic + version dword
+      0x010  track table, up to 98 pairs of uint32le:
+               file offset of the track, absolute CD start frame (1/75 s)
+             The last used pair is a sentinel pointing at the end of the file.
+      0x320  raw CD audio: 44100 Hz, 16-bit signed little-endian, stereo,
+             2352 bytes per CD frame.
+
+    The track boundaries come straight from the table; each track converts to WAV by
+    writing a PCM header and streaming the bytes.
+    */
+    public class CdAudioSouFile
+    {
+        private const int HeaderSize = 0x320;
+        private const int BytesPerFrame = 2352;
+        public const int SampleRate = 44100;
+
+        public string FilePath { get; private set; }
+        public long FileLength { get; private set; }
+        public List<CdAudioTrack> Tracks { get; private set; }
+        public double TotalDurationSeconds { get; private set; }
+        /// <summary>Non-null when the file is not a supported CDDA.SOU variant.</summary>
+        public string ParseError { get; private set; }
+
+        private bool _parsed;
+
+        public CdAudioSouFile(string filePath)
+        {
+            FilePath = filePath;
+            Tracks = new List<CdAudioTrack>();
+        }
+
+        public void EnsureParsed()
+        {
+            if (_parsed) return;
+            _parsed = true;
+
+            try
+            {
+                Parse();
+            }
+            catch (Exception ex)
+            {
+                ParseError = ex.Message;
+            }
+        }
+
+        private void Parse()
+        {
+            using (var stream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                FileLength = stream.Length;
+
+                var header = new byte[HeaderSize];
+                if (stream.Read(header, 0, HeaderSize) != HeaderSize)
+                {
+                    ParseError = "The file is too small to hold a CDDA.SOU header.";
+                    return;
+                }
+
+                if (header[0] != ' ' || header[1] != 'G' || header[2] != 'S' || header[3] != 'A')
+                {
+                    ParseError = "Unsupported CDDA.SOU variant (expected the \" GSA\" table header).";
+                    return;
+                }
+
+                // (file offset, CD start frame) pairs; the last one is the end-of-file sentinel.
+                var offsets = new List<long>();
+                var frames = new List<int>();
+                for (int p = 0x10; p + 8 <= HeaderSize; p += 8)
+                {
+                    long offset = (uint)(header[p] | (header[p + 1] << 8) | (header[p + 2] << 16) | (header[p + 3] << 24));
+                    int frame = header[p + 4] | (header[p + 5] << 8) | (header[p + 6] << 16) | (header[p + 7] << 24);
+                    if (offset == 0 && offsets.Count > 0) break;
+                    offsets.Add(offset);
+                    frames.Add(frame);
+                }
+
+                for (int i = 0; i + 1 < offsets.Count; i++)
+                {
+                    var track = new CdAudioTrack
+                    {
+                        Number = i + 1,
+                        Offset = offsets[i],
+                        ByteLength = offsets[i + 1] - offsets[i],
+                        StartFrame = frames[i],
+                        FrameCount = frames[i + 1] - frames[i]
+                    };
+                    track.DurationSeconds = track.FrameCount / 75.0;
+                    Tracks.Add(track);
+                    TotalDurationSeconds += track.DurationSeconds;
+                }
+
+                if (Tracks.Count == 0)
+                {
+                    ParseError = "No tracks found in the CDDA.SOU table.";
+                }
+            }
+        }
+
+        /// <summary>Decodes one track to a PCM WAV file (44100 Hz, 16-bit, stereo), streaming the bytes.</summary>
+        public void ExportTrackToWav(CdAudioTrack track, string outputPath)
+        {
+            using (var output = new FileStream(outputPath, FileMode.Create, FileAccess.Write))
+            {
+                WriteTrackWav(track, output);
+            }
+        }
+
+        /// <summary>Writes the WAV of one track into a stream (used by the in-editor player).</summary>
+        public void WriteTrackWav(CdAudioTrack track, Stream output)
+        {
+            using (var input = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var writer = new BinaryWriter(output, Encoding.ASCII, true))
+            {
+                long dataLength = track.ByteLength;
+
+                writer.Write(Encoding.ASCII.GetBytes("RIFF"));
+                writer.Write((uint)(36 + dataLength));
+                writer.Write(Encoding.ASCII.GetBytes("WAVE"));
+
+                writer.Write(Encoding.ASCII.GetBytes("fmt "));
+                writer.Write(16);                          // PCM fmt chunk size
+                writer.Write((short)1);                    // audio format = PCM
+                writer.Write((short)2);                    // stereo
+                writer.Write(SampleRate);
+                writer.Write(SampleRate * 4);              // byte rate (16-bit stereo)
+                writer.Write((short)4);                    // block align
+                writer.Write((short)16);                   // bits per sample
+
+                writer.Write(Encoding.ASCII.GetBytes("data"));
+                writer.Write((uint)dataLength);
+
+                input.Seek(track.Offset, SeekOrigin.Begin);
+                var buffer = new byte[64 * 1024];
+                long remaining = dataLength;
+                while (remaining > 0)
+                {
+                    int chunk = remaining > buffer.Length ? buffer.Length : (int)remaining;
+                    int read = input.Read(buffer, 0, chunk);
+                    if (read <= 0) break;
+                    output.Write(buffer, 0, read);
+                    remaining -= read;
+                }
+            }
+        }
+    }
+}

--- a/ScummEditor/Structures/ScummV6GameData.cs
+++ b/ScummEditor/Structures/ScummV6GameData.cs
@@ -36,6 +36,15 @@ namespace ScummEditor.Structures
         /// </summary>
         public bool HasCdAudio { get; set; }
 
+        /// <summary>
+        /// Path of the speech/effects container (MONSTER.SOU or the FM Towns-style
+        /// "game".SOU) when the release ships one, regardless of its size; null otherwise.
+        /// </summary>
+        public string SpeechFilePath { get; set; }
+
+        /// <summary>Path of the ripped CD audio container (CDDA.SOU) when present; null otherwise.</summary>
+        public string CdAudioFilePath { get; set; }
+
         public string IndexFile { get; set; }
         public string DataFile { get; set; }
     }

--- a/ScummEditor/Structures/SpeechSouFile.cs
+++ b/ScummEditor/Structures/SpeechSouFile.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace ScummEditor.Structures
+{
+    /// <summary>One speech/effect line inside a .SOU container.</summary>
+    public class SpeechSouEntry
+    {
+        public int Index { get; set; }
+        /// <summary>Offset of the VCTL tag in the file (the offset the game scripts reference).</summary>
+        public long Offset { get; set; }
+        /// <summary>Number of lip-sync timestamps in the VCTL block.</summary>
+        public int LipSyncCount { get; set; }
+        /// <summary>Offset/length of the embedded Creative VOC file.</summary>
+        public long VocOffset { get; set; }
+        public int VocLength { get; set; }
+        public int SampleRate { get; set; }
+        public double DurationSeconds { get; set; }
+    }
+
+    /*
+    MONSTER.SOU / "game".SOU (FM Towns) - the speech and sound-effects container of the
+    talkie editions:
+
+      "SOU " + uint32 (always 0)
+      repeated entries:
+        "VCTL" + size:32be       (size includes the 8-byte header; body = lip-sync
+                                   timestamps, 2 bytes each)
+        Creative VOC file         ("Creative Voice File\x1A" header + typed blocks,
+                                   terminated by a 0x00 block)
+
+    The file is parsed lazily and only the block headers are read (the files reach
+    hundreds of MB); the audio bytes are loaded on demand per entry.
+    */
+    public class SpeechSouFile
+    {
+        // The trailing \x1A EOF marker is not checked: one entry of the Sam & Max floppy
+        // effects file has it replaced by \x00.
+        private const string VocSignature = "Creative Voice File";
+
+        public string FilePath { get; private set; }
+        public long FileLength { get; private set; }
+        public List<SpeechSouEntry> Entries { get; private set; }
+        /// <summary>Non-null when the walk stopped before the end of the file.</summary>
+        public string ParseError { get; private set; }
+
+        private bool _parsed;
+
+        public SpeechSouFile(string filePath)
+        {
+            FilePath = filePath;
+            Entries = new List<SpeechSouEntry>();
+        }
+
+        public void EnsureParsed()
+        {
+            if (_parsed) return;
+            _parsed = true;
+
+            try
+            {
+                Parse();
+            }
+            catch (Exception ex)
+            {
+                ParseError = ex.Message;
+            }
+        }
+
+        private void Parse()
+        {
+            using (var stream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                FileLength = stream.Length;
+
+                var header = new byte[8];
+                if (stream.Read(header, 0, 8) != 8 || header[0] != 'S' || header[1] != 'O' || header[2] != 'U')
+                {
+                    ParseError = "The file does not start with the expected \"SOU \" header.";
+                    return;
+                }
+
+                while (stream.Position + 4 <= stream.Length)
+                {
+                    long entryOffset = stream.Position;
+
+                    var tag = new byte[4];
+                    if (stream.Read(tag, 0, 4) != 4) break;
+
+                    var entry = new SpeechSouEntry
+                    {
+                        Index = Entries.Count,
+                        Offset = entryOffset
+                    };
+
+                    // Most entries start with a lip-sync block: VCTL in the talkie files,
+                    // VTTL in the sound-effects files. Some entries (seen in DOTT) have no
+                    // lip-sync block at all and start directly with the Creative VOC data.
+                    bool isLipSyncTag = (tag[0] == 'V' && (tag[1] == 'C' || tag[1] == 'T') && tag[2] == 'T' && tag[3] == 'L');
+                    bool isBareVoc = (tag[0] == 'C' && tag[1] == 'r' && tag[2] == 'e' && tag[3] == 'a');
+
+                    if (isLipSyncTag)
+                    {
+                        var sizeBytes = new byte[4];
+                        if (stream.Read(sizeBytes, 0, 4) != 4) break;
+                        int blockSize = (sizeBytes[0] << 24) | (sizeBytes[1] << 16) | (sizeBytes[2] << 8) | sizeBytes[3];
+                        if (blockSize < 8 || entryOffset + blockSize > stream.Length)
+                        {
+                            ParseError = string.Format("Invalid lip-sync block size at offset 0x{0:X}.", entryOffset);
+                            return;
+                        }
+
+                        entry.LipSyncCount = (blockSize - 8) / 2;
+                        stream.Seek(entryOffset + blockSize, SeekOrigin.Begin);
+                    }
+                    else if (isBareVoc)
+                    {
+                        stream.Seek(entryOffset, SeekOrigin.Begin); // the VOC walk re-reads its header
+                    }
+                    else
+                    {
+                        ParseError = string.Format(
+                            "Unexpected data at offset 0x{0:X}: expected a VCTL/VTTL block or VOC data.", entryOffset);
+                        return;
+                    }
+
+                    if (!WalkVocFile(stream, entry))
+                    {
+                        ParseError = string.Format("Invalid VOC data at offset 0x{0:X}.", entry.VocOffset);
+                        return;
+                    }
+
+                    Entries.Add(entry);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Walks the VOC block headers (without reading the audio bytes) to find where the
+        /// embedded VOC file ends, collecting the sample rate and the duration on the way.
+        /// </summary>
+        private static bool WalkVocFile(FileStream stream, SpeechSouEntry entry)
+        {
+            entry.VocOffset = stream.Position;
+
+            var vocHeader = new byte[26];
+            if (stream.Read(vocHeader, 0, 26) != 26) return false;
+            for (int i = 0; i < VocSignature.Length; i++)
+            {
+                if (vocHeader[i] != (byte)VocSignature[i]) return false;
+            }
+
+            int firstBlockOffset = vocHeader[20] | (vocHeader[21] << 8);
+            if (firstBlockOffset < 26) firstBlockOffset = 26;
+            stream.Seek(entry.VocOffset + firstBlockOffset, SeekOrigin.Begin);
+
+            long pcmBytes = 0;
+            var blockHeader = new byte[4];
+            while (true)
+            {
+                int read = stream.Read(blockHeader, 0, 1);
+                if (read != 1) return false;
+
+                byte blockType = blockHeader[0];
+                if (blockType == 0x00) break; // VOC terminator
+
+                if (stream.Read(blockHeader, 1, 3) != 3) return false;
+                int blockLength = blockHeader[1] | (blockHeader[2] << 8) | (blockHeader[3] << 16);
+                long bodyStart = stream.Position;
+                if (bodyStart + blockLength > stream.Length) return false;
+
+                if (blockType == 1 && blockLength >= 2) // sound data: timeConstant + codec + samples
+                {
+                    int timeConstant = stream.ReadByte();
+                    if (entry.SampleRate == 0 && timeConstant >= 0 && timeConstant < 256)
+                    {
+                        entry.SampleRate = 1000000 / (256 - timeConstant);
+                    }
+                    pcmBytes += blockLength - 2;
+                }
+                else if (blockType == 2) // continuation of the previous sound data
+                {
+                    pcmBytes += blockLength;
+                }
+
+                stream.Seek(bodyStart + blockLength, SeekOrigin.Begin);
+            }
+
+            entry.VocLength = (int)(stream.Position - entry.VocOffset);
+            if (entry.SampleRate > 0)
+            {
+                entry.DurationSeconds = pcmBytes / (double)entry.SampleRate;
+            }
+            return true;
+        }
+
+        /// <summary>Reads the raw Creative VOC bytes of one entry (loaded on demand).</summary>
+        public byte[] ReadVocBytes(SpeechSouEntry entry)
+        {
+            using (var stream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                var data = new byte[entry.VocLength];
+                stream.Seek(entry.VocOffset, SeekOrigin.Begin);
+                int total = 0;
+                while (total < data.Length)
+                {
+                    int read = stream.Read(data, total, data.Length - total);
+                    if (read <= 0) break;
+                    total += read;
+                }
+                return data;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds in-editor viewers for the standalone audio containers that ship next to the SCUMM game data, and fixes MIDI sound-block playback. One commit on top of `master` (the SCUMM v5 support is already merged). Bumps the version to 1.5.0.0.

## What changed

- **Speech file viewer** — the speech/effects container of the talkie editions (`MONSTER.SOU`, or the FM Towns-style `<game>.SOU`) now appears as a node in the tree and lists every voice/effect line with its lip-sync timestamp count, sample rate and duration. Each line can be played in the editor and exported to WAV (one entry or all at once). The container is parsed lazily and the audio bytes are read on demand, so the hundreds-of-MB speech files open instantly.
- **CD audio viewer** — releases that ship the CD music ripped as `CDDA.SOU` (` GSA` track table) show a node listing each track with its start frame and duration; tracks can be played and exported to WAV (44100 Hz, 16-bit stereo, 2352 bytes per CD frame), one or all at once.
- **MIDI sound blocks now play** — the iMUSE tracks use SMF format 2, which the Windows MCI sequencer rejects (error 296). A single-track format 2 is patched to format 0 for playback only (the exported bytes are untouched), and MCI errors are now surfaced in the status line instead of failing silently.

## Why

The talkie/CD games carry their voice and music outside the indexed data file, in `.SOU` containers the editor did not surface. Listing, playing and exporting them (plus getting the embedded MIDI to play) rounds out the audio side of the editor — useful for the translation team checking voice lines against the text.

## Notes for reviewers

- Both `.SOU` containers are read-only and parsed only when their tree node is first selected; the speech file is exposed whenever present (even the small effects-only `MONSTER.SOU` of the floppy editions), while the talkie flag still requires a large file.
- New parsers: `Structures/SpeechSouFile.cs` (walks `VCTL`/`VTTL` lip-sync blocks + embedded Creative VOC files) and `Structures/CdAudioSouFile.cs` (` GSA` table → WAV). New viewers: `Gui/SpeechSouControl` and `Gui/CdAudioSouControl`.
- VOC playback reuses the existing `SoundConverter.VocToWav`; the trailing `\x1A` VOC EOF marker is no longer required (one Sam & Max floppy effect entry has it replaced by `\x00`).
- Manually exercised against DOTT, Sam & Max and the Monkey Island 1 CD (CDDA.SOU) from the local game library.
