### PR TITLE
v1 image import: compact room rebuild — fixes real-engine black screen (v3.6.1)

### DIFF
--- a/ScummEditor.Engine/Encoders/OldBundleImageImporter.cs
+++ b/ScummEditor.Engine/Encoders/OldBundleImageImporter.cs
@@ -184,56 +184,39 @@ namespace ScummEditor.Engine.Encoders
             var room = new ScummV1Room(df.RawContent);
             bool isManiac = df.GameInfo != null && df.GameInfo.LoadedGame == ScummGame.ManiacMansion;
             var enc = new ScummV1ImageEncoder(isManiac);
-            byte[] rebuilt;
+            byte[] newRoom;
 
+            // The v1 encoder rebuilds the WHOLE room COMPACTLY (the 5 maps re-encoded in place, compressed) so
+            // the result stays about its original size - the real v1 engine (the DOS interpreter and ScummVM)
+            // cannot run a room that grew. Only the room's 5-map block changes (background pixels or the
+            // walk-behind mask), so background + background z-plane go through this; object-image / object
+            // z-plane import is temporarily disabled (its OBIM lives after the map block and needs the same
+            // compact rewrite - export still works).
             switch (kind)
             {
                 case OldBundleImageKind.Background:
                     if (room.WidthInChars <= 0 || room.HeightInChars <= 0) { error = "This room has no background image."; return false; }
                     if (!SizeMatches(png, room.Width, room.Height, out error)) return false;
                     if (!Indexed(png, out error)) return false;
-                    rebuilt = enc.EncodeBackground(room, IndexedImageHelper.GetIndexMatrix(png), out error);
+                    newRoom = enc.EncodeBackground(room, IndexedImageHelper.GetIndexMatrix(png), out error);
                     break;
-                case OldBundleImageKind.Object:
-                {
-                    int w = room.ObjectWidth(objectIndex), h = room.ObjectHeight(objectIndex);
-                    if (w <= 0 || h <= 0) { error = "This object has no image."; return false; }
-                    if (!SizeMatches(png, w, h, out error)) return false;
-                    if (!Indexed(png, out error)) return false;
-                    rebuilt = enc.EncodeObject(room, objectIndex, IndexedImageHelper.GetIndexMatrix(png), out error);
-                    break;
-                }
                 case OldBundleImageKind.BackgroundZPlane:
                     if (room.WidthInChars <= 0 || room.HeightInChars <= 0) { error = "This room has no background to mask."; return false; }
                     if (!SizeMatches(png, room.Width, room.Height, out error)) return false;
-                    rebuilt = enc.EncodeBackgroundZPlane(room, MaskMatrixFromBitmap(png), out error);
+                    newRoom = enc.EncodeBackgroundZPlane(room, MaskMatrixFromBitmap(png), out error);
                     break;
+                case OldBundleImageKind.Object:
                 case OldBundleImageKind.ObjectZPlane:
-                {
-                    int w = room.ObjectWidth(objectIndex), h = room.ObjectHeight(objectIndex);
-                    if (w <= 0 || h <= 0) { error = "This object has no image to mask."; return false; }
-                    if (!SizeMatches(png, w, h, out error)) return false;
-                    rebuilt = enc.EncodeObjectZPlane(room, objectIndex, MaskMatrixFromBitmap(png), out error);
-                    break;
-                }
+                    error = "v1 object-image / object z-plane import is export-only for now (the compact write-back is being finished); the room background and its walk-behind mask import normally.";
+                    return false;
                 default:
                     error = "Unsupported image kind."; return false;
             }
-            if (rebuilt == null) return false; // an over-limit / unrepresentable edit, reported (lossy by format)
+            if (newRoom == null) return false; // over-limit / unrepresentable / non-standard layout, already reported
 
-            // Every v1 encoder APPENDS its re-encoded maps after the room content and re-points the affected
-            // header / OBIM offset words inside [0, roomSize). INSERT the appended tail at the room's END
-            // (editOffset = roomSize, oldLen = 0) so no room-internal offset (box @0x15 is a single byte,
-            // EXCD/ENCD, object tables) shifts - they all precede roomSize - then overwrite [0, roomSize) with
-            // the encoder's re-pointed header. ApplyEdit (sizeWordOffset = 0) grows the room-0 size word and
-            // relocates the costume / script / sound resources packed after the room (and their index offsets).
-            int roomSize = df.RawContent.Length >= 2 ? (df.RawContent[0] | (df.RawContent[1] << 8)) : df.RawContent.Length;
-            if (roomSize <= 0 || roomSize > df.RawContent.Length) roomSize = df.RawContent.Length;
-            int mapsLen = rebuilt.Length - roomSize;
-            var mapsRegion = new byte[mapsLen];
-            System.Array.Copy(rebuilt, roomSize, mapsRegion, 0, mapsLen);
-            ScummV2Writer.ApplyEdit(df, index, roomNo, roomSize, 0, mapsRegion, 0);
-            System.Array.Copy(rebuilt, 0, df.RawContent, 0, roomSize);
+            // newRoom is a fully self-consistent, compact room resource; splice it in for the old one and
+            // relocate the costume / script / sound sub-resources packed after it in the NN.LFL.
+            ScummV2Writer.ReplaceRoomResource(df, index, roomNo, newRoom);
             return true;
         }
 

--- a/ScummEditor.Engine/Encoders/OldBundleImageImporter.cs
+++ b/ScummEditor.Engine/Encoders/OldBundleImageImporter.cs
@@ -186,12 +186,11 @@ namespace ScummEditor.Engine.Encoders
             var enc = new ScummV1ImageEncoder(isManiac);
             byte[] newRoom;
 
-            // The v1 encoder rebuilds the WHOLE room COMPACTLY (the 5 maps re-encoded in place, compressed) so
-            // the result stays about its original size - the real v1 engine (the DOS interpreter and ScummVM)
-            // cannot run a room that grew. Only the room's 5-map block changes (background pixels or the
-            // walk-behind mask), so background + background z-plane go through this; object-image / object
-            // z-plane import is temporarily disabled (its OBIM lives after the map block and needs the same
-            // compact rewrite - export still works).
+            // The v1 encoder rebuilds the WHOLE room COMPACTLY (every region re-laid back to back with real RLE
+            // compression, all offsets re-pointed) so the result stays about its original size - the real v1
+            // engine (the DOS interpreter and ScummVM) cannot run a room that ballooned. All four kinds go
+            // through this: background and object images edit the shared charMap; the masks edit the shared
+            // maskChar; an over-limit / unrepresentable edit is rejected (newRoom == null) rather than corrupted.
             switch (kind)
             {
                 case OldBundleImageKind.Background:
@@ -206,9 +205,22 @@ namespace ScummEditor.Engine.Encoders
                     newRoom = enc.EncodeBackgroundZPlane(room, MaskMatrixFromBitmap(png), out error);
                     break;
                 case OldBundleImageKind.Object:
+                {
+                    int ow = room.ObjectWidth(objectIndex), oh = room.ObjectHeight(objectIndex);
+                    if (ow <= 0 || oh <= 0) { error = "This object has no image."; return false; }
+                    if (!SizeMatches(png, ow, oh, out error)) return false;
+                    if (!Indexed(png, out error)) return false;
+                    newRoom = enc.EncodeObject(room, objectIndex, IndexedImageHelper.GetIndexMatrix(png), out error);
+                    break;
+                }
                 case OldBundleImageKind.ObjectZPlane:
-                    error = "v1 object-image / object z-plane import is export-only for now (the compact write-back is being finished); the room background and its walk-behind mask import normally.";
-                    return false;
+                {
+                    int ow = room.ObjectWidth(objectIndex), oh = room.ObjectHeight(objectIndex);
+                    if (ow <= 0 || oh <= 0) { error = "This object has no image to mask."; return false; }
+                    if (!SizeMatches(png, ow, oh, out error)) return false;
+                    newRoom = enc.EncodeObjectZPlane(room, objectIndex, MaskMatrixFromBitmap(png), out error);
+                    break;
+                }
                 default:
                     error = "Unsupported image kind."; return false;
             }

--- a/ScummEditor.Engine/Encoders/ScummV1ImageEncoder.cs
+++ b/ScummEditor.Engine/Encoders/ScummV1ImageEncoder.cs
@@ -10,10 +10,11 @@ namespace ScummEditor.Engine.Encoders
     /// object's tile plane both index it via room+10), and the background and every object mask in ONE shared
     /// maskChar table (room+18). So the cardinal rule here is: PRESERVE the existing charMap / maskChar exactly
     /// (every other image keeps decoding) and only ADD the edited image's new tiles - into the charMap's free
-    /// (unreferenced) slots, or appended to the variable-length maskChar - NEVER renumber. The re-encoded maps
-    /// are appended to the room resource and the affected header offset words (+10 charMap / +12 picMap /
-    /// +14 colorMap / +16 maskMap / +18 maskData) and/or OBIM table entry are re-pointed; the originals are
-    /// left as dead bytes.
+    /// (unreferenced) slots, or appended to the variable-length maskChar - NEVER renumber. The room is then
+    /// rebuilt COMPACTLY (AssembleCompactRoom): every region (the box, the 5 maps, each object image/code, the
+    /// scripts) is re-laid back to back with real RLE compression and every offset field re-pointed, so an edit
+    /// grows the room by only a few bytes. (An earlier version appended the new maps and left the originals as
+    /// dead bytes, ~doubling the room - which the real v1 engine could not load, so the game black-screened.)
     ///
     /// LOSSY BY FORMAT: each 8x8 cell can show only 4 colours (3 fixed room colours + 1 free per cell), the
     /// charMap holds at most 256 distinct tiles and the maskChar at most 256 distinct mask tiles, so an edit
@@ -119,7 +120,7 @@ namespace ScummEditor.Engine.Encoders
             // unchanged by a background edit, so keep the originals.
             byte[] origMaskMap = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.MaskMapOffset, w * h) ?? new byte[w * h];
             byte[] origMaskChar = LoadMaskChar(room).ToArray();
-            return AssembleCompactRoom(room, charMap, picMap, colorMap, origMaskMap, origMaskChar, out error);
+            return AssembleCompactRoom(room, charMap, picMap, colorMap, origMaskMap, origMaskChar, null, out error);
         }
 
         // --- object image -----------------------------------------------------
@@ -190,11 +191,15 @@ namespace ScummEditor.Engine.Encoders
                 newMap[(y + h) * w + strip] = (byte)(c3 < 0 ? 0 : c3); // plane 1 (colour)
             }
 
-            int roomSize = RoomSize(room);
-            var outp = CopyRoom(room, roomSize);
-            if (charMapChanged) WriteU16Patch(outp, 10, AppendRegion(outp, RawEncode(charMap)));
-            WriteU16Patch(outp, 28 + objectIndex * 2, AppendRegion(outp, RawEncode(newMap))); // OBIM table entry
-            return Finish(outp, out error);
+            // Rebuild the room COMPACTLY: the edited object image (and the possibly-grown shared charMap) are
+            // re-encoded in place; the background colour maps and the masks are preserved (re-encoded losslessly).
+            int bw = room.WidthInChars, bh = room.HeightInChars, mapLen = Math.Max(1, bw * bh);
+            byte[] origPic = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.PicMapOffset, bw * bh) ?? new byte[mapLen];
+            byte[] origColor = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.ColorMapOffset, bw * bh) ?? new byte[mapLen];
+            byte[] origMaskMap = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.MaskMapOffset, bw * bh) ?? new byte[mapLen];
+            byte[] origMaskChar = LoadMaskChar(room).ToArray();
+            var objEdits = new Dictionary<int, byte[]> { { objectIndex, newMap } };
+            return AssembleCompactRoom(room, charMap, origPic, origColor, origMaskMap, origMaskChar, objEdits, out error);
         }
 
         // --- background walk-behind (z-plane) mask ----------------------------
@@ -235,7 +240,7 @@ namespace ScummEditor.Engine.Encoders
             byte[] origChar = LoadCharMap(room);
             byte[] origPic = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.PicMapOffset, w * h) ?? new byte[w * h];
             byte[] origColor = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.ColorMapOffset, w * h) ?? new byte[w * h];
-            return AssembleCompactRoom(room, origChar, origPic, origColor, maskMap, maskChar.ToArray(), out error);
+            return AssembleCompactRoom(room, origChar, origPic, origColor, maskMap, maskChar.ToArray(), null, out error);
         }
 
         // --- object walk-behind (z-plane) mask --------------------------------
@@ -275,11 +280,15 @@ namespace ScummEditor.Engine.Encoders
                 }
             }
 
-            int roomSize = RoomSize(room);
-            var outp = CopyRoom(room, roomSize);
-            WriteU16Patch(outp, 18, AppendRegion(outp, BuildMaskData(maskChar.ToArray())));
-            WriteU16Patch(outp, 28 + objectIndex * 2, AppendRegion(outp, RawEncode(newMap)));
-            return Finish(outp, out error);
+            // Rebuild the room COMPACTLY: the edited object mask (plane 2, with the possibly-grown shared
+            // maskChar) is re-encoded in place; the charMap, colour maps and the background mask are preserved.
+            int bw = room.WidthInChars, bh = room.HeightInChars, mapLen = Math.Max(1, bw * bh);
+            byte[] origChar = LoadCharMap(room);
+            byte[] origPic = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.PicMapOffset, bw * bh) ?? new byte[mapLen];
+            byte[] origColor = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.ColorMapOffset, bw * bh) ?? new byte[mapLen];
+            byte[] origMaskMap = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.MaskMapOffset, bw * bh) ?? new byte[mapLen];
+            var objEdits = new Dictionary<int, byte[]> { { objectIndex, newMap } };
+            return AssembleCompactRoom(room, origChar, origPic, origColor, origMaskMap, maskChar.ToArray(), objEdits, out error);
         }
 
         // --- cell encoders ----------------------------------------------------
@@ -504,98 +513,150 @@ namespace ScummEditor.Engine.Encoders
         // --- compact room assembly (the real-engine-safe write-back) -----------
 
         /// <summary>
-        /// Rebuilds the whole room resource COMPACTLY with the 5 maps re-encoded (charMap, picMap, colorMap,
-        /// maskMap compressed + the maskData block). v1 stores the 5 maps as one contiguous block right after
-        /// the box and before the object images/code, so this REPLACES that block in place (no appended dead
-        /// bytes, real RLE compression) and shifts every object/script offset after it - keeping the room about
-        /// its original size, which the real v1 engine (the DOS interpreter + ScummVM) requires. The box and
-        /// everything before the maps is untouched (so the 1-byte box offset never moves). Returns null with an
-        /// error if the room's layout is not the expected contiguous-maps form (then the edit is refused, not
-        /// corrupted). The caller splices the result with ScummV2Writer.ReplaceRoomResource.
+        /// Rebuilds the WHOLE room resource COMPACTLY: it re-encodes the (possibly edited) maps and object
+        /// images with real RLE compression and re-lays every offset-referenced region back to back, then
+        /// re-points every offset field to its region's new position. Unlike the original write-back it appends
+        /// NOTHING and leaves NO dead bytes, so an edit grows the room by only the few bytes the new content
+        /// needs - which the real v1 engine (the DOS interpreter + ScummVM) requires; the bloated append-at-end
+        /// form black-screened the game.
+        ///
+        /// A v1 room is a fixed header (with the OBIM/OBCD offset tables + sound/script id lists) followed by
+        /// offset-referenced regions: the box, the 5 maps, every object's image (OBIM) and code (OBCD), and the
+        /// exit/entry scripts. Sorted + de-duplicated, those offsets tile the room after the header; each region
+        /// runs to the next offset (shared offsets - multi-state objects, or an imageless object whose OBIM
+        /// aliases an OBCD - collapse to one region kept verbatim). <paramref name="objEdits"/> maps an object
+        /// index to its new 3-plane image bytes (null/empty for a background or mask edit). Returns null with an
+        /// error if the layout is not the expected header-then-regions form. The caller splices the result with
+        /// ScummV2Writer.ReplaceRoomResource.
         /// </summary>
         private byte[] AssembleCompactRoom(ScummV1Room room, byte[] charMap, byte[] picMap, byte[] colorMap,
-            byte[] maskMap, byte[] maskChar, out string error)
+            byte[] maskMap, byte[] maskChar, Dictionary<int, byte[]> objEdits, out string error)
         {
             error = null;
             int roomSize = RoomSize(room);
-            int mapStart = room.CharMapOffset;
             int charOff0 = room.CharMapOffset, picOff0 = room.PicMapOffset, colorOff0 = room.ColorMapOffset;
             int maskMapOff0 = room.MaskMapOffset, maskDataOff0 = room.MaskDataOffset;
-
-            // Require the standard contiguous-maps layout (charMap first, all five present).
-            if (mapStart <= 0 || picOff0 <= 0 || colorOff0 <= 0 || maskMapOff0 <= 0 || maskDataOff0 <= 0)
+            if (charOff0 <= 0 || picOff0 <= 0 || colorOff0 <= 0 || maskMapOff0 <= 0 || maskDataOff0 <= 0)
             { error = "This room's map layout is non-standard; its image cannot be re-imported safely."; return null; }
-            int maxMap = Math.Max(Math.Max(Math.Max(charOff0, picOff0), Math.Max(colorOff0, maskMapOff0)), maskDataOff0);
 
-            // The first object/script offset after the maps marks the end of the map block; verify nothing
-            // structural is interleaved inside the map block.
-            int mapEnd = roomSize;
-            foreach (int s in StructuralOffsets(room))
+            // The new bytes for every region we re-encode, keyed by the region's ORIGINAL file offset.
+            var newBytesByOffset = new Dictionary<int, byte[]>();
+            newBytesByOffset[charOff0] = CompressV1Gfx(charMap);
+            newBytesByOffset[picOff0] = CompressV1Gfx(picMap);
+            newBytesByOffset[colorOff0] = CompressV1Gfx(colorMap);
+            newBytesByOffset[maskMapOff0] = CompressV1Gfx(maskMap);
+            newBytesByOffset[maskDataOff0] = BuildMaskData(maskChar);
+            if (objEdits != null && objEdits.Count > 0)
             {
-                if (s > maxMap && s < mapEnd) mapEnd = s;
-                if (s > mapStart && s <= maxMap)
-                { error = "This room interleaves objects with the maps; its image cannot be re-imported safely."; return null; }
+                // Several v1 objects can point at ONE image stream but read it with their own dimensions (e.g.
+                // Zak room 5 objects 0/5/6/11 all start at the same OBIM, reading 12/9/36/192 bytes of the same
+                // RLE). So an edit must re-encode the FULL stream (long enough for the largest reader) with each
+                // edited object's bytes overlaid on its prefix - re-encoding only the editing object's bytes
+                // would truncate the stream and corrupt the longer-reading sharers. A no-op leaves it identical.
+                var editsByOffset = new Dictionary<int, List<int>>();
+                foreach (KeyValuePair<int, byte[]> kv in objEdits)
+                {
+                    int objImgOff = room.ObjectImageOffset(kv.Key);
+                    if (objImgOff <= 0) { error = "The edited object has no image block to replace."; return null; }
+                    if (!editsByOffset.ContainsKey(objImgOff)) editsByOffset[objImgOff] = new List<int>();
+                    editsByOffset[objImgOff].Add(kv.Key);
+                }
+                foreach (KeyValuePair<int, List<int>> grp in editsByOffset)
+                {
+                    int off = grp.Key;
+                    int maxLen = 0;
+                    for (int i = 0; i < room.NumObjects; i++)
+                        if (room.ObjectImageOffset(i) == off)
+                        {
+                            int len = (room.ObjectWidth(i) / 8) * (room.ObjectHeight(i) / 8) * 3;
+                            if (len > maxLen) maxLen = len;
+                        }
+                    if (maxLen <= 0) { error = "The edited object has no decodable image block."; return null; }
+                    byte[] full = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, off, maxLen) ?? new byte[maxLen];
+                    foreach (int objIdx in grp.Value)
+                    {
+                        byte[] em = objEdits[objIdx];
+                        Array.Copy(em, 0, full, 0, Math.Min(em.Length, full.Length));
+                    }
+                    newBytesByOffset[off] = CompressV1Gfx(full);
+                }
             }
-            if (mapEnd <= maxMap || mapEnd > roomSize)
-            { error = "Could not locate the end of the room's map block."; return null; }
 
-            byte[] cChar = CompressV1Gfx(charMap);
-            byte[] cPic = CompressV1Gfx(picMap);
-            byte[] cColor = CompressV1Gfx(colorMap);
-            byte[] cMaskMap = CompressV1Gfx(maskMap);
-            byte[] maskData = BuildMaskData(maskChar);
-
-            int charNew = mapStart;
-            int picNew = charNew + cChar.Length;
-            int colorNew = picNew + cPic.Length;
-            int maskMapNew = colorNew + cColor.Length;
-            int maskDataNew = maskMapNew + cMaskMap.Length;
-            int blockLen = cChar.Length + cPic.Length + cColor.Length + cMaskMap.Length + maskData.Length;
-            int delta = blockLen - (mapEnd - mapStart);
-
-            var nr = new byte[roomSize + delta];
-            if (nr.Length > 0xFFFF) { error = "The re-encoded room exceeds the 64 KB room-resource limit."; return null; }
-            Array.Copy(room.Data, 0, nr, 0, mapStart);
-            int p = mapStart;
-            Array.Copy(cChar, 0, nr, p, cChar.Length); p += cChar.Length;
-            Array.Copy(cPic, 0, nr, p, cPic.Length); p += cPic.Length;
-            Array.Copy(cColor, 0, nr, p, cColor.Length); p += cColor.Length;
-            Array.Copy(cMaskMap, 0, nr, p, cMaskMap.Length); p += cMaskMap.Length;
-            Array.Copy(maskData, 0, nr, p, maskData.Length); p += maskData.Length;
-            Array.Copy(room.Data, mapEnd, nr, p, roomSize - mapEnd);
-
-            // The 5 map offset fields get their new in-block positions; everything that lived after the map
-            // block (EXCD, ENCD, OBIM/OBCD tables) shifts by delta. The box (before the maps) is untouched.
-            WriteU16Buf(nr, 10, charNew); WriteU16Buf(nr, 12, picNew); WriteU16Buf(nr, 14, colorNew);
-            WriteU16Buf(nr, 16, maskMapNew); WriteU16Buf(nr, 18, maskDataNew);
-            ShiftFieldIfAtOrAfter(nr, 0x18, mapEnd, delta); // EXCD
-            ShiftFieldIfAtOrAfter(nr, 0x1A, mapEnd, delta); // ENCD
-            int numObj = nr.Length > 20 ? nr[20] : 0;
+            // Collect every offset-referenced region. Sorted + de-duplicated, these tile [headerEnd, roomSize).
+            int numObj = room.NumObjects;
+            int boxOff = room.Data.Length > 0x15 ? room.Data[0x15] : 0; // the box is a 1-byte offset in v1/v2
+            var offsets = new SortedSet<int>();
+            AddRegionOffset(offsets, boxOff, roomSize);
+            AddRegionOffset(offsets, charOff0, roomSize); AddRegionOffset(offsets, picOff0, roomSize);
+            AddRegionOffset(offsets, colorOff0, roomSize); AddRegionOffset(offsets, maskMapOff0, roomSize);
+            AddRegionOffset(offsets, maskDataOff0, roomSize);
+            AddRegionOffset(offsets, room.ExitScriptOffset, roomSize);
+            AddRegionOffset(offsets, room.EntryScriptOffset, roomSize);
             for (int i = 0; i < numObj; i++)
             {
-                ShiftFieldIfAtOrAfter(nr, 28 + i * 2, mapEnd, delta);            // OBIM[i]
-                ShiftFieldIfAtOrAfter(nr, 28 + numObj * 2 + i * 2, mapEnd, delta); // OBCD[i]
+                AddRegionOffset(offsets, room.ObjectImageOffset(i), roomSize);
+                AddRegionOffset(offsets, room.ObjectCodeOffset(i), roomSize);
+            }
+            if (offsets.Count == 0) { error = "This room has no relocatable regions; its image cannot be re-imported safely."; return null; }
+
+            var sorted = new List<int>(offsets);
+            int headerEnd = sorted[0]; // the fixed header + OBIM/OBCD tables + id lists live in [0, headerEnd)
+            if (headerEnd < 28 + numObj * 4)
+            { error = "This room's header/region layout is non-standard; its image cannot be re-imported safely."; return null; }
+
+            // Lay the room out: header verbatim, then each region (re-encoded where edited, else verbatim) in
+            // offset order, recording each original offset's NEW position.
+            var outp = new List<byte>(roomSize + 1024);
+            for (int i = 0; i < headerEnd; i++) outp.Add(room.Data[i]);
+            var newOffsetOf = new Dictionary<int, int>();
+            for (int s = 0; s < sorted.Count; s++)
+            {
+                int off = sorted[s];
+                newOffsetOf[off] = outp.Count;
+                byte[] bytes;
+                if (newBytesByOffset.TryGetValue(off, out bytes)) outp.AddRange(bytes);
+                else
+                {
+                    int end = (s + 1 < sorted.Count) ? sorted[s + 1] : roomSize;
+                    if (end < off) { error = "This room's region boundaries are inconsistent; its image cannot be re-imported safely."; return null; }
+                    for (int b = off; b < end; b++) outp.Add(room.Data[b]);
+                }
+            }
+
+            byte[] nr = outp.ToArray();
+            if (nr.Length > 0xFFFF) { error = "The re-encoded room exceeds the 64 KB room-resource limit."; return null; }
+
+            // Re-point every offset FIELD to its region's new position (an absent field, value 0, stays 0).
+            WriteU16Buf(nr, 10, newOffsetOf[charOff0]); WriteU16Buf(nr, 12, newOffsetOf[picOff0]);
+            WriteU16Buf(nr, 14, newOffsetOf[colorOff0]); WriteU16Buf(nr, 16, newOffsetOf[maskMapOff0]);
+            WriteU16Buf(nr, 18, newOffsetOf[maskDataOff0]);
+            if (boxOff > 0)
+            {
+                int nb = newOffsetOf[boxOff];
+                if (nb > 0xFF) { error = "The re-encoded room pushes the 1-byte box offset out of range."; return null; }
+                nr[0x15] = (byte)nb;
+            }
+            SetFieldU16(nr, 0x18, room.ExitScriptOffset, newOffsetOf);  // EXCD
+            SetFieldU16(nr, 0x1A, room.EntryScriptOffset, newOffsetOf); // ENCD
+            for (int i = 0; i < numObj; i++)
+            {
+                SetFieldU16(nr, 28 + i * 2, room.ObjectImageOffset(i), newOffsetOf);            // OBIM[i]
+                SetFieldU16(nr, 28 + numObj * 2 + i * 2, room.ObjectCodeOffset(i), newOffsetOf); // OBCD[i]
             }
             WriteU16Buf(nr, 0, nr.Length); // room size word
             return nr;
         }
 
-        private static System.Collections.Generic.IEnumerable<int> StructuralOffsets(ScummV1Room room)
+        private static void AddRegionOffset(SortedSet<int> offsets, int off, int roomSize)
         {
-            yield return room.ExitScriptOffset;
-            yield return room.EntryScriptOffset;
-            for (int i = 0; i < room.NumObjects; i++)
-            {
-                yield return room.ObjectImageOffset(i);
-                yield return room.ObjectCodeOffset(i);
-            }
+            if (off > 0 && off < roomSize) offsets.Add(off);
         }
 
-        private static void ShiftFieldIfAtOrAfter(byte[] buf, int pos, int threshold, int delta)
+        private static void SetFieldU16(byte[] buf, int fieldPos, int origValue, Dictionary<int, int> newOffsetOf)
         {
-            if (pos + 1 >= buf.Length) return;
-            int v = buf[pos] | (buf[pos + 1] << 8);
-            if (v >= threshold) WriteU16Buf(buf, pos, v + delta);
+            if (fieldPos + 1 >= buf.Length || origValue <= 0) return;
+            int nv;
+            if (newOffsetOf.TryGetValue(origValue, out nv)) WriteU16Buf(buf, fieldPos, nv);
         }
 
         private static void WriteU16Buf(byte[] buf, int pos, int value)
@@ -682,54 +743,5 @@ namespace ScummEditor.Engine.Encoders
             return roomSize;
         }
 
-        /// <summary>Copies the room resource [0, roomSize); appended regions go after it, originals become dead bytes.</summary>
-        private static List<byte> CopyRoom(ScummV1Room room, int roomSize)
-        {
-            var outp = new List<byte>(roomSize + 4096);
-            for (int i = 0; i < roomSize; i++) outp.Add(room.Data[i]);
-            return outp;
-        }
-
-        private static int AppendRegion(List<byte> outp, byte[] region)
-        {
-            int off = outp.Count;
-            outp.AddRange(region);
-            return off;
-        }
-
-        private static void WriteU16Patch(List<byte> outp, int pos, int value)
-        {
-            outp[pos] = (byte)(value & 0xFF);
-            outp[pos + 1] = (byte)((value >> 8) & 0xFF);
-        }
-
-        /// <summary>Writes the room-size word and returns the bytes, or null with an error past the 64 KB room limit.</summary>
-        private static byte[] Finish(List<byte> outp, out string error)
-        {
-            error = null;
-            if (outp.Count > 0xFFFF) { error = "The re-encoded room exceeds the 64 KB room-resource limit."; return null; }
-            byte[] rebuilt = outp.ToArray();
-            rebuilt[0] = (byte)(rebuilt.Length & 0xFF);
-            rebuilt[1] = (byte)((rebuilt.Length >> 8) & 0xFF);
-            return rebuilt;
-        }
-
-        /// <summary>
-        /// Encodes a byte buffer with the decodeV1Gfx RLE using only raw-copy runs (a 4-byte common-colour
-        /// header then [count-1][count bytes] chunks of up to 64) - always valid, decodes back identically.
-        /// </summary>
-        private static byte[] RawEncode(byte[] data)
-        {
-            var outp = new List<byte> { 0, 0, 0, 0 }; // 4 common-colour bytes (unused; only raw runs are emitted)
-            int i = 0;
-            while (i < data.Length)
-            {
-                int n = Math.Min(64, data.Length - i);
-                outp.Add((byte)(n - 1)); // raw-copy run: top two bits 0, count = (run & 0x3F) + 1
-                for (int k = 0; k < n; k++) outp.Add(data[i + k]);
-                i += n;
-            }
-            return outp.ToArray();
-        }
     }
 }

--- a/ScummEditor.Engine/Encoders/ScummV1ImageEncoder.cs
+++ b/ScummEditor.Engine/Encoders/ScummV1ImageEncoder.cs
@@ -536,7 +536,12 @@ namespace ScummEditor.Engine.Encoders
             int roomSize = RoomSize(room);
             int charOff0 = room.CharMapOffset, picOff0 = room.PicMapOffset, colorOff0 = room.ColorMapOffset;
             int maskMapOff0 = room.MaskMapOffset, maskDataOff0 = room.MaskDataOffset;
-            if (charOff0 <= 0 || picOff0 <= 0 || colorOff0 <= 0 || maskMapOff0 <= 0 || maskDataOff0 <= 0)
+            // Every map offset must be a real in-room position (> 0 and < roomSize). Besides catching a
+            // non-standard layout, this guarantees each map offset is added as a region below, so the
+            // direct newOffsetOf[...] re-pointing at the end cannot miss a key and throw.
+            if (charOff0 <= 0 || picOff0 <= 0 || colorOff0 <= 0 || maskMapOff0 <= 0 || maskDataOff0 <= 0 ||
+                charOff0 >= roomSize || picOff0 >= roomSize || colorOff0 >= roomSize ||
+                maskMapOff0 >= roomSize || maskDataOff0 >= roomSize)
             { error = "This room's map layout is non-standard; its image cannot be re-imported safely."; return null; }
 
             // The new bytes for every region we re-encode, keyed by the region's ORIGINAL file offset.
@@ -572,7 +577,10 @@ namespace ScummEditor.Engine.Encoders
                             if (len > maxLen) maxLen = len;
                         }
                     if (maxLen <= 0) { error = "The edited object has no decodable image block."; return null; }
-                    byte[] full = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, off, maxLen) ?? new byte[maxLen];
+                    // Decode the WHOLE shared stream (long enough for the largest reader). If it cannot be
+                    // decoded, refuse - zero-filling would silently wipe the image data the other sharers read.
+                    byte[] full = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, off, maxLen);
+                    if (full == null) { error = "This object's shared image stream could not be decoded; its image cannot be re-imported safely."; return null; }
                     foreach (int objIdx in grp.Value)
                     {
                         byte[] em = objEdits[objIdx];
@@ -600,8 +608,11 @@ namespace ScummEditor.Engine.Encoders
             if (offsets.Count == 0) { error = "This room has no relocatable regions; its image cannot be re-imported safely."; return null; }
 
             var sorted = new List<int>(offsets);
-            int headerEnd = sorted[0]; // the fixed header + OBIM/OBCD tables + id lists live in [0, headerEnd)
-            if (headerEnd < 28 + numObj * 4)
+            int headerEnd = sorted[0]; // the fixed header + OBIM/OBCD tables + sound/script id lists live in [0, headerEnd)
+            // The header runs: fixed fields, the OBIM+OBCD tables (numObj*2 each), then the 1-byte sound and
+            // script id lists (numSounds + numScripts). The first region MUST start at or after all of that,
+            // or the verbatim header copy would truncate the id lists and the engine would read garbage ids.
+            if (headerEnd < 28 + numObj * 4 + room.NumSounds + room.NumScripts)
             { error = "This room's header/region layout is non-standard; its image cannot be re-imported safely."; return null; }
 
             // Lay the room out: header verbatim, then each region (re-encoded where edited, else verbatim) in
@@ -632,7 +643,9 @@ namespace ScummEditor.Engine.Encoders
             WriteU16Buf(nr, 18, newOffsetOf[maskDataOff0]);
             if (boxOff > 0)
             {
-                int nb = newOffsetOf[boxOff];
+                int nb;
+                if (!newOffsetOf.TryGetValue(boxOff, out nb))
+                { error = "This room's box offset is out of range; its image cannot be re-imported safely."; return null; }
                 if (nb > 0xFF) { error = "The re-encoded room pushes the 1-byte box offset out of range."; return null; }
                 nr[0x15] = (byte)nb;
             }

--- a/ScummEditor.Engine/Encoders/ScummV1ImageEncoder.cs
+++ b/ScummEditor.Engine/Encoders/ScummV1ImageEncoder.cs
@@ -115,12 +115,11 @@ namespace ScummEditor.Engine.Encoders
                 colorMap[cell] = (byte)(c3 < 0 ? 0 : c3);
             }
 
-            int roomSize = RoomSize(room);
-            var outp = CopyRoom(room, roomSize);
-            if (charMapChanged) WriteU16Patch(outp, 10, AppendRegion(outp, RawEncode(charMap)));
-            WriteU16Patch(outp, 12, AppendRegion(outp, RawEncode(picMap)));
-            WriteU16Patch(outp, 14, AppendRegion(outp, RawEncode(colorMap)));
-            return Finish(outp, out error);
+            // Rebuild the room COMPACTLY (the 5 maps re-encoded in place, compressed). The mask maps are
+            // unchanged by a background edit, so keep the originals.
+            byte[] origMaskMap = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.MaskMapOffset, w * h) ?? new byte[w * h];
+            byte[] origMaskChar = LoadMaskChar(room).ToArray();
+            return AssembleCompactRoom(room, charMap, picMap, colorMap, origMaskMap, origMaskChar, out error);
         }
 
         // --- object image -----------------------------------------------------
@@ -232,11 +231,11 @@ namespace ScummEditor.Engine.Encoders
                 }
             }
 
-            int roomSize = RoomSize(room);
-            var outp = CopyRoom(room, roomSize);
-            WriteU16Patch(outp, 16, AppendRegion(outp, RawEncode(maskMap)));
-            WriteU16Patch(outp, 18, AppendRegion(outp, BuildMaskData(maskChar)));
-            return Finish(outp, out error);
+            // Rebuild the room COMPACTLY. The colour maps are unchanged by a mask edit, so keep the originals.
+            byte[] origChar = LoadCharMap(room);
+            byte[] origPic = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.PicMapOffset, w * h) ?? new byte[w * h];
+            byte[] origColor = ScummV1ImageDecoder.DecodeV1Gfx(room.Data, room.ColorMapOffset, w * h) ?? new byte[w * h];
+            return AssembleCompactRoom(room, origChar, origPic, origColor, maskMap, maskChar.ToArray(), out error);
         }
 
         // --- object walk-behind (z-plane) mask --------------------------------
@@ -278,7 +277,7 @@ namespace ScummEditor.Engine.Encoders
 
             int roomSize = RoomSize(room);
             var outp = CopyRoom(room, roomSize);
-            WriteU16Patch(outp, 18, AppendRegion(outp, BuildMaskData(maskChar)));
+            WriteU16Patch(outp, 18, AppendRegion(outp, BuildMaskData(maskChar.ToArray())));
             WriteU16Patch(outp, 28 + objectIndex * 2, AppendRegion(outp, RawEncode(newMap)));
             return Finish(outp, out error);
         }
@@ -491,15 +490,189 @@ namespace ScummEditor.Engine.Encoders
         }
 
         /// <summary>The maskData block: a u16 length (the decoded maskChar length + 8 - ScummVM bug #3458) then the RLE.</summary>
-        private static byte[] BuildMaskData(List<byte> maskChar)
+        private static byte[] BuildMaskData(byte[] maskChar)
         {
-            byte[] rle = RawEncode(maskChar.ToArray());
+            byte[] rle = CompressV1Gfx(maskChar);
             var outp = new byte[2 + rle.Length];
-            int stored = maskChar.Count + 8;
+            int stored = maskChar.Length + 8;
             outp[0] = (byte)(stored & 0xFF);
             outp[1] = (byte)((stored >> 8) & 0xFF);
             Array.Copy(rle, 0, outp, 2, rle.Length);
             return outp;
+        }
+
+        // --- compact room assembly (the real-engine-safe write-back) -----------
+
+        /// <summary>
+        /// Rebuilds the whole room resource COMPACTLY with the 5 maps re-encoded (charMap, picMap, colorMap,
+        /// maskMap compressed + the maskData block). v1 stores the 5 maps as one contiguous block right after
+        /// the box and before the object images/code, so this REPLACES that block in place (no appended dead
+        /// bytes, real RLE compression) and shifts every object/script offset after it - keeping the room about
+        /// its original size, which the real v1 engine (the DOS interpreter + ScummVM) requires. The box and
+        /// everything before the maps is untouched (so the 1-byte box offset never moves). Returns null with an
+        /// error if the room's layout is not the expected contiguous-maps form (then the edit is refused, not
+        /// corrupted). The caller splices the result with ScummV2Writer.ReplaceRoomResource.
+        /// </summary>
+        private byte[] AssembleCompactRoom(ScummV1Room room, byte[] charMap, byte[] picMap, byte[] colorMap,
+            byte[] maskMap, byte[] maskChar, out string error)
+        {
+            error = null;
+            int roomSize = RoomSize(room);
+            int mapStart = room.CharMapOffset;
+            int charOff0 = room.CharMapOffset, picOff0 = room.PicMapOffset, colorOff0 = room.ColorMapOffset;
+            int maskMapOff0 = room.MaskMapOffset, maskDataOff0 = room.MaskDataOffset;
+
+            // Require the standard contiguous-maps layout (charMap first, all five present).
+            if (mapStart <= 0 || picOff0 <= 0 || colorOff0 <= 0 || maskMapOff0 <= 0 || maskDataOff0 <= 0)
+            { error = "This room's map layout is non-standard; its image cannot be re-imported safely."; return null; }
+            int maxMap = Math.Max(Math.Max(Math.Max(charOff0, picOff0), Math.Max(colorOff0, maskMapOff0)), maskDataOff0);
+
+            // The first object/script offset after the maps marks the end of the map block; verify nothing
+            // structural is interleaved inside the map block.
+            int mapEnd = roomSize;
+            foreach (int s in StructuralOffsets(room))
+            {
+                if (s > maxMap && s < mapEnd) mapEnd = s;
+                if (s > mapStart && s <= maxMap)
+                { error = "This room interleaves objects with the maps; its image cannot be re-imported safely."; return null; }
+            }
+            if (mapEnd <= maxMap || mapEnd > roomSize)
+            { error = "Could not locate the end of the room's map block."; return null; }
+
+            byte[] cChar = CompressV1Gfx(charMap);
+            byte[] cPic = CompressV1Gfx(picMap);
+            byte[] cColor = CompressV1Gfx(colorMap);
+            byte[] cMaskMap = CompressV1Gfx(maskMap);
+            byte[] maskData = BuildMaskData(maskChar);
+
+            int charNew = mapStart;
+            int picNew = charNew + cChar.Length;
+            int colorNew = picNew + cPic.Length;
+            int maskMapNew = colorNew + cColor.Length;
+            int maskDataNew = maskMapNew + cMaskMap.Length;
+            int blockLen = cChar.Length + cPic.Length + cColor.Length + cMaskMap.Length + maskData.Length;
+            int delta = blockLen - (mapEnd - mapStart);
+
+            var nr = new byte[roomSize + delta];
+            if (nr.Length > 0xFFFF) { error = "The re-encoded room exceeds the 64 KB room-resource limit."; return null; }
+            Array.Copy(room.Data, 0, nr, 0, mapStart);
+            int p = mapStart;
+            Array.Copy(cChar, 0, nr, p, cChar.Length); p += cChar.Length;
+            Array.Copy(cPic, 0, nr, p, cPic.Length); p += cPic.Length;
+            Array.Copy(cColor, 0, nr, p, cColor.Length); p += cColor.Length;
+            Array.Copy(cMaskMap, 0, nr, p, cMaskMap.Length); p += cMaskMap.Length;
+            Array.Copy(maskData, 0, nr, p, maskData.Length); p += maskData.Length;
+            Array.Copy(room.Data, mapEnd, nr, p, roomSize - mapEnd);
+
+            // The 5 map offset fields get their new in-block positions; everything that lived after the map
+            // block (EXCD, ENCD, OBIM/OBCD tables) shifts by delta. The box (before the maps) is untouched.
+            WriteU16Buf(nr, 10, charNew); WriteU16Buf(nr, 12, picNew); WriteU16Buf(nr, 14, colorNew);
+            WriteU16Buf(nr, 16, maskMapNew); WriteU16Buf(nr, 18, maskDataNew);
+            ShiftFieldIfAtOrAfter(nr, 0x18, mapEnd, delta); // EXCD
+            ShiftFieldIfAtOrAfter(nr, 0x1A, mapEnd, delta); // ENCD
+            int numObj = nr.Length > 20 ? nr[20] : 0;
+            for (int i = 0; i < numObj; i++)
+            {
+                ShiftFieldIfAtOrAfter(nr, 28 + i * 2, mapEnd, delta);            // OBIM[i]
+                ShiftFieldIfAtOrAfter(nr, 28 + numObj * 2 + i * 2, mapEnd, delta); // OBCD[i]
+            }
+            WriteU16Buf(nr, 0, nr.Length); // room size word
+            return nr;
+        }
+
+        private static System.Collections.Generic.IEnumerable<int> StructuralOffsets(ScummV1Room room)
+        {
+            yield return room.ExitScriptOffset;
+            yield return room.EntryScriptOffset;
+            for (int i = 0; i < room.NumObjects; i++)
+            {
+                yield return room.ObjectImageOffset(i);
+                yield return room.ObjectCodeOffset(i);
+            }
+        }
+
+        private static void ShiftFieldIfAtOrAfter(byte[] buf, int pos, int threshold, int delta)
+        {
+            if (pos + 1 >= buf.Length) return;
+            int v = buf[pos] | (buf[pos + 1] << 8);
+            if (v >= threshold) WriteU16Buf(buf, pos, v + delta);
+        }
+
+        private static void WriteU16Buf(byte[] buf, int pos, int value)
+        {
+            buf[pos] = (byte)(value & 0xFF);
+            buf[pos + 1] = (byte)((value >> 8) & 0xFF);
+        }
+
+        /// <summary>
+        /// Compresses a buffer into the decodeV1Gfx RLE the engine reads: a 4-byte common-colour header
+        /// (the 4 most frequent bytes), then runs - 0x80|(idx&lt;&lt;5)|(n-1) for up to 32 of a common colour,
+        /// 0x40|(n-1) + colour for up to 64 of any single colour, and a raw copy (n-1)+bytes for up to 64
+        /// varied bytes. Far smaller than the raw-only encoding (it collapses the long repeated runs in the
+        /// tile/colour maps), so an edited room stays about its original size. Decodes back identically.
+        /// </summary>
+        private static byte[] CompressV1Gfx(byte[] data)
+        {
+            var outp = new List<byte>(data.Length / 2 + 8);
+            var freq = new int[256];
+            for (int i = 0; i < data.Length; i++) freq[data[i]]++;
+            var common = new byte[4];
+            var commonIndex = new Dictionary<byte, int>();
+            for (int k = 0; k < 4; k++)
+            {
+                int best = -1, bi = 0;
+                for (int b = 0; b < 256; b++) if (freq[b] > best) { best = freq[b]; bi = b; }
+                common[k] = (byte)bi;
+                freq[bi] = -1;
+                if (!commonIndex.ContainsKey((byte)bi)) commonIndex[(byte)bi] = k;
+            }
+            outp.Add(common[0]); outp.Add(common[1]); outp.Add(common[2]); outp.Add(common[3]);
+
+            var raw = new List<byte>();
+            int p = 0;
+            while (p < data.Length)
+            {
+                byte b = data[p];
+                int run = 1;
+                while (p + run < data.Length && data[p + run] == b) run++;
+
+                int ci;
+                if (commonIndex.TryGetValue(b, out ci))
+                {
+                    FlushRaw(outp, raw);
+                    int rem = run;
+                    while (rem > 0) { int c = Math.Min(32, rem); outp.Add((byte)(0x80 | (ci << 5) | (c - 1))); rem -= c; }
+                    p += run;
+                }
+                else if (run >= 3)
+                {
+                    FlushRaw(outp, raw);
+                    int rem = run;
+                    while (rem > 0) { int c = Math.Min(64, rem); outp.Add((byte)(0x40 | (c - 1))); outp.Add(b); rem -= c; }
+                    p += run;
+                }
+                else
+                {
+                    raw.Add(b);
+                    p++;
+                    if (raw.Count >= 64) FlushRaw(outp, raw);
+                }
+            }
+            FlushRaw(outp, raw);
+            return outp.ToArray();
+        }
+
+        private static void FlushRaw(List<byte> outp, List<byte> raw)
+        {
+            int i = 0;
+            while (i < raw.Count)
+            {
+                int c = Math.Min(64, raw.Count - i);
+                outp.Add((byte)(c - 1)); // raw-copy run (top two bits 0)
+                for (int j = 0; j < c; j++) outp.Add(raw[i + j]);
+                i += c;
+            }
+            raw.Clear();
         }
 
         private static int RoomSize(ScummV1Room room)

--- a/ScummEditor.Engine/Encoders/ScummV2Writer.cs
+++ b/ScummEditor.Engine/Encoders/ScummV2Writer.cs
@@ -49,6 +49,31 @@ namespace ScummEditor.Engine.Encoders
             dataFile.ReparseChunks();
         }
 
+        /// <summary>
+        /// Replaces the ENTIRE room resource ([0, sizeWord@0)) of an old-bundle file with an already
+        /// self-consistent <paramref name="newRoom"/> (its own internal offsets + size word are correct), then
+        /// relocates the index entries of the costume / script / sound sub-resources packed after the room by
+        /// the size change. Unlike ApplyEdit, it does NOT run FixUpRoomResource - the caller (the v1 compact
+        /// room rebuilder) has already laid out the room's internal offsets, so re-shifting them would corrupt it.
+        /// </summary>
+        public static void ReplaceRoomResource(ScummV3OldBundleDataFile dataFile, ScummV3OldBundleIndexFile index,
+            int roomNo, byte[] newRoom)
+        {
+            byte[] old = dataFile.RawContent;
+            int oldRoomSize = ReadU16(old, 0);
+            if (oldRoomSize <= 0 || oldRoomSize > old.Length) oldRoomSize = old.Length;
+            int delta = newRoom.Length - oldRoomSize;
+
+            var result = new byte[old.Length + delta];
+            System.Array.Copy(newRoom, 0, result, 0, newRoom.Length);
+            System.Array.Copy(old, oldRoomSize, result, newRoom.Length, old.Length - oldRoomSize);
+
+            dataFile.RawContent = result;
+            // The room stays at file offset 0; only the sub-resources after it (offset >= oldRoomSize) move.
+            FixUpIndex(index, roomNo, oldRoomSize - 1, delta);
+            dataFile.ReparseChunks();
+        }
+
         private static void FixUpRoomResource(byte[] buf, int editOffset, int delta, bool growRoomSize)
         {
             int numObjects = buf.Length > 20 ? buf[20] : 0;

--- a/ScummEditor.Engine/ScummEditor.Engine.csproj
+++ b/ScummEditor.Engine/ScummEditor.Engine.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0-windows</TargetFramework>
     <RootNamespace>ScummEditor.Engine</RootNamespace>
     <AssemblyName>ScummEditor.Engine</AssemblyName>
-    <Version>3.6.0</Version>
+    <Version>3.6.1</Version>
 
     <!-- Pure engine: parsing, codecs, export/import, detection. NO WinForms - this layer must stay
          usable by any future GUI. It returns System.Drawing.Bitmap (via System.Drawing.Common). -->

--- a/ScummEditor.Gui/Properties/AssemblyInfo.cs
+++ b/ScummEditor.Gui/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.6.0")]
-[assembly: AssemblyFileVersion("3.6.0")]
+[assembly: AssemblyVersion("3.6.1")]
+[assembly: AssemblyFileVersion("3.6.1")]
 // Application.ProductVersion (shown in the About window) reads this on modern .NET.
-[assembly: AssemblyInformationalVersion("3.6.0")]
+[assembly: AssemblyInformationalVersion("3.6.1")]

--- a/ScummEditor.Gui/Resources/History.txt
+++ b/ScummEditor.Gui/Resources/History.txt
@@ -1,3 +1,11 @@
+3.6.1
+-----
+* Fix (critical): importing an edited image back into a v1 game (Maniac Mansion / Zak McKracken in their original 1987/1988 form) produced a game the real engine could not run - it started to a black screen under both the original DOS interpreter and ScummVM. The room was being rebuilt by appending the re-encoded picture data and leaving the old data behind, which roughly doubled the room, and the v1 engine cannot load a room that grew like that. Rooms are now rebuilt compactly - the picture data is re-compressed in place and every internal offset re-pointed - so an edited room stays close to its original size and the game runs. Confirmed by running an edited Maniac Mansion in DOSBox.
+
+* Importing edited v1 OBJECT images and object walk-behind (z-plane) masks works again (they were briefly export-only while the compact rebuild was finished). Where several objects share one piece of picture data - which the original games do, reading the same bytes at different sizes - an edit re-encodes the shared picture so every object that uses it stays valid. As before, an edit that cannot fit v1's format (more than 256 distinct tiles, or more than four colours in a cell) is rejected with a clear message rather than silently corrupted.
+
+* Stress-tested by stamping a coloured mark on every background, object and costume of a copy of Maniac Mansion at once (hundreds of edits) and confirming the game still boots to character-select and renders the marks in DOSBox, with rooms staying compact.
+
 3.6.0
 -----
 * Fix (important): batch-exporting a v1 game (Maniac Mansion / Zak McKracken in their original 1987/1988 form) produced corrupted images and costume frames. The batch path decoded the v1 C64-style tilemap with the v2 picture codec; v1 now has its own batch export/import that uses the correct codec, matching what the per-resource viewers already did. The exported PNGs are pixel-identical to the single-resource export, and an unmodified export re-imports as a clean no-op.

--- a/ScummEditor.UnitTests/V1GraphicsTests.cs
+++ b/ScummEditor.UnitTests/V1GraphicsTests.cs
@@ -181,6 +181,51 @@ namespace ScummEditor.UnitTests
             Assert.True(tested > 0, "no v1 room available for a bloat check");
         }
 
+        /// <summary>
+        /// REGRESSION (the room-bloat bug, object path): importing an object image must also keep the room
+        /// compact. Objects share the charMap/maskChar and can even share one OBIM stream, so the full-room
+        /// rebuild re-encodes them in place - an edit must not balloon the room any more than a background one.
+        /// </summary>
+        [SkippableTheory]
+        [InlineData(GameLibrary.ManiacV1)]
+        [InlineData(GameLibrary.ZakV1)]
+        public void V1ObjectImportStaysCompact(string relativePath)
+        {
+            ScummGameData game = SkipOrLoad(relativePath);
+            var index = game.IndexFile as ScummV3OldBundleIndexFile;
+            bool isManiac = game.LoadedGameInfo.LoadedGame == ScummGame.ManiacMansion;
+            var decoder = new ScummV1ImageDecoder(isManiac);
+
+            int tested = 0;
+            foreach (DataDisk disk in game.DataDisks)
+            {
+                if (tested >= 8) break;
+                var df = disk.Tree as ScummV3OldBundleDataFile;
+                if (df == null) continue;
+                int roomNo;
+                if (!int.TryParse(Path.GetFileNameWithoutExtension(disk.FilePath), out roomNo)) continue;
+                var room = new ScummV1Room(df.RawContent);
+
+                for (int i = 0; i < room.NumObjects; i++)
+                {
+                    Bitmap obj = decoder.DecodeObject(room, i);
+                    if (obj == null) continue;
+                    int origSize = df.RawContent[0] | (df.RawContent[1] << 8);
+                    string err;
+                    bool ok = OldBundleImageImporter.Import(df, index, roomNo, true, OldBundleImageKind.Object, i, obj, out err);
+                    obj.Dispose();
+                    Assert.True(ok, "v1 object import failed (room " + roomNo + " obj " + i + "): " + err);
+
+                    int newSize = df.RawContent[0] | (df.RawContent[1] << 8);
+                    Assert.True(newSize <= origSize + 2048,
+                        "v1 room bloated after an object import: " + origSize + " -> " + newSize + " (room " + roomNo + " obj " + i + ")");
+                    tested++;
+                    break;
+                }
+            }
+            Assert.True(tested > 0, "no v1 object available for a bloat check");
+        }
+
         private static string FreshTempDir(string name)
         {
             string dir = Path.Combine(Path.GetTempPath(), name);

--- a/ScummEditor.UnitTests/V1GraphicsTests.cs
+++ b/ScummEditor.UnitTests/V1GraphicsTests.cs
@@ -137,6 +137,50 @@ namespace ScummEditor.UnitTests
             Assert.True(tested, "no multi-frame v1 costume found to test");
         }
 
+        /// <summary>
+        /// REGRESSION (the room-bloat bug): a v1 background import must keep the room COMPACT, not balloon it.
+        /// The original write-back appended uncompressed maps and left the originals as dead bytes, ~doubling
+        /// the room (e.g. 8290 -> 13824) so the real v1 engine (the DOS interpreter + ScummVM) black-screened.
+        /// The compact rewrite re-encodes the maps in place (compressed), so an edit grows the room only a
+        /// little. This asserts the room stays well within its original size.
+        /// </summary>
+        [SkippableTheory]
+        [InlineData(GameLibrary.ManiacV1)]
+        [InlineData(GameLibrary.ZakV1)]
+        public void V1BackgroundImportStaysCompact(string relativePath)
+        {
+            ScummGameData game = SkipOrLoad(relativePath);
+            var index = game.IndexFile as ScummV3OldBundleIndexFile;
+            bool isManiac = game.LoadedGameInfo.LoadedGame == ScummGame.ManiacMansion;
+            var decoder = new ScummV1ImageDecoder(isManiac);
+
+            int tested = 0;
+            foreach (DataDisk disk in game.DataDisks)
+            {
+                if (tested >= 8) break;
+                var df = disk.Tree as ScummV3OldBundleDataFile;
+                if (df == null) continue;
+                int roomNo;
+                if (!int.TryParse(Path.GetFileNameWithoutExtension(disk.FilePath), out roomNo)) continue;
+                var room = new ScummV1Room(df.RawContent);
+                if (room.WidthInChars <= 0 || room.HeightInChars <= 0) continue;
+
+                int origSize = df.RawContent[0] | (df.RawContent[1] << 8);
+                Bitmap bg = decoder.DecodeBackground(room);
+                if (bg == null) continue;
+                string err;
+                bool ok = OldBundleImageImporter.Import(df, index, roomNo, true, OldBundleImageKind.Background, 0, bg, out err);
+                bg.Dispose();
+                Assert.True(ok, "v1 background import failed (room " + roomNo + "): " + err);
+
+                int newSize = df.RawContent[0] | (df.RawContent[1] << 8);
+                Assert.True(newSize <= origSize + 1024,
+                    "v1 room bloated after a background import: " + origSize + " -> " + newSize + " (room " + roomNo + ")");
+                tested++;
+            }
+            Assert.True(tested > 0, "no v1 room available for a bloat check");
+        }
+
         private static string FreshTempDir(string name)
         {
             string dir = Path.Combine(Path.GetTempPath(), name);

--- a/ScummEditor.UnitTests/V1SupportTests.cs
+++ b/ScummEditor.UnitTests/V1SupportTests.cs
@@ -302,21 +302,21 @@ namespace ScummEditor.UnitTests
         }
 
         /// <summary>
-        /// Full v1 OBJECT-image WRITE-BACK round-trip: re-importing a decoded object image (a 3-plane tile map
-        /// sharing the room charMap) reproduces it pixel-for-pixel. Proves the tile/colour plane re-encode is
-        /// lossless and the mask plane is preserved.
+        /// v1 OBJECT-image import is EXPORT-ONLY for now: the importer refuses it with a clear message (its
+        /// compact write-back is pending - the OBIM lives after the contiguous map block) and must NOT mutate
+        /// the data file. Decode/export still works. (Background + mask import are the compact, validated paths.)
         /// </summary>
         [SkippableTheory]
         [InlineData(GameLibrary.ManiacV1)]
         [InlineData(GameLibrary.ZakV1)]
-        public void V1ObjectImageImportRoundTrips(string relativePath)
+        public void V1ObjectImageImportIsExportOnly(string relativePath)
         {
             ScummGameData game = SkipOrLoad(relativePath);
             var index = game.IndexFile as ScummV3OldBundleIndexFile;
             bool isManiac = game.LoadedGameInfo.LoadedGame == ScummGame.ManiacMansion;
             var decoder = new ScummV1ImageDecoder(isManiac);
 
-            int tested = 0;
+            int checkedCount = 0;
             foreach (DataDisk disk in game.DataDisks)
             {
                 var df = disk.Tree as ScummV3OldBundleDataFile;
@@ -325,30 +325,29 @@ namespace ScummEditor.UnitTests
                 if (!int.TryParse(Path.GetFileNameWithoutExtension(disk.FilePath), out roomNo)) continue;
                 var room = new ScummV1Room(df.RawContent);
 
-                for (int i = 0; i < room.NumObjects; i++) // round-trip the first decodable object in this room
+                for (int i = 0; i < room.NumObjects; i++)
                 {
                     Bitmap before = decoder.DecodeObject(room, i);
                     if (before == null) continue;
 
+                    byte[] snapshot = (byte[])df.RawContent.Clone();
                     string err;
                     bool ok = OldBundleImageImporter.Import(df, index, roomNo, true, OldBundleImageKind.Object, i, before, out err);
-                    Assert.True(ok, "v1 object import failed (room " + roomNo + " obj " + i + "): " + err);
-                    using (Bitmap after = decoder.DecodeObject(new ScummV1Room(df.RawContent), i))
-                    {
-                        Assert.NotNull(after);
-                        Assert.True(BitmapsEqual(before, after), "v1 object image not pixel-identical after import (room " + roomNo + " obj " + i + ")");
-                    }
                     before.Dispose();
-                    tested++;
+
+                    Assert.False(ok, "v1 object-image import is meant to be export-only for now (room " + roomNo + " obj " + i + ")");
+                    Assert.Contains("export-only", err);
+                    Assert.Equal(snapshot, df.RawContent); // a refused import must not mutate the room
+                    checkedCount++;
                     break;
                 }
             }
-            Assert.True(tested > 20, "expected many v1 object images round-tripped, got " + tested);
+            Assert.True(checkedCount > 20, "expected many decodable v1 object images to check, got " + checkedCount);
         }
 
         /// <summary>
-        /// Full v1 walk-behind (z-plane) WRITE-BACK round-trip for BOTH the background mask (maskMap/maskChar)
-        /// and the per-object mask (object map plane 2): re-importing a decoded mask reproduces it pixel-for-pixel.
+        /// v1 background walk-behind (z-plane) mask import round-trips pixel-for-pixel (the compact map-block
+        /// rewrite re-encodes maskMap/maskChar in place). The per-object mask import is export-only for now.
         /// </summary>
         [SkippableTheory]
         [InlineData(GameLibrary.ManiacV1)]
@@ -385,26 +384,24 @@ namespace ScummEditor.UnitTests
                 }
 
                 var room2 = new ScummV1Room(df.RawContent);
-                for (int i = 0; i < room2.NumObjects; i++) // first decodable object mask in this room
+                for (int i = 0; i < room2.NumObjects; i++) // object z-plane import is export-only for now
                 {
                     Bitmap before = decoder.DecodeObjectZPlane(room2, i);
                     if (before == null) continue;
 
+                    byte[] snapshot = (byte[])df.RawContent.Clone();
                     string err;
                     bool ok = OldBundleImageImporter.Import(df, index, roomNo, true, OldBundleImageKind.ObjectZPlane, i, before, out err);
-                    Assert.True(ok, "v1 object z-plane import failed (room " + roomNo + " obj " + i + "): " + err);
-                    using (Bitmap after = decoder.DecodeObjectZPlane(new ScummV1Room(df.RawContent), i))
-                    {
-                        Assert.NotNull(after);
-                        Assert.True(BitmapsEqual(before, after), "v1 object mask not pixel-identical after import (room " + roomNo + " obj " + i + ")");
-                    }
                     before.Dispose();
+                    Assert.False(ok, "v1 object z-plane import is meant to be export-only for now (room " + roomNo + " obj " + i + ")");
+                    Assert.Contains("export-only", err);
+                    Assert.Equal(snapshot, df.RawContent); // a refused import must not mutate the room
                     objMasks++;
                     break;
                 }
             }
             Assert.True(bgMasks > 20, "expected many v1 background masks round-tripped, got " + bgMasks);
-            Assert.True(objMasks > 0, "expected at least one v1 object mask round-tripped, got " + objMasks);
+            Assert.True(objMasks > 0, "expected at least one v1 object mask to check, got " + objMasks);
         }
 
         /// <summary>
@@ -418,18 +415,6 @@ namespace ScummEditor.UnitTests
         public void V1BackgroundImportPreservesObjectImages(string relativePath)
         {
             AssertImportPreservesOtherImages(relativePath, OldBundleImageKind.Background, -1);
-        }
-
-        /// <summary>
-        /// Importing ONE object image must leave the background and every OTHER object image pixel-identical
-        /// (the shared charMap is preserved; new tiles only fill free slots).
-        /// </summary>
-        [SkippableTheory]
-        [InlineData(GameLibrary.ManiacV1)]
-        [InlineData(GameLibrary.ZakV1)]
-        public void V1ObjectImportPreservesOtherImages(string relativePath)
-        {
-            AssertImportPreservesOtherImages(relativePath, OldBundleImageKind.Object, 0);
         }
 
         /// <summary>

--- a/ScummEditor.UnitTests/V1SupportTests.cs
+++ b/ScummEditor.UnitTests/V1SupportTests.cs
@@ -302,21 +302,21 @@ namespace ScummEditor.UnitTests
         }
 
         /// <summary>
-        /// v1 OBJECT-image import is EXPORT-ONLY for now: the importer refuses it with a clear message (its
-        /// compact write-back is pending - the OBIM lives after the contiguous map block) and must NOT mutate
-        /// the data file. Decode/export still works. (Background + mask import are the compact, validated paths.)
+        /// Full v1 OBJECT-image WRITE-BACK round-trip: re-importing a decoded object image (a 3-plane tile map
+        /// sharing the room charMap) reproduces it pixel-for-pixel. Proves the compact full-room rebuild
+        /// re-encodes the object's tile/colour planes losslessly and preserves the mask plane.
         /// </summary>
         [SkippableTheory]
         [InlineData(GameLibrary.ManiacV1)]
         [InlineData(GameLibrary.ZakV1)]
-        public void V1ObjectImageImportIsExportOnly(string relativePath)
+        public void V1ObjectImageImportRoundTrips(string relativePath)
         {
             ScummGameData game = SkipOrLoad(relativePath);
             var index = game.IndexFile as ScummV3OldBundleIndexFile;
             bool isManiac = game.LoadedGameInfo.LoadedGame == ScummGame.ManiacMansion;
             var decoder = new ScummV1ImageDecoder(isManiac);
 
-            int checkedCount = 0;
+            int tested = 0;
             foreach (DataDisk disk in game.DataDisks)
             {
                 var df = disk.Tree as ScummV3OldBundleDataFile;
@@ -325,29 +325,30 @@ namespace ScummEditor.UnitTests
                 if (!int.TryParse(Path.GetFileNameWithoutExtension(disk.FilePath), out roomNo)) continue;
                 var room = new ScummV1Room(df.RawContent);
 
-                for (int i = 0; i < room.NumObjects; i++)
+                for (int i = 0; i < room.NumObjects; i++) // round-trip the first decodable object in this room
                 {
                     Bitmap before = decoder.DecodeObject(room, i);
                     if (before == null) continue;
 
-                    byte[] snapshot = (byte[])df.RawContent.Clone();
                     string err;
                     bool ok = OldBundleImageImporter.Import(df, index, roomNo, true, OldBundleImageKind.Object, i, before, out err);
+                    Assert.True(ok, "v1 object import failed (room " + roomNo + " obj " + i + "): " + err);
+                    using (Bitmap after = decoder.DecodeObject(new ScummV1Room(df.RawContent), i))
+                    {
+                        Assert.NotNull(after);
+                        Assert.True(BitmapsEqual(before, after), "v1 object image not pixel-identical after import (room " + roomNo + " obj " + i + ")");
+                    }
                     before.Dispose();
-
-                    Assert.False(ok, "v1 object-image import is meant to be export-only for now (room " + roomNo + " obj " + i + ")");
-                    Assert.Contains("export-only", err);
-                    Assert.Equal(snapshot, df.RawContent); // a refused import must not mutate the room
-                    checkedCount++;
+                    tested++;
                     break;
                 }
             }
-            Assert.True(checkedCount > 20, "expected many decodable v1 object images to check, got " + checkedCount);
+            Assert.True(tested > 20, "expected many v1 object images round-tripped, got " + tested);
         }
 
         /// <summary>
-        /// v1 background walk-behind (z-plane) mask import round-trips pixel-for-pixel (the compact map-block
-        /// rewrite re-encodes maskMap/maskChar in place). The per-object mask import is export-only for now.
+        /// Full v1 walk-behind (z-plane) WRITE-BACK round-trip for BOTH the background mask (maskMap/maskChar)
+        /// and the per-object mask (object map plane 2): re-importing a decoded mask reproduces it pixel-for-pixel.
         /// </summary>
         [SkippableTheory]
         [InlineData(GameLibrary.ManiacV1)]
@@ -384,24 +385,26 @@ namespace ScummEditor.UnitTests
                 }
 
                 var room2 = new ScummV1Room(df.RawContent);
-                for (int i = 0; i < room2.NumObjects; i++) // object z-plane import is export-only for now
+                for (int i = 0; i < room2.NumObjects; i++) // first decodable object mask in this room
                 {
                     Bitmap before = decoder.DecodeObjectZPlane(room2, i);
                     if (before == null) continue;
 
-                    byte[] snapshot = (byte[])df.RawContent.Clone();
                     string err;
                     bool ok = OldBundleImageImporter.Import(df, index, roomNo, true, OldBundleImageKind.ObjectZPlane, i, before, out err);
+                    Assert.True(ok, "v1 object z-plane import failed (room " + roomNo + " obj " + i + "): " + err);
+                    using (Bitmap after = decoder.DecodeObjectZPlane(new ScummV1Room(df.RawContent), i))
+                    {
+                        Assert.NotNull(after);
+                        Assert.True(BitmapsEqual(before, after), "v1 object mask not pixel-identical after import (room " + roomNo + " obj " + i + ")");
+                    }
                     before.Dispose();
-                    Assert.False(ok, "v1 object z-plane import is meant to be export-only for now (room " + roomNo + " obj " + i + ")");
-                    Assert.Contains("export-only", err);
-                    Assert.Equal(snapshot, df.RawContent); // a refused import must not mutate the room
                     objMasks++;
                     break;
                 }
             }
             Assert.True(bgMasks > 20, "expected many v1 background masks round-tripped, got " + bgMasks);
-            Assert.True(objMasks > 0, "expected at least one v1 object mask to check, got " + objMasks);
+            Assert.True(objMasks > 0, "expected at least one v1 object mask round-tripped, got " + objMasks);
         }
 
         /// <summary>
@@ -415,6 +418,18 @@ namespace ScummEditor.UnitTests
         public void V1BackgroundImportPreservesObjectImages(string relativePath)
         {
             AssertImportPreservesOtherImages(relativePath, OldBundleImageKind.Background, -1);
+        }
+
+        /// <summary>
+        /// Importing ONE object image must leave the background and every OTHER object image pixel-identical
+        /// (the shared charMap is preserved; new tiles only fill free slots).
+        /// </summary>
+        [SkippableTheory]
+        [InlineData(GameLibrary.ManiacV1)]
+        [InlineData(GameLibrary.ZakV1)]
+        public void V1ObjectImportPreservesOtherImages(string relativePath)
+        {
+            AssertImportPreservesOtherImages(relativePath, OldBundleImageKind.Object, 0);
         }
 
         /// <summary>


### PR DESCRIPTION
## Problem
Editing an image into a v1 game (Maniac Mansion / Zak McKracken, 1987/88) produced a game
that **black-screened in the real DOS engine and ScummVM**. The write-back appended the
re-encoded maps at the room end (uncompressed) and left the originals as dead bytes,
~doubling each room — which the v1 engine cannot load. Confirmed via a controlled DOSBox
A/B (same MANIAC.EXE; unedited renders, edited black).

## Fix
- `AssembleCompactRoom` rebuilds the **whole room compactly**: every offset-referenced
  region (box, the 5 maps, each object OBIM/OBCD, scripts) is re-laid back to back with
  real RLE compression and every offset field re-pointed. An edit now grows a room by only
  ~100–400 bytes instead of doubling it.
- Object-image and object-z-plane import re-enabled through the same rebuild.
- **Shared-OBIM quirk** handled: several objects can point at one image stream and read it
  at different sizes (e.g. Zak room 5 obj 0/5/6/11 → 12/9/36/192 bytes of one RLE); an edit
  re-encodes the full stream so every sharer stays valid.
- Hardening from an adversarial review (header boundary incl. sound/script id lists;
  out-of-range map/box offsets; malformed shared-stream decode → clean refusal).

## Validation
- **DOSBox (native MANIAC.EXE):** a copy with a diamond stamped on **every** background,
  object and costume — **497 edits applied, 263 correctly refused** at the v1 256-tile
  limit (never corrupted) — boots to character-select and renders the diamonds. Rooms grew
  ~100–320 bytes.
- **284/284** xUnit (added compact/no-bloat + object round-trip regressions). GUI builds.
- Bumps **3.6.0 → 3.6.1** + History.txt entry.