### PR TITLE
Fix v5/v6 editor re-open overflow (gate the MI2 "021_" kludge to talkie games)

### DIFF
--- a/ScummEditor.Engine/Structures/DataFile/NotImplementedDataBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/NotImplementedDataBlock.cs
@@ -39,10 +39,17 @@ namespace ScummEditor.Engine.Structures.DataFile
         public override void LoadFromBinaryReader(System.IO.Stream binaryReader)
         {
             base.LoadFromBinaryReader(binaryReader);
-            Contents = binaryReader.ReadBytes((int)(BlockSize - HeaderLength));
+            int bodyLen = (int)(BlockSize - HeaderLength);
+            if (bodyLen < 0) bodyLen = 0; // a corrupt/misaligned size must not throw OverflowException on new byte[neg]
+            Contents = binaryReader.ReadBytes(bodyLen);
 
-            //Hack for the Monkey Island 2 talkie edition (v5/v6 only).
-            if (!IsSmallHeader && BinaryHelper.ConvertByteArrayToUTF8String(binaryReader.PeekBytes(4)) == "021_")
+            // Hack for the "021_" stray block the Monkey Island 2 ULTIMATE TALKIE packer leaves behind (8
+            // orphan bytes after a generic block). Gate it to talkie games: a non-talkie game (e.g. MI2
+            // Floppy) never carries that stray, and content-sniffing "021_" on EVERY generic block made an
+            // edited floppy game's shifted bytes false-match here, absorb 8 bytes, desync the block stream
+            // and overflow when the editor RE-OPENED its own (otherwise valid) output. (v5/v6 only.)
+            if (!IsSmallHeader && _gameInfo != null && _gameInfo.IsTalkie
+                && BinaryHelper.ConvertByteArrayToUTF8String(binaryReader.PeekBytes(4)) == "021_")
             {
                 var lstBytes = new List<byte>(Contents);
                 lstBytes.AddRange(binaryReader.ReadBytes(8));

--- a/ScummEditor.UnitTests/V5ReopenTests.cs
+++ b/ScummEditor.UnitTests/V5ReopenTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Drawing;
+using System.IO;
+using ScummEditor.Engine;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// Regression for the v5/v6 editor RE-OPEN overflow: editing many images of a NON-talkie v5 game (MI2
+    /// Floppy) used to produce a save the editor could not re-open - the "021_" stray-block kludge in
+    /// NotImplementedDataBlock content-sniffed "021_" on every generic block, so the edit's shifted bytes
+    /// false-matched, absorbed 8 bytes, desynced the block stream and overflowed on reload. The kludge is now
+    /// gated to talkie games (only the Ultimate Talkie packer leaves that stray), so a floppy game re-opens,
+    /// and the genuine Ultimate Talkie edition still loads (the kludge stays active for it).
+    /// </summary>
+    public class V5ReopenTests
+    {
+        private const string MI2UltimateTalkie = "ScummV5/Monkey Island 2 - LeChucks Revenge (1991)/Ultimate Talkie Edition";
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.MonkeyIsland2Floppy)]
+        public void V5GraphicsEditReopensWithoutOverflow(string relativePath)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "GameData folder not present: " + relativePath);
+            string dst = Path.Combine(Path.GetTempPath(), "v5_reopen_test");
+            CopyTree(GameLibrary.Folder(relativePath), dst);
+
+            ScummGameData game = ScummGameData.LoadFromGameInfo(Functions.FindScummGameInFolder(dst));
+            Assert.NotNull(game);
+
+            string png = Path.Combine(dst, "_png");
+            Directory.CreateDirectory(png);
+            var opt = new ScummV5V6GraphicsBatch.ExportOptions
+            { Backgrounds = true, Objects = true, Costumes = true, BackgroundZPlanes = false, ObjectZPlanes = false };
+            ScummV5V6GraphicsBatch.Export(game.DataFile, png, opt, null, null);
+            foreach (string f in Directory.GetFiles(png, "*.png")) StampDiamond(f);
+            ScummV5V6GraphicsBatch.Import(game.DataFile, png, null);
+            game.SaveDataToDisk();
+
+            // The editor must be able to RE-OPEN its own (valid) output. This used to throw OverflowException.
+            Exception thrown = Record.Exception(() => ScummGameData.LoadFromGameInfo(Functions.FindScummGameInFolder(dst)));
+            Assert.True(thrown == null, "re-opening the graphics-edited copy threw: " + thrown);
+
+            try { Directory.Delete(dst, true); } catch { }
+        }
+
+        [SkippableFact]
+        public void MI2UltimateTalkieStillLoads()
+        {
+            Skip.If(GameLibrary.Folder(MI2UltimateTalkie) == null, "MI2 Ultimate Talkie not present");
+            // The genuine case the "021_" kludge exists for: it is a talkie repack, so IsTalkie must be true
+            // (that is what keeps the kludge active after gating it). It must load without throwing.
+            ScummGameData game = GameLibrary.Load(MI2UltimateTalkie);
+            Assert.NotNull(game);
+            Assert.True(game.LoadedGameInfo != null && game.LoadedGameInfo.IsTalkie,
+                "MI2 Ultimate Talkie should be detected as a talkie (keeps the 021_ kludge active)");
+        }
+
+        private static void StampDiamond(string file)
+        {
+            Color[] pal; byte[,] m;
+            using (var bmp = (Bitmap)Image.FromFile(file))
+            {
+                if (!IndexedImageHelper.IsIndexed(bmp)) return;
+                pal = bmp.Palette.Entries;
+                m = IndexedImageHelper.GetIndexMatrix(bmp);
+            }
+            int w = m.GetLength(0), h = m.GetLength(1), cx = w / 2, cy = h / 2, r = Math.Max(1, Math.Min(w, h) / 3), bright = 0, best = -1;
+            for (int i = 0; i < pal.Length; i++) { int b = pal[i].R + pal[i].G + pal[i].B; if (b > best) { best = b; bright = i; } }
+            for (int x = 0; x < w; x++) for (int y = 0; y < h; y++) if (Math.Abs(x - cx) + Math.Abs(y - cy) <= r) m[x, y] = (byte)bright;
+            using (Bitmap ed = IndexedImageHelper.FromIndexMatrix(m, pal, -1)) ed.Save(file, System.Drawing.Imaging.ImageFormat.Png);
+        }
+
+        private static void CopyTree(string src, string dst)
+        {
+            if (Directory.Exists(dst)) Directory.Delete(dst, true);
+            Directory.CreateDirectory(dst);
+            foreach (string f in Directory.GetFiles(src, "*", SearchOption.AllDirectories))
+            { string t = f.Replace(src, dst); Directory.CreateDirectory(Path.GetDirectoryName(t)); File.Copy(f, t, true); }
+        }
+    }
+}


### PR DESCRIPTION
## Fix
Editing many images of a NON-talkie v5 game (e.g. Monkey Island 2 Floppy) produced a save the
editor could not **re-open** — it threw `OverflowException` (a block size read back negative).
The save itself is valid (ScummVM and DOSBox run it); only our own reader choked on reopening.

Cause: `NotImplementedDataBlock` content-sniffed `"021_"` (a stray block the MI2 **Ultimate
Talkie** packer leaves behind) after *every* generic block; an edit's shifted bytes false-matched,
absorbed 8 bytes, desynced the block stream, and overflowed downstream. Verified by walking the
saved IFF tree — it is structurally valid; the desync was purely this reader kludge.

Fix: gate the kludge to talkie games (`IsTalkie`) — only the Ultimate Talkie repack carries that
stray; a floppy game never does — and clamp the body length so a misaligned size can never throw
`OverflowException`. The genuine Ultimate Talkie still loads (kludge stays active for it).

## Tests
`V5ReopenTests`: a v5 graphics edit (MI2 Floppy, every background/object/costume) now re-opens
without throwing; MI2 Ultimate Talkie still loads and is detected as a talkie. **286/286 xUnit.**

## Note (no code change)
This branch also covers the v3old/ScummVM investigation: editing a v3old object's verb code so its
OBCD grows ≥4 bytes crashes **ScummVM** but runs fine in **DOSBox** (the original interpreter) — our
write-back output is byte-correct by every measure, so it's a ScummVM-side bug with no fix on our
side. Documented for an upstream report.