### PR TITLE
Font guide: draw the glyph offset box (not a cross); FontXY metrics u…

### DIFF
--- a/ScummEditor.Engine/Encoders/CharsetPngCodec.cs
+++ b/ScummEditor.Engine/Encoders/CharsetPngCodec.cs
@@ -23,8 +23,9 @@ namespace ScummEditor.Engine.Encoders
       - The PNG is 8bpp indexed and each pixel byte is the raw glyph pixel value
         (0 = transparent, 1..2^bpp-1 = ink), exactly like the room-image export pipeline.
         The file must stay in indexed mode when edited.
-      - A companion guide PNG (same size) shows the grid, the hex slot ids, the origin
-        marks and the current glyphs, to be used as a reference layer in Photoshop.
+      - A companion guide PNG (same size) shows the grid, the hex slot ids, a box around
+        each present glyph at its x/y offset (the footprint the FontXY metrics control)
+        and the current glyphs, to be used as a reference layer in Photoshop.
 
     Import safety: a cell whose pixels are identical to what export produces for the
     current font keeps the original glyph bytes verbatim (so blank-but-present glyphs like
@@ -189,10 +190,6 @@ namespace ScummEditor.Engine.Encoders
                     int cx = (slot % Columns) * cellW;
                     int cy = (slot / Columns) * cellH;
 
-                    // origin marks: the glyph origin is at (marginX, marginY) in each cell
-                    gfx.DrawLine(originPen, cx + marginX, cy + marginY - 3, cx + marginX, cy + marginY + 3);
-                    gfx.DrawLine(originPen, cx + marginX - 3, cy + marginY, cx + marginX + 3, cy + marginY);
-
                     // current glyph, as editing context
                     if (slot < charset.Glyphs.Count)
                     {
@@ -205,6 +202,13 @@ namespace ScummEditor.Engine.Encoders
                                     if (values[x, y] != 0)
                                         gfx.FillRectangle(glyphBrush,
                                             cx + marginX + glyph.XOffset + x, cy + marginY + glyph.YOffset + y, 1, 1);
+
+                            // offset box: the glyph's W x H footprint at its x/y draw offset, relative to the
+                            // cell origin at (marginX, marginY). Its position shows the offset (what FontXY's
+                            // X/Y metrics control); its size shows the glyph's extent. (Replaces the old origin cross.)
+                            gfx.DrawRectangle(originPen,
+                                cx + marginX + glyph.XOffset, cy + marginY + glyph.YOffset,
+                                glyph.Width - 1, glyph.Height - 1);
                         }
                     }
 

--- a/ScummEditor.Engine/Encoders/FontMetricsCodec.cs
+++ b/ScummEditor.Engine/Encoders/FontMetricsCodec.cs
@@ -14,9 +14,10 @@ namespace ScummEditor.Engine.Encoders
     /// independently here. The edit is SIZE-NEUTRAL (it patches the two offset bytes in place), so no block
     /// relocation is needed; the parent re-saves the charset's RawContent verbatim.
     ///
-    /// Text format: one line per PRESENT glyph, "&lt;index&gt;: &lt;xOffset&gt; &lt;yOffset&gt;", with a read-only
-    /// "; WxH" width/height note. Lines starting with ';' and blank lines are ignored. Absent glyphs are
-    /// omitted. Re-importing an unmodified export changes nothing.
+    /// Text format: one line per PRESENT glyph, "&lt;hexIndex&gt;: &lt;xOffset&gt; &lt;yOffset&gt;", with a read-only
+    /// "; WxH" width/height note. The index is the 2-digit HEX glyph slot id, matching the cell labels in
+    /// the guide PNG, so a translator can line up each row with the glyph it sees. Lines starting with ';'
+    /// and blank lines are ignored. Absent glyphs are omitted. Re-importing an unmodified export changes nothing.
     /// </summary>
     public static class FontMetricsCodec
     {
@@ -24,14 +25,15 @@ namespace ScummEditor.Engine.Encoders
         {
             var sb = new StringBuilder();
             sb.Append("; SCUMM font glyph metrics - X/Y draw offsets (like scummtr FontXY).\r\n");
-            sb.Append("; Edit the two numbers after each index: <index>: <xOffset> <yOffset>   (range -128..127).\r\n");
+            sb.Append("; The index is the HEX glyph slot id (same as the cell labels in the guide PNG).\r\n");
+            sb.Append("; Edit the two numbers after each index: <hexIndex>: <xOffset> <yOffset>   (range -128..127).\r\n");
             sb.Append("; The 'WxH' note is read-only - width/height come from the glyph bitmap (edit via the PNG atlas).\r\n");
             if (charset == null || charset.Glyphs == null) return sb.ToString();
 
             foreach (Glyph g in charset.Glyphs)
             {
                 if (!g.Present) continue;
-                sb.Append(g.Index).Append(": ")
+                sb.Append(g.Index.ToString("X2")).Append(": ")
                   .Append(g.XOffset).Append(' ').Append(g.YOffset)
                   .Append("   ; ").Append(g.Width).Append('x').Append(g.Height)
                   .Append("\r\n");
@@ -66,11 +68,14 @@ namespace ScummEditor.Engine.Encoders
                 if (line.Length == 0) continue;
 
                 int colon = line.IndexOf(':');
-                if (colon <= 0) { errors.Add(Line(ln) + "expected '<index>: <x> <y>'"); continue; }
+                if (colon <= 0) { errors.Add(Line(ln) + "expected '<hexIndex>: <x> <y>'"); continue; }
 
+                // The index is hex (matching the guide PNG cell labels); tolerate an optional 0x prefix.
+                string idText = line.Substring(0, colon).Trim();
+                if (idText.StartsWith("0x") || idText.StartsWith("0X")) idText = idText.Substring(2);
                 int index;
-                if (!int.TryParse(line.Substring(0, colon).Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out index))
-                { errors.Add(Line(ln) + "invalid glyph index"); continue; }
+                if (!int.TryParse(idText, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out index))
+                { errors.Add(Line(ln) + "invalid glyph index (expected hex, e.g. E3)"); continue; }
 
                 string[] parts = line.Substring(colon + 1).Split(new[] { ' ', '\t', ',' }, StringSplitOptions.RemoveEmptyEntries);
                 int x, y;

--- a/ScummEditor.UnitTests/FontMetricsCodecTests.cs
+++ b/ScummEditor.UnitTests/FontMetricsCodecTests.cs
@@ -45,7 +45,7 @@ namespace ScummEditor.UnitTests
             int newX = g.XOffset == 5 ? 6 : 5;
             int newY = g.YOffset == -3 ? -2 : -3;
 
-            changed = FontMetricsCodec.Import(cs, index + ": " + newX + " " + newY, out errors);
+            changed = FontMetricsCodec.Import(cs, index.ToString("X2") + ": " + newX + " " + newY, out errors);
             Assert.Empty(errors);
             Assert.Equal(1, changed);
             Assert.Equal(before.Length, cs.RawContent.Length); // size-neutral
@@ -80,9 +80,9 @@ namespace ScummEditor.UnitTests
 
             string text =
                 "; a comment\n" +
-                "9999: 0 0\n" +              // unknown/absent glyph -> reported
-                g.Index + ": 200 0\n" +      // out of range -> reported
-                g.Index + ": " + (g.XOffset == 1 ? 2 : 1) + " " + g.YOffset + "\n"; // valid edit
+                "9999: 0 0\n" +                          // unknown/absent glyph (hex 0x9999) -> reported
+                g.Index.ToString("X2") + ": 200 0\n" +   // out of range -> reported
+                g.Index.ToString("X2") + ": " + (g.XOffset == 1 ? 2 : 1) + " " + g.YOffset + "\n"; // valid edit
             List<string> errors;
             int changed = FontMetricsCodec.Import(cs, text, out errors);
 


### PR DESCRIPTION
…se hex glyph ids

- The charset guide PNG (v4/v5/v6, where glyphs carry an x/y draw offset) now draws a box around each present glyph at its offset - the box position shows the offset and its size shows the glyph footprint - instead of the small origin cross. v2/v3 fonts have no per-glyph offset (width-table charsets), so their guide is unchanged.
- The FontXY X/Y metrics file now numbers each glyph with its 2-digit HEX slot id (E3:, 80:), matching the cell labels in the guide PNG, so a translator can line up each row with the glyph it sees. The parser reads the hex index (optional 0x prefix); tests updated.

280/280 xUnit.