### PR TITLE
SCUMM v7 support (The Dig, Full Throttle) - v4.0.0

### DIFF
--- a/ScummEditor.Engine/Encoders/AkosImageDecoder.cs
+++ b/ScummEditor.Engine/Encoders/AkosImageDecoder.cs
@@ -23,18 +23,52 @@ namespace ScummEditor.Engine.Encoders
             return akhd != null && akhd.Length >= 8 ? ReadUInt16(akhd, 6) : 0;
         }
 
-        /// <summary>The cel compression codec from AKHD (1 = BYLE RLE, 5 = CDAT/BOMP).</summary>
+        /// <summary>The cel compression codec from AKHD (1 = BYLE RLE, 5 = CDAT/BOMP, 16 = MAJMIN).</summary>
         public static int GetCodec(BlockBase akos)
         {
             byte[] akhd = GetSubBlock(akos, "AKHD");
             return akhd != null && akhd.Length >= 10 ? ReadUInt16(akhd, 8) : 0;
         }
 
-        /// <summary>
-        /// Decodes cel <paramref name="celIndex"/> to an indexed bitmap using the costume's own RGB
-        /// palette (RGBS). Returns null for an empty/zero-size cel or an unsupported codec.
-        /// </summary>
+        /// <summary>The cel colour count = AKPL size (16/32/64 for codec 1; drives the BYLE-RLE bit split).</summary>
+        public static int GetColorCount(BlockBase akos)
+        {
+            byte[] akpl = GetSubBlock(akos, "AKPL");
+            return akpl != null ? akpl.Length : 0;
+        }
+
+        /// <summary>Width/height of a cel from its AKCI record, without decoding the pixels (0x0 if absent).
+        /// Lets the GUI label cels and spot the tiny placeholder cels AKOS uses for unused frames.</summary>
+        public static Size GetCelSize(BlockBase akos, int celIndex)
+        {
+            byte[] akhd = GetSubBlock(akos, "AKHD");
+            byte[] akof = GetSubBlock(akos, "AKOF");
+            byte[] akci = GetSubBlock(akos, "AKCI");
+            if (akhd == null || akhd.Length < 8 || akof == null || akci == null) return Size.Empty;
+            if (celIndex < 0 || celIndex >= ReadUInt16(akhd, 6)) return Size.Empty;
+
+            int recordBase = celIndex * 6;
+            if (recordBase + 6 > akof.Length) return Size.Empty;
+            int akciOffset = ReadUInt16(akof, recordBase + 4);
+            if (akciOffset + 4 > akci.Length) return Size.Empty;
+            return new Size(ReadUInt16(akci, akciOffset), ReadUInt16(akci, akciOffset + 2));
+        }
+
+        /// <summary>Decodes cel <paramref name="celIndex"/> using the costume's own colours (RGBS / grayscale).</summary>
         public static Bitmap DecodeCel(BlockBase akos, int celIndex)
+        {
+            return DecodeCel(akos, celIndex, null);
+        }
+
+        /// <summary>
+        /// Decodes cel <paramref name="celIndex"/> to an indexed bitmap. With <paramref name="roomPalette"/>
+        /// null the costume's own colours are used: RGBS for codec 1/5 (the costume's standalone colour
+        /// snapshot), grayscale for codec 16 masks (which carry no snapshot). When a 256-colour room palette
+        /// is given, the cel is rendered as it would appear in that room: codec 1/5 map cel colour i through
+        /// AKPL (i -&gt; akpl[i] -&gt; roomPalette, matching ScummVM's _palette[i]=akpl[i]); codec 16 indexes
+        /// the room palette directly. Returns null for an empty/zero-size cel or an unsupported codec.
+        /// </summary>
+        public static Bitmap DecodeCel(BlockBase akos, int celIndex, Color[] roomPalette)
         {
             byte[] akhd = GetSubBlock(akos, "AKHD");
             byte[] akof = GetSubBlock(akos, "AKOF");
@@ -42,7 +76,7 @@ namespace ScummEditor.Engine.Encoders
             byte[] akcd = GetSubBlock(akos, "AKCD");
             byte[] akpl = GetSubBlock(akos, "AKPL");
             byte[] rgbs = GetSubBlock(akos, "RGBS");
-            if (akhd == null || akof == null || akci == null || akcd == null || akpl == null)
+            if (akhd == null || akhd.Length < 10 || akof == null || akci == null || akcd == null || akpl == null)
             {
                 return null;
             }
@@ -74,29 +108,40 @@ namespace ScummEditor.Engine.Encoders
                 return null;
             }
 
-            Color[] palette = BuildPalette(akpl, rgbs);
+            Color[] palette = BuildPalette(codec, akpl, rgbs, roomPalette);
 
-            if (codec != 1)
+            // The Dig and Full Throttle use three cel codecs (matching ScummVM akos.cpp): 1 = BYLE RLE
+            // (column-RLE), 5 = CDAT (a BOMP-encoded cel), 16 = MAJMIN (a bit-stream delta codec). Other
+            // codecs (32/TRLE, HE-only) are left undecoded - the cel is preserved byte-for-byte either way.
+            byte[,] indices;
+            switch (codec)
             {
-                // The Dig and Full Throttle use codec 1 (BYLE RLE). Codec 5 (CDAT/BOMP) and the HE-only
-                // codecs are left undecoded for now (the cel is preserved byte-for-byte either way).
-                return null;
+                case 1:
+                    indices = DecodeByleRle(akcd, (int)akcdOffset, width, height, akpl.Length);
+                    break;
+                case 5:
+                    indices = DecodeBomp(akcd, (int)akcdOffset, width, height);
+                    break;
+                case 16:
+                    indices = DecodeMajMin(akcd, (int)akcdOffset, width, height);
+                    break;
+                default:
+                    return null;
             }
-
-            byte[,] indices = DecodeByleRle(akcd, (int)akcdOffset, width, height, akpl.Length);
             return IndexedImageHelper.FromIndexMatrix(indices, palette, -1);
         }
 
         /// <summary>
         /// AKOS codec 1 (BYLE RLE): byte-oriented run-length, decoded column by column. Each byte holds
-        /// the colour in the high bits and the run length in the low bits (the split depends on the cel
-        /// colour count: 4/4 for &lt;=16 colours, 5/3 otherwise); a zero run length means the next byte
-        /// is the real length. Identical to the v5/v6 COST codec.
+        /// the colour in the high bits and the run length in the low bits; the split is keyed on the cel
+        /// colour count (AKPL size), exactly as ScummVM BaseCostumeRenderer::paintCelByleRLECommon:
+        /// 32 colours -&gt; 5 colour bits / 3 run bits, 64 -&gt; 6/2, otherwise (incl. 16) -&gt; 4/4. A zero
+        /// run length means the next byte is the real length. NOTE: the 64-colour case is AKOS-specific -
+        /// the v5/v6 COST codec only ever has 16 or 32 colours, so do NOT collapse this to a binary split.
         /// </summary>
         private static byte[,] DecodeByleRle(byte[] data, int offset, int width, int height, int paletteSize)
         {
-            int colorBits = paletteSize <= 16 ? 4 : 5;
-            int runBits = 8 - colorBits;
+            int runBits = paletteSize == 32 ? 3 : (paletteSize == 64 ? 2 : 4);
             int runMask = (1 << runBits) - 1;
 
             var result = new byte[width, height];
@@ -126,26 +171,175 @@ namespace ScummEditor.Engine.Encoders
         }
 
         /// <summary>
-        /// The costume palette: prefer RGBS (the costume's own absolute RGB triplets, one per cel
-        /// colour); fall back to a grayscale ramp when it is absent so the cel is still visible.
+        /// AKOS codec 5 (CDAT): a BOMP-encoded cel, decoded row by row (the same scheme as the v6/v7
+        /// object BOMP images). Each row is a uint16 LE byte-length followed by byte-oriented RLE: a
+        /// control byte whose low bit is the "repeat" flag and whose upper 7 bits are (run-1); a repeat
+        /// run is one colour byte, a literal run is <c>run</c> colour bytes. Mirrors BompImageDecoder.
         /// </summary>
-        private static Color[] BuildPalette(byte[] akpl, byte[] rgbs)
+        private static byte[,] DecodeBomp(byte[] data, int offset, int width, int height)
         {
-            int count = akpl.Length;
-            var palette = new Color[count];
-            for (int i = 0; i < count; i++)
+            var result = new byte[width, height];
+            int p = offset;
+            for (int y = 0; y < height && p + 2 <= data.Length; y++)
             {
-                if (rgbs != null && i * 3 + 2 < rgbs.Length)
+                int lineSize = data[p] | (data[p + 1] << 8);
+                p += 2;
+                int lineEnd = p + lineSize;
+                int x = 0;
+                while (x < width && p < lineEnd && p < data.Length)
+                {
+                    byte control = data[p++];
+                    int run = (control >> 1) + 1;
+                    bool repeat = (control & 1) != 0;
+                    if (repeat)
+                    {
+                        if (p >= data.Length) break;
+                        byte color = data[p++];
+                        for (int i = 0; i < run && x < width; i++) { result[x, y] = color; x++; }
+                    }
+                    else
+                    {
+                        for (int i = 0; i < run && x < width && p < data.Length; i++) { result[x, y] = data[p++]; x++; }
+                    }
+                }
+                p = lineEnd; // each row is exactly lineSize bytes, even if it ended early
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// AKOS codec 16 (MAJMIN): a bit-stream delta codec, decoded row by row (matching ScummVM
+        /// MajMinCodec). The header is [shift:1][startColour:1][initialBits:2 LE]; then per pixel: bit 0
+        /// keeps the colour; "10" replaces it with <c>shift</c> raw bits; "11"+3 bits is a signed delta
+        /// (-4..3), and a zero delta starts a repeat run whose length is the next 8 bits.
+        /// </summary>
+        private static byte[,] DecodeMajMin(byte[] data, int offset, int width, int height)
+        {
+            var result = new byte[width, height];
+            if (offset + 4 > data.Length)
+            {
+                return result;
+            }
+
+            int shift = data[offset];
+            int color = data[offset + 1];
+            int bits = data[offset + 2] | (data[offset + 3] << 8);
+            int dataPtr = offset + 4;
+            int numBits = 16;
+            bool repeatMode = false;
+            int repeatCount = 0;
+
+            for (int y = 0; y < height; y++)
+            {
+                for (int x = 0; x < width; x++)
+                {
+                    result[x, y] = (byte)color;
+
+                    if (!repeatMode)
+                    {
+                        if (ReadBits(data, ref dataPtr, ref bits, ref numBits, 1) != 0)
+                        {
+                            if (ReadBits(data, ref dataPtr, ref bits, ref numBits, 1) != 0)
+                            {
+                                int diff = ReadBits(data, ref dataPtr, ref bits, ref numBits, 3) - 4;
+                                if (diff != 0)
+                                {
+                                    color = (color + diff) & 0xFF;
+                                }
+                                else
+                                {
+                                    repeatMode = true;
+                                    repeatCount = ReadBits(data, ref dataPtr, ref bits, ref numBits, 8) - 1;
+                                }
+                            }
+                            else
+                            {
+                                color = ReadBits(data, ref dataPtr, ref bits, ref numBits, shift);
+                            }
+                        }
+                    }
+                    else if (--repeatCount == 0)
+                    {
+                        repeatMode = false;
+                    }
+                }
+            }
+            return result;
+        }
+
+        /// <summary>Reads <paramref name="n"/> low bits from the MAJMIN little-endian bit reservoir,
+        /// refilling a byte at a time (ScummVM MajMinCodec readBits).</summary>
+        private static int ReadBits(byte[] data, ref int dataPtr, ref int bits, ref int numBits, int n)
+        {
+            if (numBits <= 8 && dataPtr < data.Length)
+            {
+                bits |= data[dataPtr++] << numBits;
+                numBits += 8;
+            }
+            int value = bits & ((1 << n) - 1);
+            numBits -= n;
+            bits >>= n;
+            return value;
+        }
+
+        /// <summary>
+        /// Builds the 256-entry render palette for a cel (so any colour byte indexes safely), honouring
+        /// how the codec's pixel value is interpreted:
+        /// - codec 1/5 pixel = a costume-colour index. With no room palette it maps through the costume's
+        ///   own RGB snapshot (RGBS); with a room palette it maps colour i -&gt; akpl[i] -&gt; roomPalette
+        ///   (ScummVM's _palette[i]=akpl[i]), i.e. the costume as it looks in that room.
+        /// - codec 16 pixel = a room/screen palette index already, so a room palette is indexed directly;
+        ///   with none it falls back to grayscale (these masks carry no RGBS snapshot of their own).
+        /// </summary>
+        private static Color[] BuildPalette(int codec, byte[] akpl, byte[] rgbs, Color[] roomPalette)
+        {
+            var palette = new Color[256];
+            bool costumeIndexed = codec == 1 || codec == 5;
+
+            if (roomPalette != null && roomPalette.Length >= 256)
+            {
+                for (int i = 0; i < 256; i++)
+                {
+                    if (costumeIndexed)
+                    {
+                        int roomIndex = (akpl != null && i < akpl.Length) ? akpl[i] : i;
+                        palette[i] = roomPalette[roomIndex & 0xFF];
+                    }
+                    else
+                    {
+                        palette[i] = roomPalette[i];
+                    }
+                }
+                return palette;
+            }
+
+            // Codec 16 pixels are direct 0-255 palette indices, so its grayscale fallback must span the
+            // full 256-entry ramp (else indices above the AKPL size would wrap and band); codec 1/5 pixels
+            // are costume-colour indices (0..AKPL size-1), so the ramp is scaled to the cel colour count.
+            int count = codec == 16 ? 256 : (akpl != null && akpl.Length > 0 ? akpl.Length : 256);
+            int denom = count > 1 ? count - 1 : 1;
+            bool useRgbs = costumeIndexed && rgbs != null;
+            for (int i = 0; i < 256; i++)
+            {
+                if (useRgbs && i * 3 + 2 < rgbs.Length)
                 {
                     palette[i] = Color.FromArgb(rgbs[i * 3], rgbs[i * 3 + 1], rgbs[i * 3 + 2]);
                 }
                 else
                 {
-                    int g = count > 1 ? i * 255 / (count - 1) : 0;
+                    int g = (i < count ? i : i % count) * 255 / denom;
                     palette[i] = Color.FromArgb(g, g, g);
                 }
             }
             return palette;
+        }
+
+        /// <summary>True when the AKOS has its own RGBS colour snapshot (codec 1/5 costumes); false for the
+        /// codec-16 masks that have none (they need a room palette to show their true colours).</summary>
+        public static bool HasOwnPalette(BlockBase akos)
+        {
+            byte[] rgbs = GetSubBlock(akos, "RGBS");
+            return rgbs != null && rgbs.Length >= 3;
         }
 
         /// <summary>Raw bytes of the named AKOS sub-block (its child's Contents), or null when absent.</summary>

--- a/ScummEditor.Engine/Encoders/AkosImageDecoder.cs
+++ b/ScummEditor.Engine/Encoders/AkosImageDecoder.cs
@@ -1,0 +1,169 @@
+using System.Drawing;
+using System.Linq;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+
+namespace ScummEditor.Engine.Encoders
+{
+    /// <summary>
+    /// Decodes a single cel (frame) of a SCUMM v7 AKOS costume (The Dig, Full Throttle) to a bitmap.
+    /// AKOS keeps its data in sub-blocks (parsed as the AKOS block's children): AKHD (header: codec +
+    /// cel count), AKOF (per-cel offset table: akcd offset + akci offset), AKCI (per-cel width/height),
+    /// AKCD (the compressed cel pixels), AKPL (cel-colour count / room-palette remap) and RGBS (the
+    /// costume's own RGB palette). The Dig and Full Throttle use cel codec 1 (BYLE RLE) - the same
+    /// column-oriented run-length scheme as the v5/v6 COST costumes - so the decode mirrors
+    /// CostumeImageDecoder; codec 5 (CDAT/BOMP) is decoded with the shared BOMP decoder.
+    /// </summary>
+    public static class AkosImageDecoder
+    {
+        /// <summary>Number of cels (frames) in the AKOS costume.</summary>
+        public static int GetCelCount(BlockBase akos)
+        {
+            byte[] akhd = GetSubBlock(akos, "AKHD");
+            return akhd != null && akhd.Length >= 8 ? ReadUInt16(akhd, 6) : 0;
+        }
+
+        /// <summary>The cel compression codec from AKHD (1 = BYLE RLE, 5 = CDAT/BOMP).</summary>
+        public static int GetCodec(BlockBase akos)
+        {
+            byte[] akhd = GetSubBlock(akos, "AKHD");
+            return akhd != null && akhd.Length >= 10 ? ReadUInt16(akhd, 8) : 0;
+        }
+
+        /// <summary>
+        /// Decodes cel <paramref name="celIndex"/> to an indexed bitmap using the costume's own RGB
+        /// palette (RGBS). Returns null for an empty/zero-size cel or an unsupported codec.
+        /// </summary>
+        public static Bitmap DecodeCel(BlockBase akos, int celIndex)
+        {
+            byte[] akhd = GetSubBlock(akos, "AKHD");
+            byte[] akof = GetSubBlock(akos, "AKOF");
+            byte[] akci = GetSubBlock(akos, "AKCI");
+            byte[] akcd = GetSubBlock(akos, "AKCD");
+            byte[] akpl = GetSubBlock(akos, "AKPL");
+            byte[] rgbs = GetSubBlock(akos, "RGBS");
+            if (akhd == null || akof == null || akci == null || akcd == null || akpl == null)
+            {
+                return null;
+            }
+
+            int celCount = ReadUInt16(akhd, 6);
+            int codec = ReadUInt16(akhd, 8);
+            if (celIndex < 0 || celIndex >= celCount)
+            {
+                return null;
+            }
+
+            // AKOF record per cel: akcd offset (uint32 LE) + akci offset (uint16 LE) = 6 bytes.
+            int recordBase = celIndex * 6;
+            if (recordBase + 6 > akof.Length)
+            {
+                return null;
+            }
+            long akcdOffset = ReadUInt32(akof, recordBase);
+            int akciOffset = ReadUInt16(akof, recordBase + 4);
+            if (akciOffset + 4 > akci.Length || akcdOffset >= akcd.Length)
+            {
+                return null;
+            }
+
+            int width = ReadUInt16(akci, akciOffset);
+            int height = ReadUInt16(akci, akciOffset + 2);
+            if (width <= 0 || height <= 0)
+            {
+                return null;
+            }
+
+            Color[] palette = BuildPalette(akpl, rgbs);
+
+            if (codec != 1)
+            {
+                // The Dig and Full Throttle use codec 1 (BYLE RLE). Codec 5 (CDAT/BOMP) and the HE-only
+                // codecs are left undecoded for now (the cel is preserved byte-for-byte either way).
+                return null;
+            }
+
+            byte[,] indices = DecodeByleRle(akcd, (int)akcdOffset, width, height, akpl.Length);
+            return IndexedImageHelper.FromIndexMatrix(indices, palette, -1);
+        }
+
+        /// <summary>
+        /// AKOS codec 1 (BYLE RLE): byte-oriented run-length, decoded column by column. Each byte holds
+        /// the colour in the high bits and the run length in the low bits (the split depends on the cel
+        /// colour count: 4/4 for &lt;=16 colours, 5/3 otherwise); a zero run length means the next byte
+        /// is the real length. Identical to the v5/v6 COST codec.
+        /// </summary>
+        private static byte[,] DecodeByleRle(byte[] data, int offset, int width, int height, int paletteSize)
+        {
+            int colorBits = paletteSize <= 16 ? 4 : 5;
+            int runBits = 8 - colorBits;
+            int runMask = (1 << runBits) - 1;
+
+            var result = new byte[width, height];
+            int x = 0, y = 0, p = offset;
+            while (x < width && p < data.Length)
+            {
+                byte b = data[p++];
+                int color = b >> runBits;
+                int run = b & runMask;
+                if (run == 0)
+                {
+                    if (p >= data.Length) break;
+                    run = data[p++];
+                }
+                for (int i = 0; i < run && x < width; i++)
+                {
+                    result[x, y] = (byte)color;
+                    y++;
+                    if (y == height)
+                    {
+                        y = 0;
+                        x++;
+                    }
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// The costume palette: prefer RGBS (the costume's own absolute RGB triplets, one per cel
+        /// colour); fall back to a grayscale ramp when it is absent so the cel is still visible.
+        /// </summary>
+        private static Color[] BuildPalette(byte[] akpl, byte[] rgbs)
+        {
+            int count = akpl.Length;
+            var palette = new Color[count];
+            for (int i = 0; i < count; i++)
+            {
+                if (rgbs != null && i * 3 + 2 < rgbs.Length)
+                {
+                    palette[i] = Color.FromArgb(rgbs[i * 3], rgbs[i * 3 + 1], rgbs[i * 3 + 2]);
+                }
+                else
+                {
+                    int g = count > 1 ? i * 255 / (count - 1) : 0;
+                    palette[i] = Color.FromArgb(g, g, g);
+                }
+            }
+            return palette;
+        }
+
+        /// <summary>Raw bytes of the named AKOS sub-block (its child's Contents), or null when absent.</summary>
+        private static byte[] GetSubBlock(BlockBase akos, string tag)
+        {
+            BlockBase child = akos.Childrens.FirstOrDefault(c => c.BlockType == tag);
+            var raw = child as IRawContentBlock;
+            return raw != null ? raw.Contents : null;
+        }
+
+        private static int ReadUInt16(byte[] b, int o)
+        {
+            return b[o] | (b[o + 1] << 8);
+        }
+
+        private static long ReadUInt32(byte[] b, int o)
+        {
+            return (long)b[o] | ((long)b[o + 1] << 8) | ((long)b[o + 2] << 16) | ((long)b[o + 3] << 24);
+        }
+    }
+}

--- a/ScummEditor.Engine/Encoders/AkosImageDecoder.cs
+++ b/ScummEditor.Engine/Encoders/AkosImageDecoder.cs
@@ -70,12 +70,32 @@ namespace ScummEditor.Engine.Encoders
         /// </summary>
         public static Bitmap DecodeCel(BlockBase akos, int celIndex, Color[] roomPalette)
         {
+            byte[,] indices = DecodeCelIndices(akos, celIndex);
+            if (indices == null)
+            {
+                return null;
+            }
+
+            int codec = GetCodec(akos);
+            byte[] akpl = GetSubBlock(akos, "AKPL");
+            byte[] rgbs = GetSubBlock(akos, "RGBS");
+            Color[] palette = BuildPalette(codec, akpl, rgbs, roomPalette);
+            return IndexedImageHelper.FromIndexMatrix(indices, palette, -1);
+        }
+
+        /// <summary>
+        /// Decodes cel <paramref name="celIndex"/> to its raw palette-index matrix [width, height], or null
+        /// for an empty/zero-size cel or an unsupported codec. The indices are codec-local: costume-colour
+        /// indices for codec 1/5, room/screen palette indices for codec 16. This is the shared core used by
+        /// the viewer (which then applies a palette) and the encoder (which re-encodes an edited matrix).
+        /// </summary>
+        public static byte[,] DecodeCelIndices(BlockBase akos, int celIndex)
+        {
             byte[] akhd = GetSubBlock(akos, "AKHD");
             byte[] akof = GetSubBlock(akos, "AKOF");
             byte[] akci = GetSubBlock(akos, "AKCI");
             byte[] akcd = GetSubBlock(akos, "AKCD");
             byte[] akpl = GetSubBlock(akos, "AKPL");
-            byte[] rgbs = GetSubBlock(akos, "RGBS");
             if (akhd == null || akhd.Length < 10 || akof == null || akci == null || akcd == null || akpl == null)
             {
                 return null;
@@ -108,27 +128,20 @@ namespace ScummEditor.Engine.Encoders
                 return null;
             }
 
-            Color[] palette = BuildPalette(codec, akpl, rgbs, roomPalette);
-
             // The Dig and Full Throttle use three cel codecs (matching ScummVM akos.cpp): 1 = BYLE RLE
             // (column-RLE), 5 = CDAT (a BOMP-encoded cel), 16 = MAJMIN (a bit-stream delta codec). Other
             // codecs (32/TRLE, HE-only) are left undecoded - the cel is preserved byte-for-byte either way.
-            byte[,] indices;
             switch (codec)
             {
                 case 1:
-                    indices = DecodeByleRle(akcd, (int)akcdOffset, width, height, akpl.Length);
-                    break;
+                    return DecodeByleRle(akcd, (int)akcdOffset, width, height, akpl.Length);
                 case 5:
-                    indices = DecodeBomp(akcd, (int)akcdOffset, width, height);
-                    break;
+                    return DecodeBomp(akcd, (int)akcdOffset, width, height);
                 case 16:
-                    indices = DecodeMajMin(akcd, (int)akcdOffset, width, height);
-                    break;
+                    return DecodeMajMin(akcd, (int)akcdOffset, width, height);
                 default:
                     return null;
             }
-            return IndexedImageHelper.FromIndexMatrix(indices, palette, -1);
         }
 
         /// <summary>

--- a/ScummEditor.Engine/Encoders/AkosImageEncoder.cs
+++ b/ScummEditor.Engine/Encoders/AkosImageEncoder.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ScummEditor.Engine.Exceptions;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+
+namespace ScummEditor.Engine.Encoders
+{
+    /// <summary>
+    /// Re-encodes an edited SCUMM v7 AKOS cel and splices it back into the costume's AKCD pixel pool,
+    /// fixing the AKOF offset table. Codec 1 (BYLE RLE) is the inverse of AkosImageDecoder.DecodeByleRle;
+    /// codecs 5 (BOMP) and 16 (MAJMIN) are not encoded yet. The cel keeps its original width/height (AKCI is
+    /// untouched). Only the AKCD/AKOF sub-block bytes change; the AKOS block size, the LFLF/LECF positions
+    /// and the index (DCOS) offset to the costume are recomputed by the normal save path (CalculateBlockSize
+    /// / CalculateOffsets / FixUpIndexOffsets), so the saved game stays consistent.
+    /// </summary>
+    public static class AkosImageEncoder
+    {
+        /// <summary>True when this costume's cels can be re-encoded (codec 1 BYLE RLE or codec 5 BOMP).</summary>
+        public static bool CanEncode(BlockBase akos)
+        {
+            int codec = AkosImageDecoder.GetCodec(akos);
+            return codec == 1 || codec == 5;
+        }
+
+        /// <summary>
+        /// Replaces cel <paramref name="celIndex"/>'s pixels with <paramref name="indices"/> (a
+        /// width-by-height matrix of costume-colour indices), re-encoding with the costume's codec and
+        /// splicing the result into AKCD. The matrix must match the cel's stored width/height.
+        /// </summary>
+        public static void ReplaceCel(BlockBase akos, int celIndex, byte[,] indices)
+        {
+            int codec = AkosImageDecoder.GetCodec(akos);
+            if (codec != 1 && codec != 5)
+            {
+                throw new ImageEncodeException("AKOS cel import is implemented for codec 1 (BYLE RLE) and codec 5 (BOMP); this costume uses codec " + codec + ".");
+            }
+
+            RawContainerBlock akof = GetSub(akos, "AKOF");
+            RawContainerBlock akci = GetSub(akos, "AKCI");
+            RawContainerBlock akcd = GetSub(akos, "AKCD");
+            RawContainerBlock akpl = GetSub(akos, "AKPL");
+            if (akof == null || akci == null || akcd == null || akpl == null)
+            {
+                throw new ImageEncodeException("AKOS is missing a required sub-block (AKOF/AKCI/AKCD/AKPL).");
+            }
+
+            int recordBase = celIndex * 6;
+            if (recordBase + 6 > akof.Contents.Length)
+            {
+                throw new ImageEncodeException("Cel index " + celIndex + " is out of range.");
+            }
+
+            int celStart = (int)ReadU32(akof.Contents, recordBase);
+            int akciOffset = ReadU16(akof.Contents, recordBase + 4);
+            // Validate the offsets read from AKOF before using them (mirror the decoder's guards), so a
+            // corrupt/edited AKOF gives a controlled ImageEncodeException instead of an IndexOutOfRange.
+            if (celStart < 0 || celStart >= akcd.Contents.Length)
+            {
+                throw new ImageEncodeException("AKCD offset " + celStart + " is out of range for cel " + celIndex + ".");
+            }
+            if (akciOffset + 4 > akci.Contents.Length)
+            {
+                throw new ImageEncodeException("AKCI offset " + akciOffset + " is out of range for cel " + celIndex + ".");
+            }
+            int width = ReadU16(akci.Contents, akciOffset);
+            int height = ReadU16(akci.Contents, akciOffset + 2);
+            if (indices.GetLength(0) != width || indices.GetLength(1) != height)
+            {
+                throw new ImageEncodeException(string.Format(
+                    "The image must be {0}x{1} (the cel's size); got {2}x{3}.",
+                    width, height, indices.GetLength(0), indices.GetLength(1)));
+            }
+
+            // The encoders are validated separately (V7CostumeTests.AkosCelEncodeRoundTrips decodes the
+            // re-encoded bytes and asserts the indices are identical), so no per-call round-trip is done
+            // here. A valid (non-empty) cel always yields at least one byte.
+            byte[] newData = codec == 1 ? EncodeByleRle(indices, akpl.Contents.Length) : EncodeBomp(indices);
+
+            // The cel runs from celStart up to the next cel's start in AKCD (or the end of AKCD).
+            int celEnd = akcd.Contents.Length;
+            for (int i = 0; i + 6 <= akof.Contents.Length; i += 6)
+            {
+                int off = (int)ReadU32(akof.Contents, i);
+                if (off > celStart && off < celEnd)
+                {
+                    celEnd = off;
+                }
+            }
+
+            int delta = newData.Length - (celEnd - celStart);
+
+            // Rebuild AKCD with the cel's slice replaced.
+            byte[] oldAkcd = akcd.Contents;
+            var newAkcd = new byte[oldAkcd.Length + delta];
+            Array.Copy(oldAkcd, 0, newAkcd, 0, celStart);
+            Array.Copy(newData, 0, newAkcd, celStart, newData.Length);
+            Array.Copy(oldAkcd, celEnd, newAkcd, celStart + newData.Length, oldAkcd.Length - celEnd);
+
+            // Shift every AKOF entry that points at data after the replaced cel.
+            byte[] newAkof = (byte[])akof.Contents.Clone();
+            for (int i = 0; i + 6 <= newAkof.Length; i += 6)
+            {
+                int off = (int)ReadU32(newAkof, i);
+                if (off >= celEnd)
+                {
+                    WriteU32(newAkof, i, off + delta);
+                }
+            }
+
+            akcd.Contents = newAkcd;
+            akof.Contents = newAkof;
+        }
+
+        /// <summary>
+        /// AKOS codec 1 (BYLE RLE) encoder: the inverse of AkosImageDecoder.DecodeByleRle. Column-major
+        /// run-length; each byte holds the colour in the high bits and the run in the low bits, the split
+        /// keyed on the colour count (16 → 4/4, 32 → 5/3, 64 → 6/2). A run longer than the low-bits maximum
+        /// is written as an escape (low bits 0) followed by a length byte (1..255); runs &gt; 255 are split.
+        /// </summary>
+        public static byte[] EncodeByleRle(byte[,] indices, int paletteSize)
+        {
+            int width = indices.GetLength(0);
+            int height = indices.GetLength(1);
+            int runBits = paletteSize == 32 ? 3 : (paletteSize == 64 ? 2 : 4);
+            int runMask = (1 << runBits) - 1;
+            int maxColor = (1 << (8 - runBits)) - 1;
+
+            var output = new List<byte>();
+            int x = 0, y = 0;
+            while (x < width)
+            {
+                int color = indices[x, y];
+                if (color > maxColor)
+                {
+                    throw new ImageEncodeException(string.Format(
+                        "Pixel palette index {0} exceeds the costume's {1}-colour palette; the image must use only the costume's colours.",
+                        color, paletteSize));
+                }
+
+                int runLen = 0;
+                while (x < width && indices[x, y] == color)
+                {
+                    runLen++;
+                    y++;
+                    if (y == height)
+                    {
+                        y = 0;
+                        x++;
+                    }
+                }
+
+                while (runLen > 0)
+                {
+                    int chunk = Math.Min(runLen, 255);
+                    if (chunk <= runMask)
+                    {
+                        output.Add((byte)((color << runBits) | chunk));
+                    }
+                    else
+                    {
+                        output.Add((byte)(color << runBits)); // low bits 0 = "run is in the next byte"
+                        output.Add((byte)chunk);
+                    }
+                    runLen -= chunk;
+                }
+            }
+            return output.ToArray();
+        }
+
+        /// <summary>
+        /// AKOS codec 5 (CDAT/BOMP) encoder: the inverse of AkosImageDecoder.DecodeBomp. Each row is a
+        /// uint16 LE byte-length followed by run-length data: a control byte whose low bit is the "repeat"
+        /// flag and whose upper 7 bits are (run-1); a repeat run stores one colour byte, a literal run stores
+        /// <c>run</c> colour bytes. Runs are capped at 128 (the 7-bit limit). Colours are full bytes (0-255).
+        /// </summary>
+        public static byte[] EncodeBomp(byte[,] indices)
+        {
+            int width = indices.GetLength(0);
+            int height = indices.GetLength(1);
+            var result = new List<byte>();
+
+            for (int y = 0; y < height; y++)
+            {
+                var line = new List<byte>();
+                int x = 0;
+                while (x < width)
+                {
+                    int color = indices[x, y];
+                    int runLen = 1;
+                    while (x + runLen < width && indices[x + runLen, y] == color)
+                    {
+                        runLen++;
+                    }
+
+                    if (runLen >= 2)
+                    {
+                        int remaining = runLen;
+                        while (remaining > 0)
+                        {
+                            int chunk = Math.Min(remaining, 128);
+                            line.Add((byte)(((chunk - 1) << 1) | 1)); // repeat
+                            line.Add((byte)color);
+                            remaining -= chunk;
+                        }
+                        x += runLen;
+                    }
+                    else
+                    {
+                        // Gather a literal run of single (non-repeating) pixels.
+                        int litStart = x;
+                        int litLen = 0;
+                        while (x < width)
+                        {
+                            int c = indices[x, y];
+                            int rl = 1;
+                            while (x + rl < width && indices[x + rl, y] == c) rl++;
+                            if (rl >= 2) break; // a repeat run starts here - end the literal
+                            litLen++;
+                            x++;
+                        }
+
+                        int pos = litStart;
+                        int rem = litLen;
+                        while (rem > 0)
+                        {
+                            int chunk = Math.Min(rem, 128);
+                            line.Add((byte)(((chunk - 1) << 1) | 0)); // literal
+                            for (int k = 0; k < chunk; k++) line.Add((byte)indices[pos + k, y]);
+                            pos += chunk;
+                            rem -= chunk;
+                        }
+                    }
+                }
+
+                result.Add((byte)(line.Count & 0xFF));
+                result.Add((byte)((line.Count >> 8) & 0xFF));
+                result.AddRange(line);
+            }
+            return result.ToArray();
+        }
+
+        private static RawContainerBlock GetSub(BlockBase akos, string tag)
+        {
+            return akos.Childrens.FirstOrDefault(c => c.BlockType == tag) as RawContainerBlock;
+        }
+
+        private static long ReadU32(byte[] b, int o)
+        {
+            return (long)b[o] | ((long)b[o + 1] << 8) | ((long)b[o + 2] << 16) | ((long)b[o + 3] << 24);
+        }
+
+        private static int ReadU16(byte[] b, int o)
+        {
+            return b[o] | (b[o + 1] << 8);
+        }
+
+        private static void WriteU32(byte[] b, int o, long value)
+        {
+            b[o] = (byte)(value & 0xFF);
+            b[o + 1] = (byte)((value >> 8) & 0xFF);
+            b[o + 2] = (byte)((value >> 16) & 0xFF);
+            b[o + 3] = (byte)((value >> 24) & 0xFF);
+        }
+    }
+}

--- a/ScummEditor.Engine/Encoders/AkosImageEncoder.cs
+++ b/ScummEditor.Engine/Encoders/AkosImageEncoder.cs
@@ -17,11 +17,11 @@ namespace ScummEditor.Engine.Encoders
     /// </summary>
     public static class AkosImageEncoder
     {
-        /// <summary>True when this costume's cels can be re-encoded (codec 1 BYLE RLE or codec 5 BOMP).</summary>
+        /// <summary>True when this costume's cels can be re-encoded (codec 1 BYLE RLE, 5 BOMP or 16 MAJMIN).</summary>
         public static bool CanEncode(BlockBase akos)
         {
             int codec = AkosImageDecoder.GetCodec(akos);
-            return codec == 1 || codec == 5;
+            return codec == 1 || codec == 5 || codec == 16;
         }
 
         /// <summary>
@@ -32,9 +32,9 @@ namespace ScummEditor.Engine.Encoders
         public static void ReplaceCel(BlockBase akos, int celIndex, byte[,] indices)
         {
             int codec = AkosImageDecoder.GetCodec(akos);
-            if (codec != 1 && codec != 5)
+            if (codec != 1 && codec != 5 && codec != 16)
             {
-                throw new ImageEncodeException("AKOS cel import is implemented for codec 1 (BYLE RLE) and codec 5 (BOMP); this costume uses codec " + codec + ".");
+                throw new ImageEncodeException("AKOS cel import is implemented for codec 1 (BYLE RLE), 5 (BOMP) and 16 (MAJMIN); this costume uses codec " + codec + ".");
             }
 
             RawContainerBlock akof = GetSub(akos, "AKOF");
@@ -76,7 +76,13 @@ namespace ScummEditor.Engine.Encoders
             // The encoders are validated separately (V7CostumeTests.AkosCelEncodeRoundTrips decodes the
             // re-encoded bytes and asserts the indices are identical), so no per-call round-trip is done
             // here. A valid (non-empty) cel always yields at least one byte.
-            byte[] newData = codec == 1 ? EncodeByleRle(indices, akpl.Contents.Length) : EncodeBomp(indices);
+            byte[] newData;
+            switch (codec)
+            {
+                case 1: newData = EncodeByleRle(indices, akpl.Contents.Length); break;
+                case 5: newData = EncodeBomp(indices); break;
+                default: newData = EncodeMajMin(indices); break; // codec 16
+            }
 
             // The cel runs from celStart up to the next cel's start in AKCD (or the end of AKCD).
             int celEnd = akcd.Contents.Length;
@@ -239,6 +245,112 @@ namespace ScummEditor.Engine.Encoders
                 result.AddRange(line);
             }
             return result.ToArray();
+        }
+
+        /// <summary>
+        /// AKOS codec 16 (MAJMIN) encoder: the inverse of AkosImageDecoder.DecodeMajMin. Row-major. Header
+        /// = [shift:1][startColour:1][bit-stream...]; per pixel a code transitions to the NEXT pixel's
+        /// colour: "0" = keep; "11"+3-bit (value=delta+4, delta in -4..3 excluding 0) = signed delta; "10"+
+        /// shift raw bits = absolute colour. The bit stream is packed LSB-first (matching the decoder's
+        /// reservoir, which reads bytes 2,3.. low bit first). The decoder's repeat-run form is not emitted
+        /// (a "keep" per repeated pixel is valid, just less compact). shift is chosen to fit the max index.
+        /// </summary>
+        public static byte[] EncodeMajMin(byte[,] indices)
+        {
+            int width = indices.GetLength(0);
+            int height = indices.GetLength(1);
+
+            int maxIndex = 0;
+            foreach (byte v in indices)
+            {
+                if (v > maxIndex) maxIndex = v;
+            }
+            int shift = 1;
+            while ((1 << shift) <= maxIndex)
+            {
+                shift++;
+            }
+
+            int total = width * height;
+            int startColor = indices[0, 0];
+            int color = startColor;
+            var bw = new LsbBitWriter();
+
+            for (int idx = 0; idx < total; idx++)
+            {
+                int nextColor = idx + 1 < total ? indices[(idx + 1) % width, (idx + 1) / width] : color;
+
+                if (nextColor == color)
+                {
+                    bw.WriteBit(0); // keep
+                }
+                else
+                {
+                    int delta = ((nextColor - color + 128) & 0xFF) - 128; // signed delta mod 256
+                    if (delta >= -4 && delta <= 3 && delta != 0)
+                    {
+                        bw.WriteBit(1);
+                        bw.WriteBit(1);
+                        bw.WriteBits(delta + 4, 3); // delta -4..3 (skip 0) -> 0,1,2,3,5,6,7
+                    }
+                    else
+                    {
+                        bw.WriteBit(1);
+                        bw.WriteBit(0);
+                        bw.WriteBits(nextColor, shift); // absolute colour
+                    }
+                }
+                color = nextColor;
+            }
+
+            byte[] packed = bw.ToBytes();
+            // The decoder seeds its reservoir from bytes 2 and 3 unconditionally, so the stream needs >= 2 bytes.
+            int streamLen = packed.Length < 2 ? 2 : packed.Length;
+            var output = new byte[2 + streamLen];
+            output[0] = (byte)shift;
+            output[1] = (byte)startColor;
+            Array.Copy(packed, 0, output, 2, packed.Length);
+            return output;
+        }
+
+        /// <summary>Writes bits least-significant-bit-first, matching MajMin's ReadBits reservoir.</summary>
+        private sealed class LsbBitWriter
+        {
+            private readonly List<byte> _bytes = new List<byte>();
+            private int _current;
+            private int _count;
+
+            public void WriteBit(int bit)
+            {
+                if ((bit & 1) != 0)
+                {
+                    _current |= 1 << _count;
+                }
+                _count++;
+                if (_count == 8)
+                {
+                    _bytes.Add((byte)_current);
+                    _current = 0;
+                    _count = 0;
+                }
+            }
+
+            public void WriteBits(int value, int bits)
+            {
+                for (int i = 0; i < bits; i++)
+                {
+                    WriteBit((value >> i) & 1);
+                }
+            }
+
+            public byte[] ToBytes()
+            {
+                if (_count > 0)
+                {
+                    _bytes.Add((byte)_current);
+                }
+                return _bytes.ToArray();
+            }
         }
 
         private static RawContainerBlock GetSub(BlockBase akos, string tag)

--- a/ScummEditor.Engine/Encoders/CharsetPngCodec.cs
+++ b/ScummEditor.Engine/Encoders/CharsetPngCodec.cs
@@ -224,7 +224,7 @@ namespace ScummEditor.Engine.Encoders
         // ---------------------------------------------------------------------
 
         /// <summary>Charsets of the game in tree (file) order - the index defines the file names.</summary>
-        public static List<Charset> CollectCharsets(ScummV5V6DataFile dataFile)
+        public static List<Charset> CollectCharsets(ScummDataFile dataFile)
         {
             var result = new List<Charset>();
             Collect(dataFile, result);
@@ -239,7 +239,7 @@ namespace ScummEditor.Engine.Encoders
         }
 
         /// <summary>Exports the charsets embedded in the data file (v5/v6).</summary>
-        public static string ExportAll(ScummV5V6DataFile dataFile, string folder)
+        public static string ExportAll(ScummDataFile dataFile, string folder)
         {
             return ExportAll(CollectCharsets(dataFile), folder);
         }
@@ -259,7 +259,7 @@ namespace ScummEditor.Engine.Encoders
         }
 
         /// <summary>Imports the charsets embedded in the data file (v5/v6).</summary>
-        public static string ImportAll(ScummV5V6DataFile dataFile, string folder)
+        public static string ImportAll(ScummDataFile dataFile, string folder)
         {
             return ImportAll(CollectCharsets(dataFile), folder);
         }

--- a/ScummEditor.Engine/Encoders/CharsetPngCodec.cs
+++ b/ScummEditor.Engine/Encoders/CharsetPngCodec.cs
@@ -40,12 +40,14 @@ namespace ScummEditor.Engine.Encoders
         // European MI2 fonts do). Import recomputes the same margins from the same font,
         // so the convention stays self-describing.
         private const int MinimumMargin = 8;
-        // Palette slot for the cell divider lines, drawn before the glyphs and stripped on import. The line
-        // sits on each cell's left/top edge; a most-negative-offset glyph's leftmost/topmost ink can land on
-        // that same edge and overdraw the line (it is drawn after the grid) - harmless, because import only
-        // strips pixels that are STILL == GridIndex, so real ink survives. At 8bpp (maxVal==255==GridIndex)
-        // the divider would be indistinguishable from brightest ink, so the grid is omitted there entirely.
+        // A 1px gutter is baked into the left/top margin so each cell's column 0 / row 0 is NEVER reached by a
+        // glyph (even the most-negative-offset one). The cell divider line lives in that gutter, so the grid
+        // is drawn for EVERY font (including 8bpp) and stripped on import by POSITION (zeroing column 0 / row
+        // 0 of each cell) rather than by value - which would be impossible at 8bpp where 255 is real ink.
+        // Same gutter+grid scheme as the .NUT font atlas, so all font exports look alike.
+        private const int Gutter = 1;
         private const int GridIndex = 255;
+        private static readonly Color GridColor = Color.FromArgb(0, 170, 210); // cyan, matching the .NUT atlas grid
         private const int OffsetBase = 0x15;
         private const int TableStart = 0x19;
 
@@ -61,16 +63,13 @@ namespace ScummEditor.Engine.Encoders
 
             var matrix = new byte[width, height];
 
-            // Divider lines on the top/left edge of every cell (GridIndex pixels are ignored on import).
-            // Skipped at 8bpp, where GridIndex(255) would be a legal ink value and could not be told apart.
-            bool drawGrid = (1 << charset.BitsPerPixel) - 1 < GridIndex;
-            if (drawGrid)
-            {
-                for (int x = 0; x < width; x += cellW)
-                    for (int y = 0; y < height; y++) matrix[x, y] = GridIndex;
-                for (int y = 0; y < height; y += cellH)
-                    for (int x = 0; x < width; x++) matrix[x, y] = GridIndex;
-            }
+            // Divider lines in the top/left gutter of every cell. The gutter is never glyph ink, so the grid
+            // is drawn for EVERY font (it is stripped on import by position) - unlike the old edge grid that
+            // had to be omitted at 8bpp.
+            for (int x = 0; x < width; x += cellW)
+                for (int y = 0; y < height; y++) matrix[x, y] = GridIndex;
+            for (int y = 0; y < height; y += cellH)
+                for (int x = 0; x < width; x++) matrix[x, y] = GridIndex;
 
             for (int slot = 0; slot < charset.Glyphs.Count && slot < 256; slot++)
             {
@@ -113,7 +112,7 @@ namespace ScummEditor.Engine.Encoders
                     palette[v] = Color.Magenta; // painting with these would be invalid
                 }
             }
-            if (maxVal < GridIndex) palette[GridIndex] = Color.FromArgb(60, 80, 160); // divider lines (not at 8bpp)
+            palette[GridIndex] = GridColor; // the gutter divider line (always present, at every bit depth)
             return palette;
         }
 
@@ -135,6 +134,12 @@ namespace ScummEditor.Engine.Encoders
                 if (g.XOffset + g.Width > maxX) maxX = g.XOffset + g.Width;
                 if (g.YOffset + g.Height > maxY) maxY = g.YOffset + g.Height;
             }
+
+            // Push the glyph origin in by the gutter, so column 0 / row 0 of each cell (where the grid is
+            // drawn) is never touched by a glyph - even the one with the most-negative offset, whose ink now
+            // starts at column/row >= Gutter. Import strips that gutter by position, at any bit depth.
+            marginX += Gutter;
+            marginY += Gutter;
             cellW = marginX + maxX + MinimumMargin;
             cellH = marginY + maxY + MinimumMargin;
         }
@@ -333,15 +338,13 @@ namespace ScummEditor.Engine.Encoders
             int cellW = width / Columns, cellH = height / Rows;
             int maxVal = (1 << charset.BitsPerPixel) - 1;
 
-            // The divider lines are decoration only - drop them before any analysis. Only do this when the
-            // grid index is NOT a legal ink value: at 8bpp maxVal==255==GridIndex, so the divider is not
-            // drawn (see ExportPng) and stripping it would wipe real brightest-ink pixels.
-            if (maxVal < GridIndex)
-            {
-                for (int y = 0; y < height; y++)
-                    for (int x = 0; x < width; x++)
-                        if (pixels[x, y] == GridIndex) pixels[x, y] = 0;
-            }
+            // The divider lines live in each cell's top/left gutter, which a glyph never occupies, so strip
+            // them by POSITION (zero column 0 / row 0 of every cell). This works at every bit depth - unlike
+            // a value-based strip, which 8bpp's legal 255 ink would defeat.
+            for (int x = 0; x < width; x += cellW)
+                for (int y = 0; y < height; y++) pixels[x, y] = 0;
+            for (int y = 0; y < height; y += cellH)
+                for (int x = 0; x < width; x++) pixels[x, y] = 0;
 
             // Same per-font margins the export used (recomputed from the same font).
             int marginX, marginY, layoutCellW, layoutCellH;

--- a/ScummEditor.Engine/Encoders/DosCodePageText.cs
+++ b/ScummEditor.Engine/Encoders/DosCodePageText.cs
@@ -1,0 +1,65 @@
+using System.Text;
+using ScummEditor.Engine.Structures;
+
+namespace ScummEditor.Engine.Encoders
+{
+    /// <summary>
+    /// Renders the byte-faithful (Latin-1) localized v7 text with its real accents, by transcoding through
+    /// the edition's DOS code page for DISPLAY only. The bytes stored in an entry are the game's own code
+    /// page; shown as Latin-1 their high bytes look wrong, so the editor decodes them through the right code
+    /// page for the screen and re-encodes an edit back to those bytes.
+    ///
+    /// SCUMM v7 uses CP850 for every Western edition - including Portuguese (ScummVM renders v7 with
+    /// Common::kDos850, string.cpp; verified against the real PT The Dig, whose "ã" only renders correctly
+    /// via CP850, NOT CP860). The double-byte CJK editions (and unknown languages) return the text unchanged
+    /// (code page 0): a single-byte round-trip is not available for them, and they are not the translation
+    /// target. CP850 round-trips every byte 0x00-0xFF exactly, so an unedited string is unchanged.
+    /// </summary>
+    public static class DosCodePageText
+    {
+        static DosCodePageText()
+        {
+            // The DOS code pages are not built into .NET Core; register the provider that supplies them.
+            try { Encoding.RegisterProvider(CodePagesEncodingProvider.Instance); } catch { }
+        }
+
+        /// <summary>The DOS code page to display a language's text in, or 0 to leave it byte-faithful (raw).</summary>
+        public static int CodePageFor(ScummLanguage language)
+        {
+            switch (language)
+            {
+                case ScummLanguage.English:
+                case ScummLanguage.French:
+                case ScummLanguage.German:
+                case ScummLanguage.Italian:
+                case ScummLanguage.Spanish:
+                case ScummLanguage.Portuguese:
+                    return 850; // CP850 - the DOS code page SCUMM v7 uses for every Western edition (incl. PT)
+                default:
+                    return 0;   // CJK / Hebrew / Russian / unknown: no single-byte round-trip, keep raw
+            }
+        }
+
+        /// <summary>Byte-faithful (Latin-1) text -&gt; Unicode for display via the code page; cp 0 = unchanged.</summary>
+        public static string ToDisplay(string latin1, int codePage)
+        {
+            if (codePage == 0 || string.IsNullOrEmpty(latin1)) return latin1;
+            Encoding enc = TryGet(codePage);
+            return enc == null ? latin1 : enc.GetString(Encoding.Latin1.GetBytes(latin1));
+        }
+
+        /// <summary>Edited Unicode text -&gt; byte-faithful (Latin-1) via the code page; cp 0 = unchanged.</summary>
+        public static string FromDisplay(string display, int codePage)
+        {
+            if (codePage == 0 || string.IsNullOrEmpty(display)) return display;
+            Encoding enc = TryGet(codePage);
+            return enc == null ? display : Encoding.Latin1.GetString(enc.GetBytes(display));
+        }
+
+        private static Encoding TryGet(int codePage)
+        {
+            try { return Encoding.GetEncoding(codePage); }
+            catch { return null; }
+        }
+    }
+}

--- a/ScummEditor.Engine/Encoders/GameLanguageDetector.cs
+++ b/ScummEditor.Engine/Encoders/GameLanguageDetector.cs
@@ -118,6 +118,23 @@ namespace ScummEditor.Engine.Encoders
             return DetectFromEntries(entries);
         }
 
+        /// <summary>
+        /// Detects the language of an arbitrary set of already-extracted strings (the same word/SJIS
+        /// heuristic as <see cref="Detect(ScummGameData)"/>). Used for SCUMM v7, whose in-container scripts
+        /// keep English engine text - the real translation lives in the external localized-text files
+        /// (The Dig's LANGUAGE.BND, Full Throttle's .TRS), so the caller feeds those entries here instead.
+        /// </summary>
+        public static string DetectFromStrings(IEnumerable<string> texts)
+        {
+            if (texts == null) return null;
+            var entries = new List<GameTextEntry>();
+            foreach (string t in texts)
+            {
+                if (!string.IsNullOrEmpty(t)) entries.Add(new GameTextEntry { Text = t });
+            }
+            return DetectFromEntries(entries);
+        }
+
         private static string DetectFromEntries(List<GameTextEntry> entries)
         {
             // Japanese is recognized by its high-byte (SJIS) density before any word matching - the

--- a/ScummEditor.Engine/Encoders/GameLanguageDetector.cs
+++ b/ScummEditor.Engine/Encoders/GameLanguageDetector.cs
@@ -103,7 +103,7 @@ namespace ScummEditor.Engine.Encoders
         }
 
         /// <summary>Legacy overload: detect from a single v5/v6 data file.</summary>
-        public static string Detect(ScummV5V6DataFile dataFile)
+        public static string Detect(ScummDataFile dataFile)
         {
             List<GameTextEntry> entries;
             try

--- a/ScummEditor.Engine/Encoders/GameTextManager.cs
+++ b/ScummEditor.Engine/Encoders/GameTextManager.cs
@@ -42,7 +42,7 @@ namespace ScummEditor.Engine.Encoders
             return (IScriptBytecode)source.Script;
         }
 
-        private static List<Source> EnumerateSources(ScummV5V6DataFile dataFile)
+        private static List<Source> EnumerateSources(ScummDataFile dataFile)
         {
             var list = new List<Source>();
             List<DiskBlock> lflfs = dataFile.GetLFLFs();
@@ -157,7 +157,7 @@ namespace ScummEditor.Engine.Encoders
         // Export
         // ---------------------------------------------------------------------
 
-        public static List<GameTextEntry> Extract(ScummV5V6DataFile dataFile, GameTextCodec codec)
+        public static List<GameTextEntry> Extract(ScummDataFile dataFile, GameTextCodec codec)
         {
             return BuildEntries(EnumerateSources(dataFile), codec);
         }
@@ -242,7 +242,7 @@ namespace ScummEditor.Engine.Encoders
             return false;
         }
 
-        public static int ExportToFile(ScummV5V6DataFile dataFile, string path, GameTextCodec codec, string gameLabel)
+        public static int ExportToFile(ScummDataFile dataFile, string path, GameTextCodec codec, string gameLabel)
         {
             List<GameTextEntry> entries = Extract(dataFile, codec);
             WriteEntriesFile(entries, path, codec, gameLabel);
@@ -413,7 +413,7 @@ namespace ScummEditor.Engine.Encoders
         // Import
         // ---------------------------------------------------------------------
 
-        public static GameTextImportReport ImportFromFile(ScummV5V6DataFile dataFile, string path)
+        public static GameTextImportReport ImportFromFile(ScummDataFile dataFile, string path)
         {
             var report = new GameTextImportReport();
             GameTextCodec codec;
@@ -880,7 +880,7 @@ namespace ScummEditor.Engine.Encoders
         // Glyph validation: warn when an imported byte has no glyph in the fonts
         // ---------------------------------------------------------------------
 
-        private static void ValidateGlyphs(ScummV5V6DataFile dataFile, List<byte[]> changedContents,
+        private static void ValidateGlyphs(ScummDataFile dataFile, List<byte[]> changedContents,
                                            GameTextCodec codec, GameTextImportReport report)
         {
             var charsets = new List<Charset>();

--- a/ScummEditor.Engine/Encoders/ImageInfo.cs
+++ b/ScummEditor.Engine/Encoders/ImageInfo.cs
@@ -16,6 +16,10 @@ namespace ScummEditor.Engine.Encoders
         public int CostumeIndex { get; private set; }
         public int FrameIndex { get; private set; }
 
+        // SCUMM v7 AKOS costumes: "Room#i Akos#j Cel#k.png".
+        public int AkosIndex { get; private set; }
+        public int CelIndex { get; private set; }
+
         public ImageInfo(string fileName)
         {
             Filename = fileName;
@@ -26,6 +30,8 @@ namespace ScummEditor.Engine.Encoders
             ImageIndex = -1;
             CostumeIndex = -1;
             FrameIndex = -1;
+            AkosIndex = -1;
+            CelIndex = -1;
             ImageType = ImageType.Unknown;
 
             Parse();
@@ -58,13 +64,23 @@ namespace ScummEditor.Engine.Encoders
                     case "ZP":
                         ZPlaneIndex = int.Parse(pairValues[1]);
                         break;
+                    case "Akos":
+                        AkosIndex = int.Parse(pairValues[1]);
+                        break;
+                    case "Cel":
+                        CelIndex = int.Parse(pairValues[1]);
+                        break;
                 }
             }
 
             //Determine the ImageType
             if (RoomIndex < 0) return;
 
-            if (CostumeIndex >= 0)
+            if (AkosIndex >= 0)
+            {
+                ImageType = ImageType.AkosCostume;
+            }
+            else if (CostumeIndex >= 0)
             {
                 ImageType = ImageType.Costume;
             }

--- a/ScummEditor.Engine/Encoders/ImageType.cs
+++ b/ScummEditor.Engine/Encoders/ImageType.cs
@@ -7,6 +7,7 @@
         ZPlane = 2,
         Object = 3,
         ObjectsZPlane = 4,
-        Costume = 5
+        Costume = 5,
+        AkosCostume = 6 // SCUMM v7 AKOS costume cel (decoded/encoded by AkosImageDecoder/AkosImageEncoder)
     }
 }

--- a/ScummEditor.Engine/Encoders/ImuseAudioDecoder.cs
+++ b/ScummEditor.Engine/Encoders/ImuseAudioDecoder.cs
@@ -1,0 +1,171 @@
+using System.IO;
+
+namespace ScummEditor.Engine.Encoders
+{
+    /// <summary>
+    /// Decodes a SCUMM v7 in-container iMUSE digital-audio resource (the body of a v7 SOUN block in The Dig)
+    /// to a PCM WAV, for the sound viewer's preview/export. Layout (verified vs ScummVM imuse_digi):
+    ///   iMUS -> 'MAP ' { 'FRMT' [+8 dataOffset][+12 endian][+16 wordSize][+20 sampleRate][+24 channels], all
+    ///   big-endian uint32; plus REGN/JUMP/SYNC/TEXT markers } -> 'DATA' [size:uint32 BE] + raw PCM.
+    /// The in-container DATA is RAW PCM (no VIMA/ADPCM - that only wraps iMUS inside the external .BUN
+    /// bundles). wordSize is 8 (unsigned) or 12 (packed) for The Dig; 16-bit is handled defensively.
+    /// The export uses the natural full-scale conversion, not ScummVM's internal (volume-normalised) mixer.
+    /// </summary>
+    public static class ImuseAudioDecoder
+    {
+        /// <summary>Format info read from the iMUS FRMT chunk (null when there is no FRMT/iMUS).</summary>
+        public class ImuseInfo
+        {
+            public int WordSize;
+            public int SampleRate;
+            public int Channels;
+            public int DataLength;
+        }
+
+        /// <summary>True when the bytes are (or contain near the start) an iMUS resource.</summary>
+        public static bool IsImus(byte[] sounBytes)
+        {
+            if (sounBytes == null) return false;
+            int p = Find(sounBytes, "iMUS", 0, 16);
+            return p >= 0;
+        }
+
+        /// <summary>Reads the iMUS FRMT format fields, or null when the resource has no FRMT.</summary>
+        public static ImuseInfo GetInfo(byte[] sounBytes)
+        {
+            int frmt = Find(sounBytes, "FRMT", 0, sounBytes != null ? sounBytes.Length : 0);
+            if (frmt < 0 || frmt + 28 > sounBytes.Length) return null;
+
+            var info = new ImuseInfo
+            {
+                WordSize = ReadBE(sounBytes, frmt + 16),
+                SampleRate = ReadBE(sounBytes, frmt + 20),
+                Channels = ReadBE(sounBytes, frmt + 24),
+            };
+            int data = Find(sounBytes, "DATA", 0, sounBytes.Length);
+            info.DataLength = data >= 0 && data + 8 <= sounBytes.Length ? ReadBE(sounBytes, data + 4) : 0;
+            return info;
+        }
+
+        /// <summary>
+        /// Decodes the iMUS resource to a PCM WAV (8-bit unsigned, or 12/16-bit -> 16-bit signed), or null
+        /// when it is not a decodable iMUS (no FRMT/DATA, or an unsupported word size).
+        /// </summary>
+        public static byte[] ToWav(byte[] sounBytes)
+        {
+            ImuseInfo info = GetInfo(sounBytes);
+            if (info == null || info.Channels < 1 || info.Channels > 2 || info.SampleRate <= 0) return null;
+
+            int data = Find(sounBytes, "DATA", 0, sounBytes.Length);
+            if (data < 0 || data + 8 > sounBytes.Length) return null;
+            int dataSize = ReadBE(sounBytes, data + 4);
+            int dataStart = data + 8;
+            if (dataSize <= 0 || dataStart >= sounBytes.Length) return null;
+            if (dataStart + dataSize > sounBytes.Length) dataSize = sounBytes.Length - dataStart;
+
+            byte[] pcm;
+            int bits;
+            if (info.WordSize == 8)
+            {
+                pcm = new byte[dataSize];
+                System.Array.Copy(sounBytes, dataStart, pcm, 0, dataSize); // iMUSE 8-bit is unsigned = WAV 8-bit
+                bits = 8;
+            }
+            else if (info.WordSize == 12)
+            {
+                pcm = Decode12BitTo16(sounBytes, dataStart, dataSize);
+                bits = 16;
+            }
+            else if (info.WordSize == 16)
+            {
+                pcm = new byte[dataSize & ~1];
+                System.Array.Copy(sounBytes, dataStart, pcm, 0, pcm.Length); // assume signed 16-bit LE
+                bits = 16;
+            }
+            else
+            {
+                return null;
+            }
+
+            return BuildWav(pcm, info.SampleRate, info.Channels, bits);
+        }
+
+        /// <summary>
+        /// Unpacks iMUSE 12-bit PCM (2 samples per 3 bytes) to signed 16-bit LE. Each 12-bit value is
+        /// unsigned 0..4095 centred at 2048 (matching dimuse_internalmixer mixBits12Mono's index math); the
+        /// natural full-scale 16-bit sample is (v - 2048) &lt;&lt; 4.
+        /// </summary>
+        private static byte[] Decode12BitTo16(byte[] src, int offset, int length)
+        {
+            int triples = length / 3;
+            var outBytes = new byte[triples * 4]; // 2 samples * 2 bytes per 3 input bytes
+            int o = 0;
+            for (int i = 0; i < triples; i++)
+            {
+                int b0 = src[offset + i * 3];
+                int b1 = src[offset + i * 3 + 1];
+                int b2 = src[offset + i * 3 + 2];
+
+                int v0 = b0 | ((b1 & 0x0F) << 8);
+                int v1 = b2 | ((b1 & 0xF0) << 4);
+
+                short s0 = (short)((v0 - 2048) << 4);
+                short s1 = (short)((v1 - 2048) << 4);
+
+                outBytes[o++] = (byte)(s0 & 0xFF);
+                outBytes[o++] = (byte)((s0 >> 8) & 0xFF);
+                outBytes[o++] = (byte)(s1 & 0xFF);
+                outBytes[o++] = (byte)((s1 >> 8) & 0xFF);
+            }
+            return outBytes;
+        }
+
+        /// <summary>Wraps raw PCM in a canonical RIFF/WAVE header (little-endian).</summary>
+        public static byte[] BuildWav(byte[] pcm, int sampleRate, int channels, int bitsPerSample)
+        {
+            int byteRate = sampleRate * channels * bitsPerSample / 8;
+            int blockAlign = channels * bitsPerSample / 8;
+
+            using (var ms = new MemoryStream())
+            using (var w = new BinaryWriter(ms))
+            {
+                w.Write(new[] { (byte)'R', (byte)'I', (byte)'F', (byte)'F' });
+                w.Write(36 + pcm.Length);
+                w.Write(new[] { (byte)'W', (byte)'A', (byte)'V', (byte)'E' });
+                w.Write(new[] { (byte)'f', (byte)'m', (byte)'t', (byte)' ' });
+                w.Write(16);                          // fmt chunk size
+                w.Write((short)1);                    // PCM
+                w.Write((short)channels);
+                w.Write(sampleRate);
+                w.Write(byteRate);
+                w.Write((short)blockAlign);
+                w.Write((short)bitsPerSample);
+                w.Write(new[] { (byte)'d', (byte)'a', (byte)'t', (byte)'a' });
+                w.Write(pcm.Length);
+                w.Write(pcm);
+                w.Flush();
+                return ms.ToArray();
+            }
+        }
+
+        /// <summary>Index of the first occurrence of a 4-char tag in [start, start+limit), or -1.</summary>
+        private static int Find(byte[] data, string tag, int start, int limit)
+        {
+            if (data == null) return -1;
+            int end = System.Math.Min(data.Length, start + limit);
+            for (int i = start; i + 4 <= end; i++)
+            {
+                if (data[i] == tag[0] && data[i + 1] == tag[1] && data[i + 2] == tag[2] && data[i + 3] == tag[3])
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        private static int ReadBE(byte[] b, int o)
+        {
+            return (b[o] << 24) | (b[o + 1] << 16) | (b[o + 2] << 8) | b[o + 3];
+        }
+    }
+}

--- a/ScummEditor.Engine/Encoders/ImuseBundleCodecs.cs
+++ b/ScummEditor.Engine/Encoders/ImuseBundleCodecs.cs
@@ -52,6 +52,8 @@ namespace ScummEditor.Engine.Encoders
                     for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
                     for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
 
+                    if (outputSize < 2) return outputSize; // the 12-bit repack needs >= 2 bytes; guard a degenerate/empty block
+
                     var tbl = new byte[outputSize];
                     length = (outputSize << 3) / 12;
                     k = 0;
@@ -88,6 +90,8 @@ namespace ScummEditor.Engine.Encoders
                     outputSize = CompDecode(input, output);
                     for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
                     for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
+
+                    if (outputSize < 2) return outputSize; // the 12-bit repack needs >= 2 bytes; guard a degenerate/empty block
 
                     var tbl = new byte[outputSize];
                     length = (outputSize << 3) / 12;
@@ -126,6 +130,8 @@ namespace ScummEditor.Engine.Encoders
                     for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
                     for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
 
+                    if (outputSize < 2) return outputSize; // the 12-bit repack needs >= 2 bytes; guard a degenerate/empty block
+
                     var tbl = new byte[outputSize];
                     length = (outputSize << 3) / 12;
                     k = 0; c = 0; j = 0; s = -12;
@@ -162,6 +168,8 @@ namespace ScummEditor.Engine.Encoders
                     outputSize = CompDecode(input, output);
                     for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
                     for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
+
+                    if (outputSize < 2) return outputSize; // the 12-bit repack needs >= 2 bytes; guard a degenerate/empty block
 
                     var tbl = new byte[outputSize];
                     System.Array.Copy(output, 0, tbl, 0, outputSize);
@@ -211,6 +219,8 @@ namespace ScummEditor.Engine.Encoders
                     for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
                     for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
 
+                    if (outputSize < 2) return outputSize; // the 12-bit repack needs >= 2 bytes; guard a degenerate/empty block
+
                     var tbl = new byte[outputSize];
                     System.Array.Copy(output, 0, tbl, 0, outputSize);
 
@@ -256,6 +266,8 @@ namespace ScummEditor.Engine.Encoders
                     outputSize = CompDecode(input, output);
                     for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
                     for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
+
+                    if (outputSize < 2) return outputSize; // the 12-bit repack needs >= 2 bytes; guard a degenerate/empty block
 
                     var tbl = new byte[outputSize];
                     System.Array.Copy(output, 0, tbl, 0, outputSize);
@@ -354,6 +366,7 @@ namespace ScummEditor.Engine.Encoders
                         }
                     }
                     int result = dstptr + data; // data is negative -> back-reference
+                    if (result < 0) return dstptr; // malformed stream: invalid back-reference, stop gracefully
                     while (size-- != 0)
                     {
                         dst[dstptr++] = dst[result++];

--- a/ScummEditor.Engine/Encoders/ImuseBundleCodecs.cs
+++ b/ScummEditor.Engine/Encoders/ImuseBundleCodecs.cs
@@ -1,0 +1,365 @@
+namespace ScummEditor.Engine.Encoders
+{
+    /// <summary>
+    /// Decompresses the per-block COMP codecs used inside SCUMM v7 iMUSE bundles (The Dig's DIGMUSIC.BUN /
+    /// DIGVOICE.BUN). A direct port of ScummVM's BundleCodecs (dimuse_codecs.cpp): compDecode is the LZ77
+    /// inner decoder; decompressCodec dispatches codecs 0-12 = raw / LZ77 / 1st- &amp; 2nd-order delta /
+    /// delta + 12-bit nibble repack. The shipped Dig bundles use only 0-12 (verified); the IMA-ADPCM
+    /// "VIMA" codecs 13/15 are CMI-only and not implemented. Concatenating the decompressed blocks of an
+    /// entry rebuilds its iMUS resource, which ImuseAudioDecoder then turns into WAV.
+    /// </summary>
+    public static class ImuseBundleCodecs
+    {
+        /// <summary>True for the codecs this port can decompress (everything the Dig/FT bundles use).</summary>
+        public static bool CanDecode(int codec)
+        {
+            return codec >= 0 && codec <= 12;
+        }
+
+        /// <summary>
+        /// Decompresses one COMP block. <paramref name="output"/> must hold at least 0x2000 bytes (the
+        /// bundle chunk size); returns the number of bytes written. Throws for the unsupported VIMA codecs.
+        /// </summary>
+        public static int DecompressCodec(int codec, byte[] input, int inputSize, byte[] output)
+        {
+            int outputSize;
+            int offset1, offset2, offset3, length, k, c, s, j, r, t, z;
+            byte tmp1, tmp2;
+
+            switch (codec)
+            {
+                case 0:
+                    System.Array.Copy(input, 0, output, 0, inputSize);
+                    return inputSize;
+
+                case 1:
+                    return CompDecode(input, output);
+
+                case 2:
+                    outputSize = CompDecode(input, output);
+                    for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
+                    return outputSize;
+
+                case 3:
+                    outputSize = CompDecode(input, output);
+                    for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
+                    for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
+                    return outputSize;
+
+                case 4:
+                {
+                    outputSize = CompDecode(input, output);
+                    for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
+                    for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
+
+                    var tbl = new byte[outputSize];
+                    length = (outputSize << 3) / 12;
+                    k = 0;
+                    if (length > 0)
+                    {
+                        c = -12; s = 0; j = 0;
+                        do
+                        {
+                            int ptr = length + (k >> 1);
+                            tmp2 = output[j];
+                            if ((k & 1) != 0)
+                            {
+                                r = c >> 3;
+                                tbl[r + 2] = (byte)(((tmp2 & 0x0f) << 4) | (output[ptr + 1] >> 4));
+                                tbl[r + 1] = (byte)((tmp2 & 0xf0) | tbl[r + 1]);
+                            }
+                            else
+                            {
+                                r = s >> 3;
+                                tbl[r + 0] = (byte)(((tmp2 & 0x0f) << 4) | (output[ptr + 0] & 0x0f));
+                                tbl[r + 1] = (byte)(tmp2 >> 4);
+                            }
+                            s += 12; c += 12; k++; j++;
+                        } while (k < length);
+                    }
+                    offset1 = ((length - 1) * 3) >> 1;
+                    tbl[offset1 + 1] = (byte)(tbl[offset1 + 1] | (output[length - 1] & 0xf0));
+                    System.Array.Copy(tbl, 0, output, 0, outputSize);
+                    return outputSize;
+                }
+
+                case 5:
+                {
+                    outputSize = CompDecode(input, output);
+                    for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
+                    for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
+
+                    var tbl = new byte[outputSize];
+                    length = (outputSize << 3) / 12;
+                    k = 1; c = 0; s = 12;
+                    tbl[0] = (byte)(output[length] >> 4);
+                    t = length + k;
+                    j = 1;
+                    if (t > k)
+                    {
+                        do
+                        {
+                            tmp1 = output[length + (k >> 1)];
+                            tmp2 = output[j - 1];
+                            if ((k & 1) != 0)
+                            {
+                                r = c >> 3;
+                                tbl[r + 0] = (byte)((tmp2 & 0xf0) | tbl[r]);
+                                tbl[r + 1] = (byte)(((tmp2 & 0x0f) << 4) | (tmp1 & 0x0f));
+                            }
+                            else
+                            {
+                                r = s >> 3;
+                                tbl[r + 0] = (byte)(tmp2 >> 4);
+                                tbl[r - 1] = (byte)(((tmp2 & 0x0f) << 4) | (tmp1 >> 4));
+                            }
+                            s += 12; c += 12; k++; j++;
+                        } while (k < t);
+                    }
+                    System.Array.Copy(tbl, 0, output, 0, outputSize);
+                    return outputSize;
+                }
+
+                case 6:
+                {
+                    outputSize = CompDecode(input, output);
+                    for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
+                    for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
+
+                    var tbl = new byte[outputSize];
+                    length = (outputSize << 3) / 12;
+                    k = 0; c = 0; j = 0; s = -12;
+                    tbl[0] = output[outputSize - 1];
+                    tbl[outputSize - 1] = output[length - 1];
+                    t = length - 1;
+                    if (t > 0)
+                    {
+                        do
+                        {
+                            tmp1 = output[length + (k >> 1)];
+                            tmp2 = output[j];
+                            if ((k & 1) != 0)
+                            {
+                                r = s >> 3;
+                                tbl[r + 2] = (byte)((tmp2 & 0xf0) | tbl[r + 2]);
+                                tbl[r + 3] = (byte)(((tmp2 & 0x0f) << 4) | (tmp1 >> 4));
+                            }
+                            else
+                            {
+                                r = c >> 3;
+                                tbl[r + 2] = (byte)(tmp2 >> 4);
+                                tbl[r + 1] = (byte)(((tmp2 & 0x0f) << 4) | (tmp1 & 0x0f));
+                            }
+                            s += 12; c += 12; k++; j++;
+                        } while (k < t);
+                    }
+                    System.Array.Copy(tbl, 0, output, 0, outputSize);
+                    return outputSize;
+                }
+
+                case 10:
+                {
+                    outputSize = CompDecode(input, output);
+                    for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
+                    for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
+
+                    var tbl = new byte[outputSize];
+                    System.Array.Copy(output, 0, tbl, 0, outputSize);
+
+                    offset1 = outputSize / 3; offset2 = offset1 << 1; offset3 = offset2;
+                    while (offset1-- != 0)
+                    {
+                        offset2 -= 2; offset3--;
+                        tbl[offset2 + 0] = output[offset1];
+                        tbl[offset2 + 1] = output[offset3];
+                    }
+
+                    length = (outputSize << 3) / 12;
+                    k = 0;
+                    if (length > 0)
+                    {
+                        c = -12; s = 0;
+                        do
+                        {
+                            j = length + (k >> 1);
+                            tmp1 = tbl[k];
+                            if ((k & 1) != 0)
+                            {
+                                r = c >> 3;
+                                tmp2 = tbl[j + 1];
+                                output[r + 2] = (byte)(((tmp1 & 0x0f) << 4) | (tmp2 >> 4));
+                                output[r + 1] = (byte)(output[r + 1] | (tmp1 & 0xf0));
+                            }
+                            else
+                            {
+                                r = s >> 3;
+                                tmp2 = tbl[j];
+                                output[r + 0] = (byte)(((tmp1 & 0x0f) << 4) | (tmp2 & 0x0f));
+                                output[r + 1] = (byte)(tmp1 >> 4);
+                            }
+                            s += 12; c += 12; k++;
+                        } while (k < length);
+                    }
+                    offset1 = ((length - 1) * 3) >> 1;
+                    output[offset1 + 1] = (byte)((tbl[length] & 0xf0) | output[offset1 + 1]);
+                    return outputSize;
+                }
+
+                case 11:
+                {
+                    outputSize = CompDecode(input, output);
+                    for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
+                    for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
+
+                    var tbl = new byte[outputSize];
+                    System.Array.Copy(output, 0, tbl, 0, outputSize);
+
+                    offset1 = outputSize / 3; offset2 = offset1 << 1; offset3 = offset2;
+                    while (offset1-- != 0)
+                    {
+                        offset2 -= 2; offset3--;
+                        tbl[offset2 + 0] = output[offset1];
+                        tbl[offset2 + 1] = output[offset3];
+                    }
+
+                    length = (outputSize << 3) / 12;
+                    k = 1; c = 0; s = 12;
+                    output[0] = (byte)(tbl[length] >> 4);
+                    t = length + k;
+                    if (t > k)
+                    {
+                        do
+                        {
+                            j = length + (k >> 1);
+                            tmp1 = tbl[k - 1];
+                            tmp2 = tbl[j];
+                            if ((k & 1) != 0)
+                            {
+                                r = c >> 3;
+                                output[r + 0] = (byte)(output[r] | (tmp1 & 0xf0));
+                                output[r + 1] = (byte)(((tmp1 & 0x0f) << 4) | (tmp2 & 0x0f));
+                            }
+                            else
+                            {
+                                r = s >> 3;
+                                output[r + 0] = (byte)(tmp1 >> 4);
+                                output[r - 1] = (byte)(((tmp1 & 0x0f) << 4) | (tmp2 >> 4));
+                            }
+                            s += 12; c += 12; k++;
+                        } while (k < t);
+                    }
+                    return outputSize;
+                }
+
+                case 12:
+                {
+                    outputSize = CompDecode(input, output);
+                    for (z = 2; z < outputSize; z++) output[z] += output[z - 1];
+                    for (z = 1; z < outputSize; z++) output[z] += output[z - 1];
+
+                    var tbl = new byte[outputSize];
+                    System.Array.Copy(output, 0, tbl, 0, outputSize);
+
+                    offset1 = outputSize / 3; offset2 = offset1 << 1; offset3 = offset2;
+                    while (offset1-- != 0)
+                    {
+                        offset2 -= 2; offset3--;
+                        tbl[offset2 + 0] = output[offset1];
+                        tbl[offset2 + 1] = output[offset3];
+                    }
+
+                    length = (outputSize << 3) / 12;
+                    k = 0; c = 0; s = -12;
+                    output[0] = tbl[outputSize - 1];
+                    output[outputSize - 1] = tbl[length - 1];
+                    t = length - 1;
+                    if (t > 0)
+                    {
+                        do
+                        {
+                            j = length + (k >> 1);
+                            tmp1 = tbl[k];
+                            tmp2 = tbl[j];
+                            if ((k & 1) != 0)
+                            {
+                                r = s >> 3;
+                                output[r + 2] = (byte)(output[r + 2] | (tmp1 & 0xf0));
+                                output[r + 3] = (byte)(((tmp1 & 0x0f) << 4) | (tmp2 >> 4));
+                            }
+                            else
+                            {
+                                r = c >> 3;
+                                output[r + 2] = (byte)(tmp1 >> 4);
+                                output[r + 1] = (byte)(((tmp1 & 0x0f) << 4) | (tmp2 & 0x0f));
+                            }
+                            s += 12; c += 12; k++;
+                        } while (k < t);
+                    }
+                    return outputSize;
+                }
+
+                default:
+                    throw new System.NotSupportedException("iMUSE bundle codec " + codec + " is not supported (VIMA 13/15 are CMI-only)");
+            }
+        }
+
+        /// <summary>The LZ77 inner decoder (ScummVM compDecode): a bit-stream of literals and back-references.</summary>
+        private static int CompDecode(byte[] src, byte[] dst)
+        {
+            int srcptr = 0, dstptr = 0;
+            int bitsleft = 16;
+            int mask = src[srcptr] | (src[srcptr + 1] << 8);
+            srcptr += 2;
+
+            int NextBit()
+            {
+                int b = mask & 1;
+                mask >>= 1;
+                if (--bitsleft == 0)
+                {
+                    mask = src[srcptr] | (src[srcptr + 1] << 8);
+                    srcptr += 2;
+                    bitsleft = 16;
+                }
+                return b;
+            }
+
+            for (;;)
+            {
+                if (NextBit() != 0)
+                {
+                    dst[dstptr++] = src[srcptr++];
+                }
+                else
+                {
+                    int data, size;
+                    if (NextBit() == 0)
+                    {
+                        size = NextBit() << 1;
+                        size = (size | NextBit()) + 3;
+                        data = src[srcptr++] - 256; // byte | 0xffffff00
+                    }
+                    else
+                    {
+                        data = src[srcptr++];
+                        size = src[srcptr++];
+                        data |= unchecked((int)(0xfffff000u + (uint)((size & 0xf0) << 4)));
+                        size = (size & 0x0f) + 3;
+                        if (size == 3)
+                        {
+                            if ((src[srcptr++] + 1) == 1)
+                            {
+                                return dstptr;
+                            }
+                        }
+                    }
+                    int result = dstptr + data; // data is negative -> back-reference
+                    while (size-- != 0)
+                    {
+                        dst[dstptr++] = dst[result++];
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ScummEditor.Engine/Encoders/ImuseBundleDecoder.cs
+++ b/ScummEditor.Engine/Encoders/ImuseBundleDecoder.cs
@@ -41,24 +41,36 @@ namespace ScummEditor.Engine.Encoders
 
             var imus = new MemoryStream();
             var output = new byte[BundleChunkSize + 16]; // a little slack over the chunk size
-            var blockInput = new byte[1];
+            var blockInput = new byte[2];
 
-            for (int i = 0; i < numBlocks; i++)
+            try
             {
-                int rec = tableStart + i * 16;
-                int blockOffset = ReadBE(comp, rec);
-                int blockSize = ReadBE(comp, rec + 4);
-                int codec = ReadBE(comp, rec + 8);
-                if (!ImuseBundleCodecs.CanDecode(codec)) return null; // VIMA / unknown
-                if (blockOffset < 0 || blockSize < 0 || blockOffset + blockSize > comp.Length) return null;
+                for (int i = 0; i < numBlocks; i++)
+                {
+                    int rec = tableStart + i * 16;
+                    int blockOffset = ReadBE(comp, rec);
+                    int blockSize = ReadBE(comp, rec + 4);
+                    int codec = ReadBE(comp, rec + 8);
+                    if (!ImuseBundleCodecs.CanDecode(codec)) return null; // VIMA / unknown
+                    if (blockOffset < 0 || blockSize < 0 || blockOffset + blockSize > comp.Length) return null;
 
-                // Copy the block to its own buffer with one trailing zero byte (the ScummVM CMI over-read guard).
-                if (blockInput.Length < blockSize + 1) blockInput = new byte[blockSize + 1];
-                System.Array.Copy(comp, blockOffset, blockInput, 0, blockSize);
-                blockInput[blockSize] = 0;
+                    // Copy the block to its own buffer with TWO trailing zero bytes: the LZ77 reader refills
+                    // its 16-bit mask by reading two bytes, so a single guard byte (the ScummVM CMI trick)
+                    // could still over-read by one at the very end.
+                    if (blockInput.Length < blockSize + 2) blockInput = new byte[blockSize + 2];
+                    System.Array.Copy(comp, blockOffset, blockInput, 0, blockSize);
+                    blockInput[blockSize] = 0;
+                    blockInput[blockSize + 1] = 0;
 
-                int outSize = ImuseBundleCodecs.DecompressCodec(codec, blockInput, blockSize, output);
-                if (outSize > 0) imus.Write(output, 0, outSize);
+                    int outSize = ImuseBundleCodecs.DecompressCodec(codec, blockInput, blockSize, output);
+                    if (outSize > 0) imus.Write(output, 0, outSize);
+                }
+            }
+            catch (System.Exception)
+            {
+                // A malformed/truncated COMP block can still run a codec off the end; treat the whole entry
+                // as undecodable rather than crashing the viewer (real Dig/FT bundles never hit this).
+                return null;
             }
 
             return imus.ToArray();

--- a/ScummEditor.Engine/Encoders/ImuseBundleDecoder.cs
+++ b/ScummEditor.Engine/Encoders/ImuseBundleDecoder.cs
@@ -1,0 +1,85 @@
+using System.IO;
+
+namespace ScummEditor.Engine.Encoders
+{
+    /// <summary>
+    /// Turns a raw iMUSE-bundle entry (a COMP-compressed chunk, or a plain iMUS resource) into its
+    /// decompressed iMUS resource, and from there into a PCM WAV. The COMP chunk holds a table of blocks,
+    /// each compressed with one of codecs 0-12 (ImuseBundleCodecs); concatenating the decompressed blocks
+    /// rebuilds the iMUS resource, which ImuseAudioDecoder converts to WAV. Mirrors ScummVM
+    /// dimuse_bndmgr.cpp loadCompTable/readFile (block offsets are relative to the entry start).
+    /// </summary>
+    public static class ImuseBundleDecoder
+    {
+        private const int BundleChunkSize = 0x2000; // DIMUSE_BUN_CHUNK_SIZE: each block decompresses to <= this
+
+        /// <summary>
+        /// Decompresses a bundle entry's COMP chunk to its full iMUS resource bytes, or returns the bytes
+        /// unchanged when the entry is already a plain iMUS. Returns null when it is neither, or when a
+        /// block uses an unsupported codec (VIMA 13/15).
+        /// </summary>
+        public static byte[] DecodeToImus(byte[] comp)
+        {
+            if (comp == null || comp.Length < 4) return null;
+
+            string tag = Tag(comp, 0);
+            if (tag == "iMUS")
+            {
+                return comp; // uncompressed entry
+            }
+            if (tag != "COMP" || comp.Length < 16)
+            {
+                return null;
+            }
+
+            int numBlocks = ReadBE(comp, 4);
+            // comp[8..11] padding, comp[12..15] last-block decompressed size (unused for a full extraction).
+            if (numBlocks <= 0) return null;
+
+            int tableStart = 16;
+            if (tableStart + numBlocks * 16 > comp.Length) return null;
+
+            var imus = new MemoryStream();
+            var output = new byte[BundleChunkSize + 16]; // a little slack over the chunk size
+            var blockInput = new byte[1];
+
+            for (int i = 0; i < numBlocks; i++)
+            {
+                int rec = tableStart + i * 16;
+                int blockOffset = ReadBE(comp, rec);
+                int blockSize = ReadBE(comp, rec + 4);
+                int codec = ReadBE(comp, rec + 8);
+                if (!ImuseBundleCodecs.CanDecode(codec)) return null; // VIMA / unknown
+                if (blockOffset < 0 || blockSize < 0 || blockOffset + blockSize > comp.Length) return null;
+
+                // Copy the block to its own buffer with one trailing zero byte (the ScummVM CMI over-read guard).
+                if (blockInput.Length < blockSize + 1) blockInput = new byte[blockSize + 1];
+                System.Array.Copy(comp, blockOffset, blockInput, 0, blockSize);
+                blockInput[blockSize] = 0;
+
+                int outSize = ImuseBundleCodecs.DecompressCodec(codec, blockInput, blockSize, output);
+                if (outSize > 0) imus.Write(output, 0, outSize);
+            }
+
+            return imus.ToArray();
+        }
+
+        /// <summary>Decompresses a bundle entry and decodes its iMUS resource to a PCM WAV (null if it cannot).</summary>
+        public static byte[] ToWav(byte[] comp)
+        {
+            byte[] imus = DecodeToImus(comp);
+            return imus == null ? null : ImuseAudioDecoder.ToWav(imus);
+        }
+
+        private static string Tag(byte[] b, int o)
+        {
+            if (o + 4 > b.Length) return string.Empty;
+            return string.Concat((char)b[o], (char)b[o + 1], (char)b[o + 2], (char)b[o + 3]);
+        }
+
+        private static int ReadBE(byte[] b, int o)
+        {
+            return (b[o] << 24) | (b[o + 1] << 16) | (b[o + 2] << 8) | b[o + 3];
+        }
+    }
+}

--- a/ScummEditor.Engine/Encoders/NutFontPngCodec.cs
+++ b/ScummEditor.Engine/Encoders/NutFontPngCodec.cs
@@ -43,8 +43,10 @@ namespace ScummEditor.Engine.Encoders
         // ---- whole-font atlas (batch) ----
 
         /// <summary>Exports every decodable glyph as a grid (16 columns) of fixed cells sized to the font's
-        /// largest glyph; each glyph sits at the top-left of its cell, the rest left transparent.</summary>
-        public static void ExportPng(NutFont font, string pngPath, Color[] palette)
+        /// largest glyph; each glyph sits at the top-left of its cell, the rest left transparent. When
+        /// <paramref name="guidePath"/> is given, a companion guide image (cell grid + glyph-index labels +
+        /// a faint reference of each glyph) is written too, like the CHAR/v3 font exporters.</summary>
+        public static void ExportPng(NutFont font, string pngPath, string guidePath, Color[] palette)
         {
             int cellW, cellH, cols, rows, transparency;
             List<int> drawable = AtlasLayout(font, out cellW, out cellH, out cols, out rows, out transparency);
@@ -74,6 +76,51 @@ namespace ScummEditor.Engine.Encoders
             }
 
             SaveIndexed(atlas, palette ?? Grayscale(), pngPath);
+
+            if (guidePath != null)
+            {
+                using (Bitmap guide = BuildGuide(font, drawable, cellW, cellH, cols, rows))
+                {
+                    guide.Save(guidePath, ImageFormat.Png);
+                }
+            }
+        }
+
+        /// <summary>
+        /// A companion reference image (RGB, same grid as the atlas): each cell outlined, labelled with the
+        /// glyph index, and showing a faint copy of the original glyph - so a translator knows which cell is
+        /// which glyph and where the ink sits. Mirrors the CHAR/v3 font exporters' .guide.png.
+        /// </summary>
+        private static Bitmap BuildGuide(NutFont font, List<int> drawable, int cellW, int cellH, int cols, int rows)
+        {
+            var bitmap = new Bitmap(cols * cellW, rows * cellH, PixelFormat.Format24bppRgb);
+            using (Graphics gfx = Graphics.FromImage(bitmap))
+            using (var gridPen = new Pen(Color.FromArgb(60, 80, 160)))
+            using (var idFont = new Font("Consolas", 6f))
+            using (var idBrush = new SolidBrush(Color.Red))
+            {
+                gfx.Clear(Color.White);
+
+                // A flat-gray palette renders each glyph as a faint reference under the grid/labels.
+                var refPalette = new Color[256];
+                for (int i = 0; i < 256; i++) refPalette[i] = Color.FromArgb(150, 150, 150);
+
+                for (int slot = 0; slot < drawable.Count; slot++)
+                {
+                    int gi = drawable[slot];
+                    int cx = (slot % cols) * cellW;
+                    int cy = (slot / cols) * cellH;
+
+                    using (Bitmap glyph = NutImageDecoder.DecodeGlyph(font, gi, refPalette))
+                    {
+                        if (glyph != null) gfx.DrawImageUnscaled(glyph, cx, cy);
+                    }
+
+                    gfx.DrawRectangle(gridPen, cx, cy, cellW - 1, cellH - 1);
+                    gfx.DrawString(gi.ToString(), idFont, idBrush, cx + 1, cy + 1);
+                }
+            }
+            return bitmap;
         }
 
         /// <summary>Imports a whole-font atlas: each decodable glyph is read from the top-left of its cell
@@ -124,9 +171,10 @@ namespace ScummEditor.Engine.Encoders
             for (int i = 0; i < fonts.Count; i++)
             {
                 string name = BatchFileName(fonts[i], i);
+                string guide = Path.ChangeExtension(name, null) + ".guide.png";
                 try
                 {
-                    ExportPng(fonts[i].Font, Path.Combine(folder, name), null);
+                    ExportPng(fonts[i].Font, Path.Combine(folder, name), Path.Combine(folder, guide), null);
                     count++;
                 }
                 catch (ImageEncodeException ex)

--- a/ScummEditor.Engine/Encoders/NutFontPngCodec.cs
+++ b/ScummEditor.Engine/Encoders/NutFontPngCodec.cs
@@ -133,7 +133,9 @@ namespace ScummEditor.Engine.Encoders
                     }
 
                     gfx.DrawRectangle(gridPen, cx, cy, cellW - 1, cellH - 1);
-                    gfx.DrawString(gi.ToString(), idFont, idBrush, cx + 1, cy + 1);
+                    // Hexadecimal glyph index, like the CHAR/v3 guide labels - it IS the character code the
+                    // game scripts reference, so the numbering must match the scripts and the other fonts.
+                    gfx.DrawString(gi.ToString("X2"), idFont, idBrush, cx + 1, cy + 1);
                 }
             }
             return bitmap;

--- a/ScummEditor.Engine/Encoders/NutFontPngCodec.cs
+++ b/ScummEditor.Engine/Encoders/NutFontPngCodec.cs
@@ -1,0 +1,232 @@
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using ScummEditor.Engine.Exceptions;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+
+namespace ScummEditor.Engine.Encoders
+{
+    /// <summary>
+    /// Exports a SCUMM v7 .NUT SMUSH font to an editable indexed PNG and imports it back. Two granularities
+    /// are offered: a single glyph (for the per-glyph GUI Export/Import) and a whole-font atlas (a grid of
+    /// all glyphs, used by the batch "game fonts" dialog). The PNG is 8bpp indexed and carries the raw
+    /// palette indices, so the round-trip is palette-independent (the displayed colours are only a preview);
+    /// re-import re-encodes each glyph through <see cref="NutImageEncoder"/>, keeping every glyph's size.
+    /// </summary>
+    public static class NutFontPngCodec
+    {
+        private const int AtlasColumns = 16;
+
+        // ---- single glyph (per-node GUI) ----
+
+        public static void ExportGlyphPng(NutFont font, int index, string pngPath, Color[] palette)
+        {
+            byte[,] indices = NutImageDecoder.DecodeGlyphIndices(font, index);
+            if (indices == null)
+            {
+                throw new ImageEncodeException("NUT glyph #" + index + " has no decodable pixels");
+            }
+            SaveIndexed(indices, palette ?? Grayscale(), pngPath);
+        }
+
+        public static void ImportGlyphPng(NutFont font, int index, string pngPath)
+        {
+            using (var bitmap = (Bitmap)Image.FromFile(pngPath))
+            {
+                RequireIndexed(bitmap);
+                NutImageEncoder.ReplaceGlyph(font, index, IndexedImageHelper.GetIndexMatrix(bitmap));
+            }
+        }
+
+        // ---- whole-font atlas (batch) ----
+
+        /// <summary>Exports every decodable glyph as a grid (16 columns) of fixed cells sized to the font's
+        /// largest glyph; each glyph sits at the top-left of its cell, the rest left transparent.</summary>
+        public static void ExportPng(NutFont font, string pngPath, Color[] palette)
+        {
+            int cellW, cellH, cols, rows, transparency;
+            List<int> drawable = AtlasLayout(font, out cellW, out cellH, out cols, out rows, out transparency);
+            if (drawable.Count == 0)
+            {
+                throw new ImageEncodeException("NUT font has no decodable glyphs to export");
+            }
+
+            var atlas = new byte[cols * cellW, rows * cellH];
+            if (transparency != 0)
+            {
+                for (int x = 0; x < atlas.GetLength(0); x++)
+                    for (int y = 0; y < atlas.GetLength(1); y++)
+                        atlas[x, y] = (byte)transparency;
+            }
+
+            for (int slot = 0; slot < drawable.Count; slot++)
+            {
+                int gi = drawable[slot];
+                byte[,] g = NutImageDecoder.DecodeGlyphIndices(font, gi);
+                if (g == null) continue;
+                int ox = (slot % cols) * cellW;
+                int oy = (slot / cols) * cellH;
+                for (int x = 0; x < g.GetLength(0); x++)
+                    for (int y = 0; y < g.GetLength(1); y++)
+                        atlas[ox + x, oy + y] = g[x, y];
+            }
+
+            SaveIndexed(atlas, palette ?? Grayscale(), pngPath);
+        }
+
+        /// <summary>Imports a whole-font atlas: each decodable glyph is read from the top-left of its cell
+        /// (at the glyph's stored width x height) and re-encoded. The atlas must match the export layout.</summary>
+        public static void ImportPng(NutFont font, string pngPath)
+        {
+            int cellW, cellH, cols, rows, transparency;
+            List<int> drawable = AtlasLayout(font, out cellW, out cellH, out cols, out rows, out transparency);
+            if (drawable.Count == 0)
+            {
+                throw new ImageEncodeException("NUT font has no decodable glyphs to import");
+            }
+
+            using (var bitmap = (Bitmap)Image.FromFile(pngPath))
+            {
+                RequireIndexed(bitmap);
+                if (bitmap.Width < cols * cellW || bitmap.Height < rows * cellH)
+                {
+                    throw new ImageEncodeException(string.Format(
+                        "atlas is {0}x{1}; this font needs at least {2}x{3}",
+                        bitmap.Width, bitmap.Height, cols * cellW, rows * cellH));
+                }
+
+                byte[,] atlas = IndexedImageHelper.GetIndexMatrix(bitmap);
+                for (int slot = 0; slot < drawable.Count; slot++)
+                {
+                    int gi = drawable[slot];
+                    NutGlyph glyph = font.Glyphs[gi];
+                    int ox = (slot % cols) * cellW;
+                    int oy = (slot / cols) * cellH;
+
+                    var cell = new byte[glyph.Width, glyph.Height];
+                    for (int x = 0; x < glyph.Width; x++)
+                        for (int y = 0; y < glyph.Height; y++)
+                            cell[x, y] = atlas[ox + x, oy + y];
+
+                    NutImageEncoder.ReplaceGlyph(font, gi, cell);
+                }
+            }
+        }
+
+        // ---- batch over many fonts ----
+
+        public static string ExportAll(List<NutFontResource> fonts, string folder)
+        {
+            int count = 0;
+            var errors = new List<string>();
+            for (int i = 0; i < fonts.Count; i++)
+            {
+                string name = BatchFileName(fonts[i], i);
+                try
+                {
+                    ExportPng(fonts[i].Font, Path.Combine(folder, name), null);
+                    count++;
+                }
+                catch (ImageEncodeException ex)
+                {
+                    errors.Add(name + ": " + ex.Message);
+                }
+            }
+            return Report("Exported", count, fonts.Count, errors);
+        }
+
+        public static string ImportAll(List<NutFontResource> fonts, string folder)
+        {
+            int count = 0;
+            var errors = new List<string>();
+            for (int i = 0; i < fonts.Count; i++)
+            {
+                string name = BatchFileName(fonts[i], i);
+                string path = Path.Combine(folder, name);
+                if (!File.Exists(path))
+                {
+                    continue; // not every font has to be edited
+                }
+                try
+                {
+                    ImportPng(fonts[i].Font, path);
+                    count++;
+                }
+                catch (ImageEncodeException ex)
+                {
+                    errors.Add(name + ": " + ex.Message);
+                }
+            }
+            return Report("Imported", count, fonts.Count, errors);
+        }
+
+        /// <summary>The batch PNG name for a font: an index prefix keeps it unique (a game can ship two NUT
+        /// files with the same base name in different subfolders, e.g. Full Throttle's TITLFNT.NUT), while
+        /// the base name keeps it readable. Import reconstructs the same name from the font list order.</summary>
+        private static string BatchFileName(NutFontResource resource, int index)
+        {
+            return string.Format("nutfont_{0:D2}_{1}.png", index, Path.GetFileNameWithoutExtension(resource.FilePath));
+        }
+
+        // ---- helpers ----
+
+        /// <summary>Computes the atlas grid: the list of glyph indexes that have pixels, the cell size
+        /// (the largest glyph), the column/row counts and the transparent index.</summary>
+        private static List<int> AtlasLayout(NutFont font, out int cellW, out int cellH, out int cols, out int rows, out int transparency)
+        {
+            var drawable = new List<int>();
+            cellW = 1; cellH = 1; transparency = 0;
+            for (int i = 0; i < font.Glyphs.Count; i++)
+            {
+                NutGlyph g = font.Glyphs[i];
+                if (!g.HasPixels || !NutImageDecoder.IsSupportedCodec(g.Codec)) continue;
+                drawable.Add(i);
+                if (g.Width > cellW) cellW = g.Width;
+                if (g.Height > cellH) cellH = g.Height;
+                transparency = NutImageDecoder.TransparencyIndex(g.Codec); // one codec per NUT file
+            }
+            cols = drawable.Count < AtlasColumns ? (drawable.Count == 0 ? 1 : drawable.Count) : AtlasColumns;
+            rows = drawable.Count == 0 ? 1 : (drawable.Count + cols - 1) / cols;
+            return drawable;
+        }
+
+        private static void SaveIndexed(byte[,] indices, Color[] palette, string pngPath)
+        {
+            // Save as a plain opaque 8bpp indexed PNG (no tRNS): a transparent palette entry makes GDI+
+            // reload the file as 32bpp, which would lose the raw indices. Transparent pixels keep their
+            // index value (0, or 2 for codec 44) and read back losslessly; the encoder treats those indices
+            // as transparent again. (The on-screen preview applies real transparency separately.)
+            using (Bitmap bitmap = IndexedImageHelper.FromIndexMatrix(indices, palette, -1))
+            {
+                bitmap.Save(pngPath, ImageFormat.Png);
+            }
+        }
+
+        private static void RequireIndexed(Bitmap bitmap)
+        {
+            if (!IndexedImageHelper.IsIndexed(bitmap))
+            {
+                throw new ImageEncodeException("NUT font PNG must be an indexed image (re-export it and edit without converting to RGB)");
+            }
+        }
+
+        private static Color[] Grayscale()
+        {
+            var palette = new Color[256];
+            for (int i = 0; i < 256; i++) palette[i] = Color.FromArgb(i, i, i);
+            return palette;
+        }
+
+        private static string Report(string verb, int count, int total, List<string> errors)
+        {
+            string report = verb + " " + count + " of " + total + " NUT font(s).";
+            if (errors.Count > 0)
+            {
+                report += "\r\n\r\nSkipped:\r\n" + string.Join("\r\n", errors);
+            }
+            return report;
+        }
+    }
+}

--- a/ScummEditor.Engine/Encoders/NutFontPngCodec.cs
+++ b/ScummEditor.Engine/Encoders/NutFontPngCodec.cs
@@ -19,6 +19,14 @@ namespace ScummEditor.Engine.Encoders
     {
         private const int AtlasColumns = 16;
 
+        // Each cell carries a 1px gutter on its top/left edge that holds the grid divider line; the glyph
+        // sits just past the gutter, so the grid never overlaps a glyph and the gutter is never read back on
+        // import. The grid index lives only in the gutter, so any value is safe; 255 is coloured visibly in
+        // the exported atlas (NUT font ink is typically a different index, e.g. 240-242).
+        private const int GridGutter = 1;
+        private const int GridIndex = 255;
+        private static readonly Color GridColor = Color.FromArgb(0, 170, 210); // cyan: visible on any glyph palette
+
         // ---- single glyph (per-node GUI) ----
 
         public static void ExportGlyphPng(NutFont font, int index, string pngPath, Color[] palette)
@@ -55,27 +63,35 @@ namespace ScummEditor.Engine.Encoders
                 throw new ImageEncodeException("NUT font has no decodable glyphs to export");
             }
 
-            var atlas = new byte[cols * cellW, rows * cellH];
+            int atlasW = cols * cellW, atlasH = rows * cellH;
+            var atlas = new byte[atlasW, atlasH];
             if (transparency != 0)
             {
-                for (int x = 0; x < atlas.GetLength(0); x++)
-                    for (int y = 0; y < atlas.GetLength(1); y++)
+                for (int x = 0; x < atlasW; x++)
+                    for (int y = 0; y < atlasH; y++)
                         atlas[x, y] = (byte)transparency;
             }
+
+            // Grid divider lines on every cell's top/left edge (the gutter). Glyphs are placed past the
+            // gutter, so the grid never overlaps a glyph, and import reads only the glyph area.
+            for (int gx = 0; gx < atlasW; gx += cellW)
+                for (int y = 0; y < atlasH; y++) atlas[gx, y] = GridIndex;
+            for (int gy = 0; gy < atlasH; gy += cellH)
+                for (int x = 0; x < atlasW; x++) atlas[x, gy] = GridIndex;
 
             for (int slot = 0; slot < drawable.Count; slot++)
             {
                 int gi = drawable[slot];
                 byte[,] g = NutImageDecoder.DecodeGlyphIndices(font, gi);
                 if (g == null) continue;
-                int ox = (slot % cols) * cellW;
-                int oy = (slot / cols) * cellH;
+                int ox = (slot % cols) * cellW + GridGutter;
+                int oy = (slot / cols) * cellH + GridGutter;
                 for (int x = 0; x < g.GetLength(0); x++)
                     for (int y = 0; y < g.GetLength(1); y++)
                         atlas[ox + x, oy + y] = g[x, y];
             }
 
-            SaveIndexed(atlas, palette ?? Grayscale(), pngPath);
+            SaveIndexed(atlas, WithGridColor(palette ?? Grayscale()), pngPath);
 
             if (guidePath != null)
             {
@@ -113,7 +129,7 @@ namespace ScummEditor.Engine.Encoders
 
                     using (Bitmap glyph = NutImageDecoder.DecodeGlyph(font, gi, refPalette))
                     {
-                        if (glyph != null) gfx.DrawImageUnscaled(glyph, cx, cy);
+                        if (glyph != null) gfx.DrawImageUnscaled(glyph, cx + GridGutter, cy + GridGutter);
                     }
 
                     gfx.DrawRectangle(gridPen, cx, cy, cellW - 1, cellH - 1);
@@ -149,8 +165,8 @@ namespace ScummEditor.Engine.Encoders
                 {
                     int gi = drawable[slot];
                     NutGlyph glyph = font.Glyphs[gi];
-                    int ox = (slot % cols) * cellW;
-                    int oy = (slot / cols) * cellH;
+                    int ox = (slot % cols) * cellW + GridGutter;
+                    int oy = (slot / cols) * cellH + GridGutter;
 
                     var cell = new byte[glyph.Width, glyph.Height];
                     for (int x = 0; x < glyph.Width; x++)
@@ -225,16 +241,20 @@ namespace ScummEditor.Engine.Encoders
         private static List<int> AtlasLayout(NutFont font, out int cellW, out int cellH, out int cols, out int rows, out int transparency)
         {
             var drawable = new List<int>();
-            cellW = 1; cellH = 1; transparency = 0;
+            int maxW = 1, maxH = 1;
+            transparency = 0;
             for (int i = 0; i < font.Glyphs.Count; i++)
             {
                 NutGlyph g = font.Glyphs[i];
                 if (!g.HasPixels || !NutImageDecoder.IsSupportedCodec(g.Codec)) continue;
                 drawable.Add(i);
-                if (g.Width > cellW) cellW = g.Width;
-                if (g.Height > cellH) cellH = g.Height;
+                if (g.Width > maxW) maxW = g.Width;
+                if (g.Height > maxH) maxH = g.Height;
                 transparency = NutImageDecoder.TransparencyIndex(g.Codec); // one codec per NUT file
             }
+            // The cell is the largest glyph plus the gutter that carries the grid line.
+            cellW = maxW + GridGutter;
+            cellH = maxH + GridGutter;
             cols = drawable.Count < AtlasColumns ? (drawable.Count == 0 ? 1 : drawable.Count) : AtlasColumns;
             rows = drawable.Count == 0 ? 1 : (drawable.Count + cols - 1) / cols;
             return drawable;
@@ -265,6 +285,15 @@ namespace ScummEditor.Engine.Encoders
             var palette = new Color[256];
             for (int i = 0; i < 256; i++) palette[i] = Color.FromArgb(i, i, i);
             return palette;
+        }
+
+        /// <summary>Copies a palette and paints the grid index a visible colour, so the cell grid stands out
+        /// in the exported atlas whatever the base preview palette is.</summary>
+        private static Color[] WithGridColor(Color[] palette)
+        {
+            var copy = (Color[])palette.Clone();
+            copy[GridIndex] = GridColor;
+            return copy;
         }
 
         private static string Report(string verb, int count, int total, List<string> errors)

--- a/ScummEditor.Engine/Encoders/NutImageDecoder.cs
+++ b/ScummEditor.Engine/Encoders/NutImageDecoder.cs
@@ -1,0 +1,178 @@
+using System.Drawing;
+using ScummEditor.Engine.Structures.DataFile;
+
+namespace ScummEditor.Engine.Encoders
+{
+    /// <summary>
+    /// Decodes one glyph (frame) of a SCUMM v7 .NUT SMUSH font to a palette-index matrix or a bitmap.
+    /// NUT glyphs use SMUSH frame-object codecs (verified against ScummVM nut_renderer.cpp / codec1.cpp /
+    /// bomp.cpp and the real Dig/Full Throttle font files):
+    ///   - codec 1 and codec 3  : BOMP run-length, row by row (each row a uint16 LE byte-length prefix +
+    ///     bompDecodeLine). codec 3 (SMUSH_CODEC_RLE_ALT) decodes identically to codec 1.
+    ///   - codec 21 and codec 44: a "skip + copy" run-length, row by row (each row a uint16 LE length +
+    ///     records of [skip:uint16][run-1:uint16][run bytes]). codec 44 decodes the same way but its
+    ///     transparent fill colour is 2 instead of 0.
+    /// Glyph pixels are direct 8-bit indices into the game's runtime palette; the index matrix is what the
+    /// PNG export/import round-trips (palette-independent), and a palette is only applied for the preview.
+    /// </summary>
+    public static class NutImageDecoder
+    {
+        /// <summary>The SMUSH codecs NUT fonts use that this engine can decode/encode.</summary>
+        public static bool IsSupportedCodec(int codec)
+        {
+            return codec == 1 || codec == 3 || codec == 21 || codec == 44;
+        }
+
+        /// <summary>The colour index a codec leaves where no pixel is drawn (transparent): 2 for codec 44,
+        /// 0 for the others - matching ScummVM's kSmush44TransparentColor / kDefaultTransparentColor.</summary>
+        public static int TransparencyIndex(int codec)
+        {
+            return codec == 44 ? 2 : 0;
+        }
+
+        /// <summary>
+        /// Decodes glyph <paramref name="index"/> to its raw palette-index matrix [width, height], or null
+        /// for an empty glyph or an unsupported codec. Pixels not written by the codec are left at the
+        /// codec's transparent index. This is the shared core used by the viewer and the encoder.
+        /// </summary>
+        public static byte[,] DecodeGlyphIndices(NutFont font, int index)
+        {
+            if (font == null || font.RawContent == null || index < 0 || index >= font.Glyphs.Count)
+            {
+                return null;
+            }
+
+            NutGlyph glyph = font.Glyphs[index];
+            if (!glyph.HasPixels || !IsSupportedCodec(glyph.Codec))
+            {
+                return null;
+            }
+
+            byte[] data = font.RawContent;
+            int start = glyph.PayloadOffset;
+            int end = glyph.PayloadOffset + glyph.PayloadLength;
+            int width = glyph.Width;
+            int height = glyph.Height;
+
+            var result = new byte[width, height];
+            int transparency = TransparencyIndex(glyph.Codec);
+            if (transparency != 0)
+            {
+                for (int y = 0; y < height; y++)
+                    for (int x = 0; x < width; x++)
+                        result[x, y] = (byte)transparency;
+            }
+
+            if (glyph.Codec == 1 || glyph.Codec == 3)
+            {
+                DecodeBomp(data, start, end, width, height, result);
+            }
+            else // 21 or 44
+            {
+                DecodeSkipCopy(data, start, end, width, height, result);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Decodes glyph <paramref name="index"/> to an indexed bitmap. With <paramref name="palette"/> null
+        /// the pixels are shown on a 256-level grayscale ramp (the index value); when a 256-colour game/room
+        /// palette is supplied the glyph is shown as it would look on screen. The transparent index is
+        /// rendered fully transparent. Returns null for an empty glyph or an unsupported codec.
+        /// </summary>
+        public static Bitmap DecodeGlyph(NutFont font, int index, Color[] palette)
+        {
+            byte[,] indices = DecodeGlyphIndices(font, index);
+            if (indices == null)
+            {
+                return null;
+            }
+
+            Color[] effective = (palette != null && palette.Length >= 256) ? palette : Grayscale();
+            int transparency = TransparencyIndex(font.Glyphs[index].Codec);
+            return IndexedImageHelper.FromIndexMatrix(indices, effective, transparency);
+        }
+
+        /// <summary>Width/height of a glyph without decoding the pixels.</summary>
+        public static Size GetGlyphSize(NutFont font, int index)
+        {
+            if (font == null || index < 0 || index >= font.Glyphs.Count) return Size.Empty;
+            NutGlyph g = font.Glyphs[index];
+            return new Size(g.Width, g.Height);
+        }
+
+        /// <summary>
+        /// BOMP run-length (codec 1/3): each row is [size:uint16 LE] then control bytes - low bit = repeat,
+        /// upper 7 bits = run-1; a repeat run is one colour byte, a literal run is <c>run</c> colour bytes.
+        /// Colour 0 stays transparent (the matrix is pre-zeroed). Mirrors smushDecodeRLE + bompDecodeLine.
+        /// </summary>
+        private static void DecodeBomp(byte[] data, int start, int end, int width, int height, byte[,] result)
+        {
+            int p = start;
+            for (int y = 0; y < height && p + 2 <= end; y++)
+            {
+                int lineSize = data[p] | (data[p + 1] << 8);
+                p += 2;
+                int lineEnd = p + lineSize;
+                if (lineEnd > end) lineEnd = end;
+
+                int x = 0;
+                while (x < width && p < lineEnd)
+                {
+                    byte control = data[p++];
+                    int run = (control >> 1) + 1;
+                    bool repeat = (control & 1) != 0;
+                    if (repeat)
+                    {
+                        if (p >= lineEnd) break;
+                        byte color = data[p++];
+                        for (int i = 0; i < run && x < width; i++) { result[x, y] = color; x++; }
+                    }
+                    else
+                    {
+                        for (int i = 0; i < run && x < width && p < lineEnd; i++) { result[x, y] = data[p++]; x++; }
+                    }
+                }
+                p = lineEnd; // each row occupies exactly lineSize bytes
+            }
+        }
+
+        /// <summary>
+        /// Skip-copy run-length (codec 21/44): each row is [size:uint16 LE] then records of
+        /// [skip:uint16 LE] (transparent pixels to skip) + [run-1:uint16 LE] + <c>run</c> raw colour bytes.
+        /// Skipped pixels keep the pre-filled transparent index. Mirrors NutRenderer::codec21.
+        /// </summary>
+        private static void DecodeSkipCopy(byte[] data, int start, int end, int width, int height, byte[,] result)
+        {
+            int p = start;
+            for (int y = 0; y < height && p + 2 <= end; y++)
+            {
+                int lineSize = data[p] | (data[p + 1] << 8);
+                p += 2;
+                int lineEnd = p + lineSize;
+                if (lineEnd > end) lineEnd = end;
+
+                int x = 0;
+                while (x < width && p + 2 <= lineEnd)
+                {
+                    int skip = data[p] | (data[p + 1] << 8);
+                    p += 2;
+                    x += skip;
+                    if (x >= width || p + 2 > lineEnd) break;
+
+                    int run = (data[p] | (data[p + 1] << 8)) + 1;
+                    p += 2;
+                    for (int i = 0; i < run && x < width && p < lineEnd; i++) { result[x, y] = data[p++]; x++; }
+                }
+                p = lineEnd;
+            }
+        }
+
+        private static Color[] Grayscale()
+        {
+            var palette = new Color[256];
+            for (int i = 0; i < 256; i++) palette[i] = Color.FromArgb(i, i, i);
+            return palette;
+        }
+    }
+}

--- a/ScummEditor.Engine/Encoders/NutImageEncoder.cs
+++ b/ScummEditor.Engine/Encoders/NutImageEncoder.cs
@@ -1,0 +1,244 @@
+using System.Collections.Generic;
+using System.IO;
+using ScummEditor.Engine.Exceptions;
+using ScummEditor.Engine.Structures.DataFile;
+
+namespace ScummEditor.Engine.Encoders
+{
+    /// <summary>
+    /// Re-encodes one edited glyph of a SCUMM v7 .NUT SMUSH font and splices it back into the file. The
+    /// edit is index-based (an edited matrix of palette indices), so it is palette-independent and exactly
+    /// reverses <see cref="NutImageDecoder"/>: codec 1/3 are written as BOMP run-length, codec 21/44 as the
+    /// skip-copy run-length (the codec-44 transparent index is 2, the others 0). NUT frames are walked
+    /// sequentially with no offset table, so splicing only rewrites the one FRME and fixes the outer ANIM
+    /// size - every other frame is preserved byte-for-byte, and an unedited font never changes at all.
+    /// </summary>
+    public static class NutImageEncoder
+    {
+        public static bool CanEncode(int codec)
+        {
+            return NutImageDecoder.IsSupportedCodec(codec);
+        }
+
+        /// <summary>
+        /// Replaces glyph <paramref name="index"/>'s pixels with <paramref name="indices"/> (which must be
+        /// exactly the glyph's width x height), re-encoding with the glyph's own codec and rebuilding the
+        /// font's RawContent. Throws <see cref="ImageEncodeException"/> on a bad index, an unsupported codec
+        /// or a size mismatch.
+        /// </summary>
+        public static void ReplaceGlyph(NutFont font, int index, byte[,] indices)
+        {
+            if (font == null || font.RawContent == null || index < 0 || index >= font.Glyphs.Count)
+            {
+                throw new ImageEncodeException("no NUT glyph #" + index);
+            }
+
+            NutGlyph glyph = font.Glyphs[index];
+            if (!glyph.HasFobj)
+            {
+                throw new ImageEncodeException("NUT glyph #" + index + " has no editable frame object");
+            }
+            if (!CanEncode(glyph.Codec))
+            {
+                throw new ImageEncodeException("NUT glyph #" + index + " uses unsupported codec " + glyph.Codec);
+            }
+
+            int width = indices.GetLength(0);
+            int height = indices.GetLength(1);
+            if (width != glyph.Width || height != glyph.Height)
+            {
+                throw new ImageEncodeException(string.Format(
+                    "NUT glyph #{0} is {1}x{2}; the imported image is {3}x{4} (glyph size must match)",
+                    index, glyph.Width, glyph.Height, width, height));
+            }
+
+            int transparency = NutImageDecoder.TransparencyIndex(glyph.Codec);
+            byte[] payload = (glyph.Codec == 1 || glyph.Codec == 3)
+                ? EncodeBomp(indices, width, height)
+                : EncodeSkipCopy(indices, width, height, (byte)transparency);
+
+            font.RawContent = SpliceFrame(font, glyph, payload);
+            font.Reparse();
+        }
+
+        /// <summary>
+        /// Rebuilds RawContent with the edited frame's new FOBJ payload spliced in. Everything before and
+        /// after the frame is copied verbatim (NUT frames carry no absolute offsets, so the trailing frames
+        /// just shift); the four reserved FOBJ bytes and any trailing FRME data are preserved, and the
+        /// outer ANIM size is recomputed.
+        /// </summary>
+        private static byte[] SpliceFrame(NutFont font, NutGlyph glyph, byte[] payload)
+        {
+            byte[] src = font.RawContent;
+
+            int fobjSize = 14 + payload.Length;             // codec/x/y/w/h(10) + 4 reserved + payload
+            int fobjChunkLen = 8 + fobjSize;                // FOBJ tag+size + body
+            int trailingFrmeLen = glyph.FrameSize - (8 + glyph.FobjSize); // FRME data after the FOBJ chunk
+            if (trailingFrmeLen < 0) trailingFrmeLen = 0;
+            int frameSize = fobjChunkLen + trailingFrmeLen; // FRME body size
+
+            var frame = new MemoryStream();
+            WriteTag(frame, "FRME");
+            WriteUInt32BE(frame, (uint)frameSize);
+            WriteTag(frame, "FOBJ");
+            WriteUInt32BE(frame, (uint)fobjSize);
+            WriteUInt16LE(frame, glyph.Codec);
+            WriteUInt16LE(frame, glyph.XOffset);
+            WriteUInt16LE(frame, glyph.YOffset);
+            WriteUInt16LE(frame, glyph.Width);
+            WriteUInt16LE(frame, glyph.Height);
+            // The four reserved bytes (FOBJ +18..+21) are preserved from the original frame.
+            frame.Write(src, glyph.FobjOffset + 18, 4);
+            frame.Write(payload, 0, payload.Length);
+            if (trailingFrmeLen > 0)
+            {
+                frame.Write(src, glyph.FobjOffset + 8 + glyph.FobjSize, trailingFrmeLen);
+            }
+            byte[] frameBytes = frame.ToArray();
+
+            // Where this frame's block (including its even-alignment pad) ends in the original file.
+            int oldNext = glyph.FrameOffset + 8 + glyph.FrameSize;
+            if ((glyph.FrameSize & 1) != 0) oldNext++;
+
+            var output = new MemoryStream();
+            output.Write(src, 0, glyph.FrameOffset);   // everything before the frame, verbatim
+            output.Write(frameBytes, 0, frameBytes.Length);
+            if ((frameSize & 1) != 0) output.WriteByte(0); // re-pad to an even boundary like the original
+            if (oldNext < src.Length)
+            {
+                output.Write(src, oldNext, src.Length - oldNext); // following frames + trailer, verbatim
+            }
+
+            byte[] result = output.ToArray();
+            // Fix the outer ANIM chunk size (big-endian uint32 at offset 4).
+            uint animSize = (uint)(result.Length - 8);
+            result[4] = (byte)(animSize >> 24);
+            result[5] = (byte)(animSize >> 16);
+            result[6] = (byte)(animSize >> 8);
+            result[7] = (byte)animSize;
+            return result;
+        }
+
+        /// <summary>
+        /// BOMP run-length encode (codec 1/3), row by row: each row is [size:uint16 LE] then control bytes
+        /// (low bit = repeat, upper 7 = run-1). Runs of >= 2 equal bytes are emitted as repeats (max 128),
+        /// the rest as literals (max 128). Reverses <see cref="NutImageDecoder"/>'s BOMP decode.
+        /// </summary>
+        private static byte[] EncodeBomp(byte[,] indices, int width, int height)
+        {
+            var output = new MemoryStream();
+            var line = new List<byte>();
+            var literals = new List<byte>();
+
+            for (int y = 0; y < height; y++)
+            {
+                line.Clear();
+                literals.Clear();
+
+                int x = 0;
+                while (x < width)
+                {
+                    byte value = indices[x, y];
+                    int run = 1;
+                    while (x + run < width && indices[x + run, y] == value && run < 128) run++;
+
+                    if (run >= 2)
+                    {
+                        FlushLiterals(line, literals);
+                        line.Add((byte)(((run - 1) << 1) | 1)); // repeat
+                        line.Add(value);
+                        x += run;
+                    }
+                    else
+                    {
+                        literals.Add(value);
+                        if (literals.Count == 128) FlushLiterals(line, literals);
+                        x++;
+                    }
+                }
+                FlushLiterals(line, literals);
+
+                output.WriteByte((byte)(line.Count & 0xFF));
+                output.WriteByte((byte)((line.Count >> 8) & 0xFF));
+                output.Write(line.ToArray(), 0, line.Count);
+            }
+            return output.ToArray();
+        }
+
+        private static void FlushLiterals(List<byte> line, List<byte> literals)
+        {
+            if (literals.Count == 0) return;
+            line.Add((byte)((literals.Count - 1) << 1)); // literal (low bit 0)
+            line.AddRange(literals);
+            literals.Clear();
+        }
+
+        /// <summary>
+        /// Skip-copy run-length encode (codec 21/44), row by row: each row is [size:uint16 LE] then records
+        /// of [skip:uint16 LE][run-1:uint16 LE][run bytes], where a "skip" is a span of the transparent
+        /// index. Reverses <see cref="NutImageDecoder"/>'s skip-copy decode.
+        /// </summary>
+        private static byte[] EncodeSkipCopy(byte[,] indices, int width, int height, byte transparency)
+        {
+            var output = new MemoryStream();
+            var line = new List<byte>();
+
+            for (int y = 0; y < height; y++)
+            {
+                line.Clear();
+                int x = 0;
+                while (x < width)
+                {
+                    int gapStart = x;
+                    while (x < width && indices[x, y] == transparency) x++;
+                    int skip = x - gapStart;
+
+                    if (x >= width)
+                    {
+                        // Trailing transparent run: emit just the skip (the decoder stops after it).
+                        if (skip > 0) AddUInt16LE(line, skip);
+                        break;
+                    }
+
+                    int runStart = x;
+                    while (x < width && indices[x, y] != transparency) x++;
+                    int run = x - runStart;
+
+                    AddUInt16LE(line, skip);
+                    AddUInt16LE(line, run - 1);
+                    for (int i = runStart; i < x; i++) line.Add(indices[i, y]);
+                }
+
+                output.WriteByte((byte)(line.Count & 0xFF));
+                output.WriteByte((byte)((line.Count >> 8) & 0xFF));
+                output.Write(line.ToArray(), 0, line.Count);
+            }
+            return output.ToArray();
+        }
+
+        private static void AddUInt16LE(List<byte> list, int value)
+        {
+            list.Add((byte)(value & 0xFF));
+            list.Add((byte)((value >> 8) & 0xFF));
+        }
+
+        private static void WriteTag(Stream s, string tag)
+        {
+            for (int i = 0; i < 4; i++) s.WriteByte((byte)tag[i]);
+        }
+
+        private static void WriteUInt32BE(Stream s, uint value)
+        {
+            s.WriteByte((byte)(value >> 24));
+            s.WriteByte((byte)(value >> 16));
+            s.WriteByte((byte)(value >> 8));
+            s.WriteByte((byte)value);
+        }
+
+        private static void WriteUInt16LE(Stream s, int value)
+        {
+            s.WriteByte((byte)(value & 0xFF));
+            s.WriteByte((byte)((value >> 8) & 0xFF));
+        }
+    }
+}

--- a/ScummEditor.Engine/Encoders/NutImageEncoder.cs
+++ b/ScummEditor.Engine/Encoders/NutImageEncoder.cs
@@ -73,9 +73,16 @@ namespace ScummEditor.Engine.Encoders
 
             int fobjSize = 14 + payload.Length;             // codec/x/y/w/h(10) + 4 reserved + payload
             int fobjChunkLen = 8 + fobjSize;                // FOBJ tag+size + body
-            int trailingFrmeLen = glyph.FrameSize - (8 + glyph.FobjSize); // FRME data after the FOBJ chunk
-            if (trailingFrmeLen < 0) trailingFrmeLen = 0;
-            int frameSize = fobjChunkLen + trailingFrmeLen; // FRME body size
+
+            // Canonical NUT layout (verified against real fonts + ScummVM NutRenderer::loadFont): the FOBJ
+            // chunk is padded to an EVEN length with a single 0 byte INSIDE the FRME, so the FRME size is
+            // always even. ScummVM's two frame-walk loops rely on this (the decodedLength count loop pads by
+            // the FOBJ size's parity, the decode loop by the FRME size's), so an odd FRME size with external
+            // padding - what the old code produced when a re-encode changed the payload's parity - desyncs
+            // them and overflows ScummVM's glyph buffer (Full Throttle, which draws .NUT text at boot, then
+            // crashes). Re-pad here exactly like the original instead of preserving its old trailing pad.
+            int frmePad = fobjChunkLen & 1;                 // 1 when the FOBJ chunk is odd, else 0
+            int frameSize = fobjChunkLen + frmePad;         // FRME body size (always even)
 
             var frame = new MemoryStream();
             WriteTag(frame, "FRME");
@@ -90,10 +97,7 @@ namespace ScummEditor.Engine.Encoders
             // The four reserved bytes (FOBJ +18..+21) are preserved from the original frame.
             frame.Write(src, glyph.FobjOffset + 18, 4);
             frame.Write(payload, 0, payload.Length);
-            if (trailingFrmeLen > 0)
-            {
-                frame.Write(src, glyph.FobjOffset + 8 + glyph.FobjSize, trailingFrmeLen);
-            }
+            if (frmePad != 0) frame.WriteByte(0);           // the FOBJ chunk's even-alignment pad, inside the FRME
             byte[] frameBytes = frame.ToArray();
 
             // Where this frame's block (including its even-alignment pad) ends in the original file.
@@ -102,8 +106,7 @@ namespace ScummEditor.Engine.Encoders
 
             var output = new MemoryStream();
             output.Write(src, 0, glyph.FrameOffset);   // everything before the frame, verbatim
-            output.Write(frameBytes, 0, frameBytes.Length);
-            if ((frameSize & 1) != 0) output.WriteByte(0); // re-pad to an even boundary like the original
+            output.Write(frameBytes, 0, frameBytes.Length); // frameSize is even, so no external FRME pad
             if (oldNext < src.Length)
             {
                 output.Write(src, oldNext, src.Length - oldNext); // following frames + trailer, verbatim

--- a/ScummEditor.Engine/Encoders/ScriptPaletteScanner.cs
+++ b/ScummEditor.Engine/Encoders/ScriptPaletteScanner.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+
+namespace ScummEditor.Engine.Encoders
+{
+    /// <summary>
+    /// Statically scans SCUMM v6/v7 script bytecode for LITERAL setCurrentPalette(roomN) calls - the
+    /// roomOps opcode (0x9C) with sub-op SO_ROOM_NEW_PALETTE (213) immediately preceded by a literal
+    /// pushByte/pushWord. These reveal which room's palette a cutscene loads at runtime, which is useful as
+    /// a VIEW-ONLY candidate palette for codec-16 AKOS cels (they carry no palette of their own).
+    ///
+    /// Only LITERAL arguments are recovered: when the room number is pushed from a variable/array (the usual
+    /// way a full palette is set) it cannot be known without running the script, so it is simply not found.
+    /// This is a best-effort byte scan for a display aid - a stray match only adds an extra candidate the
+    /// user can ignore (the caller further filters to rooms that actually exist and have a palette).
+    /// </summary>
+    public static class ScriptPaletteScanner
+    {
+        private const byte PushByte = 0x00;
+        private const byte PushWord = 0x01;
+        private const byte RoomOps = 0x9C;
+        private const byte SoRoomNewPalette = 213; // SO_ROOM_NEW_PALETTE (ScummVM scumm_v6.h)
+
+        /// <summary>Room numbers referenced by a literal setCurrentPalette(N) in this script's bytecode.</summary>
+        public static IEnumerable<int> FindCurrentPaletteRooms(byte[] code, int startOffset)
+        {
+            var rooms = new List<int>();
+            if (code == null)
+            {
+                return rooms;
+            }
+
+            for (int i = startOffset; i + 1 < code.Length; i++)
+            {
+                if (code[i] != RoomOps || code[i + 1] != SoRoomNewPalette)
+                {
+                    continue;
+                }
+
+                // The room number is whatever was pushed just before roomOps; recover it only when that push
+                // is a literal. pushWord is checked first so a 0x01 0x00 .. word is not misread as a pushByte.
+                if (i - 3 >= startOffset && code[i - 3] == PushWord)
+                {
+                    rooms.Add(code[i - 2] | (code[i - 1] << 8));
+                }
+                else if (i - 2 >= startOffset && code[i - 2] == PushByte)
+                {
+                    rooms.Add(code[i - 1]);
+                }
+            }
+            return rooms;
+        }
+    }
+}

--- a/ScummEditor.Engine/Encoders/ScummLanguageDetector.cs
+++ b/ScummEditor.Engine/Encoders/ScummLanguageDetector.cs
@@ -80,6 +80,12 @@ namespace ScummEditor.Engine.Encoders
         {
             if (game == null || game.LoadedGameInfo == null) return;
 
+            // The content word-heuristic is tuned for v2-v6. v7 (The Dig, Full Throttle) translated
+            // editions keep many English engine/debug strings in their scripts, which the heuristic
+            // misreads as English; until a proper v7 language detector exists, leave v7 as Unknown
+            // rather than report the wrong language.
+            if (game.LoadedGameInfo.ScummVersion >= 7) return;
+
             ScummLanguage md5 = game.LoadedGameInfo.Language;
             if (md5 != ScummLanguage.Unknown && md5 != ScummLanguage.English) return; // trust a confident non-English MD5
 

--- a/ScummEditor.Engine/Encoders/ScummLanguageDetector.cs
+++ b/ScummEditor.Engine/Encoders/ScummLanguageDetector.cs
@@ -80,11 +80,15 @@ namespace ScummEditor.Engine.Encoders
         {
             if (game == null || game.LoadedGameInfo == null) return;
 
-            // The content word-heuristic is tuned for v2-v6. v7 (The Dig, Full Throttle) translated
-            // editions keep many English engine/debug strings in their scripts, which the heuristic
-            // misreads as English; until a proper v7 language detector exists, leave v7 as Unknown
-            // rather than report the wrong language.
-            if (game.LoadedGameInfo.ScummVersion >= 7) return;
+            // SCUMM v7 (The Dig, Full Throttle) needs its own detector: The Dig keeps its dialogue in the
+            // external LANGUAGE.BND (its in-container scripts are English engine text), while Full Throttle
+            // keeps the translated dialogue in the container scripts. DetectV7Language routes each correctly.
+            if (game.LoadedGameInfo.ScummVersion >= 7)
+            {
+                ScummLanguage v7 = DetectV7Language(game);
+                if (v7 != ScummLanguage.Unknown) game.LoadedGameInfo.Language = v7;
+                return;
+            }
 
             ScummLanguage md5 = game.LoadedGameInfo.Language;
             if (md5 != ScummLanguage.Unknown && md5 != ScummLanguage.English) return; // trust a confident non-English MD5
@@ -96,6 +100,44 @@ namespace ScummEditor.Engine.Encoders
             if (content == ScummLanguage.Unknown) return;           // nothing better to offer
             if (md5 == content) return;                             // already agree
             game.LoadedGameInfo.Language = content;                 // fill Unknown, or override a dubious English
+        }
+
+        /// <summary>
+        /// Detects a SCUMM v7 edition's language from its real translated text. The Dig's dialogue lives in
+        /// the external LANGUAGE.BND - its double-byte editions declare a CJK marker (j/h/c), and the Western
+        /// ones are recognised by the word heuristic over the bundle entries. Full Throttle (and the English
+        /// Dig) have no bundle, so their translated dialogue is the in-container script text. Returns Unknown
+        /// when nothing decides (e.g. a language with no word profile), so the caller leaves it unset.
+        /// </summary>
+        private static ScummLanguage DetectV7Language(ScummGameData game)
+        {
+            LanguageBundleFile bundle = null;
+            if (game.LocalizedTextFiles != null)
+            {
+                foreach (ILocalizedTextFile f in game.LocalizedTextFiles)
+                {
+                    if (f is LanguageBundleFile b && b.IsValid) { bundle = b; break; }
+                }
+            }
+
+            if (bundle != null)
+            {
+                switch (bundle.CjkMarker)
+                {
+                    case 'j': return ScummLanguage.Japanese;
+                    case 'h': return ScummLanguage.Korean;
+                    case 'c': return ScummLanguage.Chinese;
+                }
+                var texts = new System.Collections.Generic.List<string>(bundle.Entries.Count);
+                foreach (LocalizedTextEntry e in bundle.Entries) texts.Add(e.Text);
+                try { return FromName(GameLanguageDetector.DetectFromStrings(texts)); }
+                catch { return ScummLanguage.Unknown; }
+            }
+
+            // No LANGUAGE.BND: Full Throttle (dialogue in the scripts) or the English Dig - detect from the
+            // in-container text, which for these is the actual (possibly translated) dialogue.
+            try { return FromName(GameLanguageDetector.Detect(game)); }
+            catch { return ScummLanguage.Unknown; }
         }
 
         private static ScummLanguage FromName(string name)

--- a/ScummEditor.Engine/Encoders/ScummV12Disassembler.cs
+++ b/ScummEditor.Engine/Encoders/ScummV12Disassembler.cs
@@ -385,9 +385,14 @@ namespace ScummEditor.Engine.Encoders
                 case 0x7A: case 0xFA: VerbOps(offset, op); break;
                 case 0x0C: case 0x8C: ResourceRoutines(offset); break;
 
+                // All 256 byte opcodes are handled above, so this default is unreachable today (hence the
+                // suppressed CS0162). It is kept on purpose as a defensive guard: if a case is ever removed,
+                // the offending opcode is reported cleanly instead of being silently skipped.
+#pragma warning disable CS0162 // Unreachable code: every 0x00-0xFF opcode has a case; default is a deliberate guard.
                 default:
                     Unknown(op, offset);
                     break;
+#pragma warning restore CS0162
             }
         }
 

--- a/ScummEditor.Engine/Encoders/ScummV5V6GraphicsBatch.cs
+++ b/ScummEditor.Engine/Encoders/ScummV5V6GraphicsBatch.cs
@@ -37,7 +37,7 @@ namespace ScummEditor.Engine.Encoders
             public List<string> Errors = new List<string>();
         }
 
-        public static int Export(ScummV5V6DataFile dataFile, string folder, ExportOptions options, Action<int, int> onProgress, Func<bool> shouldCancel = null)
+        public static int Export(ScummDataFile dataFile, string folder, ExportOptions options, Action<int, int> onProgress, Func<bool> shouldCancel = null)
         {
             List<DiskBlock> diskBlocks = dataFile.GetLFLFs();
             var convert = new ImageDepthConversor();
@@ -147,7 +147,7 @@ namespace ScummEditor.Engine.Encoders
             return count;
         }
 
-        public static ImportReport Import(ScummV5V6DataFile dataFile, string folder, Action<int, int> onProgress)
+        public static ImportReport Import(ScummDataFile dataFile, string folder, Action<int, int> onProgress)
         {
             var report = new ImportReport();
             List<DiskBlock> diskBlocks = dataFile.GetLFLFs();

--- a/ScummEditor.Engine/Encoders/ScummV5V6GraphicsBatch.cs
+++ b/ScummEditor.Engine/Encoders/ScummV5V6GraphicsBatch.cs
@@ -150,8 +150,14 @@ namespace ScummEditor.Engine.Encoders
                     {
                         if (file.ImageType == ImageType.Costume)
                         {
-                            Costume costume = diskBlocks[file.RoomIndex].GetCostumes()[file.CostumeIndex];
-                            ImageResourceCodec.Encode(room, costume, ImageType.Costume, 0, file.FrameIndex, 0, bitmap, ImageEncoder.EncodeTypeSettings.AutoDetect);
+                            // v7 costumes are AKOS (not the v5/v6 COST format), so GetCostumes() is empty
+                            // for a v7 game; guard the index so a stray costume PNG is reported, not a crash.
+                            List<Costume> costumes = diskBlocks[file.RoomIndex].GetCostumes();
+                            if (file.CostumeIndex < 0 || file.CostumeIndex >= costumes.Count)
+                            {
+                                throw new ImageEncodeException("no costume #" + file.CostumeIndex + " in room " + file.RoomIndex);
+                            }
+                            ImageResourceCodec.Encode(room, costumes[file.CostumeIndex], ImageType.Costume, 0, file.FrameIndex, 0, bitmap, ImageEncoder.EncodeTypeSettings.AutoDetect);
                         }
                         else
                         {

--- a/ScummEditor.Engine/Encoders/ScummV5V6GraphicsBatch.cs
+++ b/ScummEditor.Engine/Encoders/ScummV5V6GraphicsBatch.cs
@@ -5,6 +5,7 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using ScummEditor.Engine.Exceptions;
+using ScummEditor.Engine.Structures;
 using ScummEditor.Engine.Structures.DataFile;
 
 namespace ScummEditor.Engine.Encoders
@@ -116,6 +117,28 @@ namespace ScummEditor.Engine.Encoders
                             if (img != null) { Save(img, folder, string.Format("Room#{0} Costume#{1} FrameIndex#{2}.png", i, j, k)); count++; }
                         }
                     }
+
+                    // v7 AKOS costumes (the COST list above is empty for v7; AKOS is empty for v5/v6). Cels are
+                    // saved as indexed PNGs carrying the raw costume-colour indexes, so re-import is exact.
+                    List<BlockBase> akosList = diskBlocks[i].Childrens.Where(c => c.BlockType == "AKOS").ToList();
+                    for (int j = 0; j < akosList.Count; j++)
+                    {
+                        BlockBase akos = akosList[j];
+                        int cels = AkosImageDecoder.GetCelCount(akos);
+                        for (int k = 0; k < cels; k++)
+                        {
+                            Size sz = AkosImageDecoder.GetCelSize(akos, k);
+                            if (sz.Width * sz.Height <= 4) continue; // tiny placeholder cel (unused animation slot)
+
+                            Bitmap cel = AkosImageDecoder.DecodeCel(akos, k);
+                            if (cel != null)
+                            {
+                                Save(cel, folder, string.Format("Room#{0} Akos#{1} Cel#{2}.png", i, j, k));
+                                cel.Dispose();
+                                count++;
+                            }
+                        }
+                    }
                 }
 
                 if (onProgress != null) onProgress(i + 1, diskBlocks.Count);
@@ -148,7 +171,21 @@ namespace ScummEditor.Engine.Encoders
                 {
                     using (var bitmap = (Bitmap)Image.FromFile(file.Filename))
                     {
-                        if (file.ImageType == ImageType.Costume)
+                        if (file.ImageType == ImageType.AkosCostume)
+                        {
+                            // v7 AKOS costume cel: re-encode the indexed PNG's raw indexes into the cel.
+                            List<BlockBase> akosList = diskBlocks[file.RoomIndex].Childrens.Where(c => c.BlockType == "AKOS").ToList();
+                            if (file.AkosIndex < 0 || file.AkosIndex >= akosList.Count)
+                            {
+                                throw new ImageEncodeException("no AKOS costume #" + file.AkosIndex + " in room " + file.RoomIndex);
+                            }
+                            if (!IndexedImageHelper.IsIndexed(bitmap))
+                            {
+                                throw new ImageEncodeException("AKOS cel must be an indexed PNG (re-export it and edit without converting to RGB)");
+                            }
+                            AkosImageEncoder.ReplaceCel(akosList[file.AkosIndex], file.CelIndex, IndexedImageHelper.GetIndexMatrix(bitmap));
+                        }
+                        else if (file.ImageType == ImageType.Costume)
                         {
                             // v7 costumes are AKOS (not the v5/v6 COST format), so GetCostumes() is empty
                             // for a v7 game; guard the index so a stray costume PNG is reported, not a crash.
@@ -161,6 +198,9 @@ namespace ScummEditor.Engine.Encoders
                         }
                         else
                         {
+                            // Guard the object/image/z-plane indexes so a stray or out-of-range PNG is reported
+                            // (ImageEncodeException, caught below) instead of throwing IndexOutOfRange.
+                            ValidateRoomImageIndices(room, file);
                             ImageResourceCodec.Encode(room, null, file.ImageType, file.ObjectIndex, file.ImageIndex, file.ZPlaneIndex, bitmap, ImageEncoder.EncodeTypeSettings.AutoDetect);
                         }
                     }
@@ -175,6 +215,41 @@ namespace ScummEditor.Engine.Encoders
             }
 
             return report;
+        }
+
+        /// <summary>Throws ImageEncodeException when a background-z-plane / object / object-z-plane file's
+        /// indexes do not exist in the room, so a stray PNG is reported instead of crashing the import.</summary>
+        private static void ValidateRoomImageIndices(RoomBlock room, ImageInfo file)
+        {
+            if (file.ImageType == ImageType.Object || file.ImageType == ImageType.ObjectsZPlane)
+            {
+                List<ObjectImage> obims = room.GetOBIMs();
+                if (file.ObjectIndex < 0 || file.ObjectIndex >= obims.Count)
+                {
+                    throw new ImageEncodeException("no object #" + file.ObjectIndex + " in room " + file.RoomIndex);
+                }
+                List<ImageData> imgs = obims[file.ObjectIndex].GetIMxx();
+                if (file.ImageIndex < 0 || file.ImageIndex >= imgs.Count)
+                {
+                    throw new ImageEncodeException("no image #" + file.ImageIndex + " in object #" + file.ObjectIndex);
+                }
+                if (file.ImageType == ImageType.ObjectsZPlane)
+                {
+                    List<ZPlane> zps = imgs[file.ImageIndex].GetZPlanes();
+                    if (file.ZPlaneIndex < 0 || file.ZPlaneIndex >= zps.Count)
+                    {
+                        throw new ImageEncodeException("no z-plane #" + file.ZPlaneIndex + " in object #" + file.ObjectIndex);
+                    }
+                }
+            }
+            else if (file.ImageType == ImageType.ZPlane)
+            {
+                List<ZPlane> zps = room.GetRMIM().GetIM00().GetZPlanes();
+                if (file.ZPlaneIndex < 0 || file.ZPlaneIndex >= zps.Count)
+                {
+                    throw new ImageEncodeException("no background z-plane #" + file.ZPlaneIndex + " in room " + file.RoomIndex);
+                }
+            }
         }
 
         private static void Save(Bitmap bitmap, string folder, string fileName)

--- a/ScummEditor.Engine/Encoders/ScummV6Disassembler.cs
+++ b/ScummEditor.Engine/Encoders/ScummV6Disassembler.cs
@@ -484,6 +484,16 @@ namespace ScummEditor.Engine.Encoders
                 case 0xD8: Push("isRoomScriptRunning(" + Pop() + ")"); break;
                 case 0xDD: Push("findAllObjects(" + Pop() + ")"); break;
 
+                // Valid v6 opcodes that DOTT / Sam & Max never emit but The Dig / Full Throttle (v7,
+                // which reuses the v6 opcode table) do. getPixel/getActorLayer/getObjectNewDir pop their
+                // args off the stack (no inline bytes); pickVarRandom reads a stack list AND an inline
+                // word (the array variable); setBoxSet pops one arg.
+                case 0xE1: { string b = Pop(); string a = Pop(); Push("getPixel(" + a + ", " + b + ")"); break; }
+                case 0xE3: { string list = PopStackList(); string v = Var(ReadWord()); Push("pickVarRandom(" + v + ", " + list + ")"); break; }
+                case 0xE4: StmtCall(offset, "setBoxSet", 1); break;
+                case 0xEC: Push("getActorLayer(" + Pop() + ")"); break;
+                case 0xED: Push("getObjectNewDir(" + Pop() + ")"); break;
+
                 // ---- sub-opcode groups ----
                 case 0x6B: SubOp(offset, "cursorCommand", CursorCommand); break;
                 case 0x9B: SubOp(offset, "resourceRoutines", ResourceRoutines); break;
@@ -578,7 +588,10 @@ namespace ScummEditor.Engine.Encoders
 
         private static readonly Dictionary<int, string> WaitOps = new Dictionary<int, string>
         {
-            {0xA8,"waitForActor"}, {0xA9,"waitForMessage"}, {0xAA,"waitForCamera"}, {0xAB,"waitForSentence"}
+            {0xA8,"waitForActor"}, {0xA9,"waitForMessage"}, {0xAA,"waitForCamera"}, {0xAB,"waitForSentence"},
+            // SO_WAIT_FOR_ANIMATION (226) and SO_WAIT_FOR_TURN (232) are used by The Dig (v7); like
+            // waitForActor they carry an inline jump offset. DOTT / Sam & Max never emit them.
+            {0xE2,"waitForAnimation"}, {0xE8,"waitForTurn"}
         };
 
         private static readonly Dictionary<int, string> SaveRestoreVerbs = new Dictionary<int, string>
@@ -621,7 +634,10 @@ namespace ScummEditor.Engine.Encoders
         {
             byte sub = ReadByte();
             string name = SubName(WaitOps, sub);
-            if (sub == 0xA8)
+            // SO_WAIT_FOR_ACTOR (0xA8), SO_WAIT_FOR_ANIMATION (0xE2) and SO_WAIT_FOR_TURN (0xE8) each
+            // carry an inline signed-word jump offset (the script loops back while the actor is still
+            // moving / animating / turning); the other wait sub-ops have no inline operand.
+            if (sub == 0xA8 || sub == 0xE2 || sub == 0xE8)
             {
                 string actor = DrainStack();
                 string label = Jump(offset);

--- a/ScummEditor.Engine/Functions.cs
+++ b/ScummEditor.Engine/Functions.cs
@@ -209,6 +209,7 @@ namespace ScummEditor.Engine
                     DataFile = dataPath,
                     DataFiles = new List<string> { dataPath }, // v7 keeps all room data in one file
                     NutFontFiles = EnumerateNutFonts(folder), // external SMUSH fonts (FONT0.NUT, ...)
+                    BundleFiles = EnumerateBundles(folder),   // external iMUSE bundles (DIGMUSIC/DIGVOICE.BUN)
                     Xored = false,
                     XorKey = 0x00,      // v7 data is not XOR-encrypted
                     IndexXorKey = 0x00, // v7 index is not XOR-encrypted
@@ -246,6 +247,19 @@ namespace ScummEditor.Engine
             }
             fonts.Sort(StringComparer.OrdinalIgnoreCase);
             return fonts;
+        }
+
+        /// <summary>Every .BUN iMUSE sound bundle in a v7 game folder (The Dig's DIGMUSIC.BUN /
+        /// DIGVOICE.BUN), ordered by name. Full Throttle ships none (its speech is MONSTER.SOU).</summary>
+        private static List<string> EnumerateBundles(string folder)
+        {
+            var bundles = new List<string>();
+            foreach (string path in Directory.GetFiles(folder, "*.BUN"))
+            {
+                bundles.Add(path);
+            }
+            bundles.Sort(StringComparer.OrdinalIgnoreCase);
+            return bundles;
         }
 
         /// <summary>True when the file begins with a v5/v6/v7 big-header 4-char block tag.</summary>

--- a/ScummEditor.Engine/Functions.cs
+++ b/ScummEditor.Engine/Functions.cs
@@ -140,7 +140,14 @@ namespace ScummEditor.Engine
                 return result;
             }
 
-            // No v5/v6 game matched - try the SCUMM v4 layout (000.LFL + DISKnn.LEC).
+            // LucasArts SCUMM v7 (The Dig, Full Throttle): GAME.LA0 index + GAME.LA1 data.
+            GameInfo v7 = DetectScummV7(folder);
+            if (v7 != null)
+            {
+                return v7;
+            }
+
+            // No v5/v6/v7 game matched - try the SCUMM v4 layout (000.LFL + DISKnn.LEC).
             GameInfo v4 = DetectScummV4(folder);
             if (v4 != null)
             {
@@ -157,6 +164,78 @@ namespace ScummEditor.Engine
             var none = new GameInfo();
             none.LoadedGame = ScummGame.None;
             return none;
+        }
+
+        /// <summary>
+        /// Detects a SCUMM v7 game (The Dig, Full Throttle). Both use a GAME.LA0 index file and a
+        /// GAME.LA1 data file, neither XOR-encrypted, so the layout is confirmed by content: the index
+        /// begins with a plain "RNAM" tag and the data with the "LECF" container tag. The specific game
+        /// is read from the data file's base name (DIG / FT), the only two SCUMM v7 titles.
+        /// </summary>
+        private static GameInfo DetectScummV7(string folder)
+        {
+            foreach (string indexPath in Directory.GetFiles(folder, "*.LA0"))
+            {
+                string baseName = Path.GetFileNameWithoutExtension(indexPath);
+                string dataPath = Path.Combine(folder, baseName + ".LA1");
+
+                if (!File.Exists(dataPath))
+                {
+                    continue;
+                }
+                if (!StartsWithBigHeaderTag(indexPath, "RNAM") || !StartsWithBigHeaderTag(dataPath, "LECF"))
+                {
+                    continue;
+                }
+
+                // The only two SCUMM v7 games are The Dig (DIG.LA0) and Full Throttle (FT.LA0). The
+                // Curse of Monkey Island (SCUMM v8) ships the SAME COMI.LA0/COMI.LA1 naming and the
+                // same plain RNAM/LECF magic, so it passes the content checks above. v8 is NOT
+                // supported, so reject any other base name here rather than mislabel it as The Dig and
+                // crash on load (the v8 index has a DRSC block and a larger MAXS the v7 reader chokes on).
+                bool isFullThrottle = string.Equals(baseName, "FT", StringComparison.OrdinalIgnoreCase);
+                bool isTheDig = string.Equals(baseName, "DIG", StringComparison.OrdinalIgnoreCase);
+                if (!isFullThrottle && !isTheDig)
+                {
+                    continue;
+                }
+
+                ScummGame game = isFullThrottle ? ScummGame.FullThrottle : ScummGame.TheDig;
+
+                return new GameInfo
+                {
+                    LoadedGame = game,
+                    IndexFile = indexPath,
+                    DataFile = dataPath,
+                    DataFiles = new List<string> { dataPath }, // v7 keeps all room data in one file
+                    Xored = false,
+                    XorKey = 0x00,      // v7 data is not XOR-encrypted
+                    IndexXorKey = 0x00, // v7 index is not XOR-encrypted
+                    ScummVersion = 7,
+                    UsesSmallHeader = false, // big-header [tag:4][size:4 BE] IFF blocks, like v5/v6
+                    IsTalkie = true          // The Dig and Full Throttle are CD/talkie releases
+                };
+            }
+
+            return null;
+        }
+
+        /// <summary>True when the file begins with a v5/v6/v7 big-header 4-char block tag.</summary>
+        private static bool StartsWithBigHeaderTag(string path, string tag)
+        {
+            byte[] head = ReadFileHead(path, 4);
+            if (head == null || head.Length < 4)
+            {
+                return false;
+            }
+            for (int i = 0; i < 4; i++)
+            {
+                if ((char)head[i] != tag[i])
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         /// <summary>

--- a/ScummEditor.Engine/Functions.cs
+++ b/ScummEditor.Engine/Functions.cs
@@ -210,6 +210,7 @@ namespace ScummEditor.Engine
                     DataFiles = new List<string> { dataPath }, // v7 keeps all room data in one file
                     NutFontFiles = EnumerateNutFonts(folder), // external SMUSH fonts (FONT0.NUT, ...)
                     BundleFiles = EnumerateBundles(folder),   // external iMUSE bundles (DIGMUSIC/DIGVOICE.BUN)
+                    TrsFiles = EnumerateTrs(folder),          // external .TRS subtitle/UI text
                     Xored = false,
                     XorKey = 0x00,      // v7 data is not XOR-encrypted
                     IndexXorKey = 0x00, // v7 index is not XOR-encrypted
@@ -225,6 +226,13 @@ namespace ScummEditor.Engine
                 if (File.Exists(speechPath))
                 {
                     info.SpeechFilePath = speechPath;
+                }
+
+                // The Dig's localized editions ship the translated in-game text in an external LANGUAGE.BND.
+                string languageBundle = Path.Combine(folder, "LANGUAGE.BND");
+                if (File.Exists(languageBundle))
+                {
+                    info.LanguageBundlePath = languageBundle;
                 }
 
                 return info;
@@ -260,6 +268,19 @@ namespace ScummEditor.Engine
             }
             bundles.Sort(StringComparer.OrdinalIgnoreCase);
             return bundles;
+        }
+
+        /// <summary>Every .TRS text resource in a v7 game folder (root + VIDEO subfolder), ordered by name:
+        /// the cutscene-subtitle / UI strings (The Dig DIGTXT.TRS/DIG.TRS, Full Throttle's per-scene .TRS).</summary>
+        private static List<string> EnumerateTrs(string folder)
+        {
+            var trs = new List<string>();
+            foreach (string path in Directory.GetFiles(folder, "*.TRS", SearchOption.AllDirectories))
+            {
+                trs.Add(path);
+            }
+            trs.Sort(StringComparer.OrdinalIgnoreCase);
+            return trs;
         }
 
         /// <summary>True when the file begins with a v5/v6/v7 big-header 4-char block tag.</summary>

--- a/ScummEditor.Engine/Functions.cs
+++ b/ScummEditor.Engine/Functions.cs
@@ -208,6 +208,7 @@ namespace ScummEditor.Engine
                     IndexFile = indexPath,
                     DataFile = dataPath,
                     DataFiles = new List<string> { dataPath }, // v7 keeps all room data in one file
+                    NutFontFiles = EnumerateNutFonts(folder), // external SMUSH fonts (FONT0.NUT, ...)
                     Xored = false,
                     XorKey = 0x00,      // v7 data is not XOR-encrypted
                     IndexXorKey = 0x00, // v7 index is not XOR-encrypted
@@ -218,6 +219,22 @@ namespace ScummEditor.Engine
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Every .NUT SMUSH font in a v7 game folder, ordered by name. The game keeps some fonts at the
+        /// folder root (BIGFONT.NUT, SCUMMFNT.NUT, ...) and the video-subtitle fonts in a VIDEO subfolder
+        /// (FONT0.NUT...), so the search recurses; both belong to this edition.
+        /// </summary>
+        private static List<string> EnumerateNutFonts(string folder)
+        {
+            var fonts = new List<string>();
+            foreach (string path in Directory.GetFiles(folder, "*.NUT", SearchOption.AllDirectories))
+            {
+                fonts.Add(path);
+            }
+            fonts.Sort(StringComparer.OrdinalIgnoreCase);
+            return fonts;
         }
 
         /// <summary>True when the file begins with a v5/v6/v7 big-header 4-char block tag.</summary>

--- a/ScummEditor.Engine/Functions.cs
+++ b/ScummEditor.Engine/Functions.cs
@@ -202,7 +202,7 @@ namespace ScummEditor.Engine
 
                 ScummGame game = isFullThrottle ? ScummGame.FullThrottle : ScummGame.TheDig;
 
-                return new GameInfo
+                var info = new GameInfo
                 {
                     LoadedGame = game,
                     IndexFile = indexPath,
@@ -216,6 +216,17 @@ namespace ScummEditor.Engine
                     UsesSmallHeader = false, // big-header [tag:4][size:4 BE] IFF blocks, like v5/v6
                     IsTalkie = true          // The Dig and Full Throttle are CD/talkie releases
                 };
+
+                // Full Throttle ships its recorded speech as an external MONSTER.SOU (Creative VOC), exactly
+                // like the v5/v6 talkies, so the existing speech viewer handles it. The Dig has no MONSTER.SOU
+                // (its voice lives in DIGVOICE.BUN), so SpeechFilePath stays null there.
+                string speechPath = Path.Combine(folder, "MONSTER.SOU");
+                if (File.Exists(speechPath))
+                {
+                    info.SpeechFilePath = speechPath;
+                }
+
+                return info;
             }
 
             return null;

--- a/ScummEditor.Engine/Functions.cs
+++ b/ScummEditor.Engine/Functions.cs
@@ -229,8 +229,14 @@ namespace ScummEditor.Engine
                 }
 
                 // The Dig's localized editions ship the translated in-game text in an external LANGUAGE.BND.
-                string languageBundle = Path.Combine(folder, "LANGUAGE.BND");
-                if (File.Exists(languageBundle))
+                // The European editions keep it at the folder root; the CJK editions (Chinese/Japanese/
+                // Korean) keep it under a VIDEO/ subfolder, so we search recursively like EnumerateNutFonts
+                // and EnumerateTrs already do (ScummVM finds it in either place via its recursive search path).
+                string languageBundle = Directory
+                    .GetFiles(folder, "LANGUAGE.BND", SearchOption.AllDirectories)
+                    .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+                    .FirstOrDefault();
+                if (!string.IsNullOrEmpty(languageBundle))
                 {
                     info.LanguageBundlePath = languageBundle;
                 }

--- a/ScummEditor.Engine/ScummEditor.Engine.csproj
+++ b/ScummEditor.Engine/ScummEditor.Engine.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0-windows</TargetFramework>
     <RootNamespace>ScummEditor.Engine</RootNamespace>
     <AssemblyName>ScummEditor.Engine</AssemblyName>
-    <Version>3.6.1</Version>
+    <Version>4.0.0</Version>
 
     <!-- Pure engine: parsing, codecs, export/import, detection. NO WinForms - this layer must stay
          usable by any future GUI. It returns System.Drawing.Bitmap (via System.Drawing.Common). -->

--- a/ScummEditor.Engine/Structures/DataDisk.cs
+++ b/ScummEditor.Engine/Structures/DataDisk.cs
@@ -6,6 +6,6 @@ namespace ScummEditor.Engine.Structures
     public class DataDisk
     {
         public string FilePath { get; set; }
-        public ScummV5V6DataFile Tree { get; set; }
+        public ScummDataFile Tree { get; set; }
     }
 }

--- a/ScummEditor.Engine/Structures/DataFile/CostumeAkos.cs
+++ b/ScummEditor.Engine/Structures/DataFile/CostumeAkos.cs
@@ -1,0 +1,14 @@
+namespace ScummEditor.Engine.Structures.DataFile
+{
+    /// <summary>
+    /// A SCUMM v7 AKOS costume (The Dig, Full Throttle). Structurally it is just the generic IFF
+    /// container (AKHD/AKOF/AKCI/AKCD/AKPL/RGBS sub-blocks), so it reuses RawContainerBlock unchanged
+    /// for a byte-exact round-trip. The distinct type exists only so the GUI can route it to the AKOS
+    /// costume viewer (AkosImageDecoder reads its sub-blocks) instead of the generic hex view - the
+    /// same pattern the v5/v6 Costume and v4 CostumeV4 blocks use.
+    /// </summary>
+    public class CostumeAkos : RawContainerBlock
+    {
+        public CostumeAkos(BlockBase parent, string blockType) : base(parent, blockType) { }
+    }
+}

--- a/ScummEditor.Engine/Structures/DataFile/DiskBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/DiskBlock.cs
@@ -132,7 +132,12 @@ namespace ScummEditor.Engine.Structures.DataFile
         {
             if (IsKnownV7LflfTag(tag) && HasValidBlockSize(binaryReader, endPosition))
             {
-                var child = new RawContainerBlock(this, tag);
+                // Global scripts are typed so the text pipeline can read them; the rest (SOUN/iMUS, AKOS
+                // costumes, CHAR) stay generic byte-preserved blocks. All keep their bytes for an exact
+                // rebuild.
+                BlockBase child = tag == "SCRP"
+                    ? (BlockBase)new ScriptBlock(this, "SCRP")
+                    : new RawContainerBlock(this, tag);
                 child.LoadFromBinaryReader(binaryReader);
                 Childrens.Add(child);
                 return;

--- a/ScummEditor.Engine/Structures/DataFile/DiskBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/DiskBlock.cs
@@ -134,9 +134,9 @@ namespace ScummEditor.Engine.Structures.DataFile
             {
                 // Global scripts are typed so the text pipeline can read them; AKOS costumes are typed so
                 // the GUI shows the costume viewer; CHAR fonts are typed as Charset so the font viewer and
-                // export/import work (the v7 in-resource charset has the same body layout as v5/v6). All
-                // of these keep their bytes verbatim, so the file still rebuilds byte-identically. The rest
-                // (SOUN/iMUS) stay generic byte-preserved blocks.
+                // export/import work; SOUN sounds are typed as SoundBlockV7 so the sound viewer can decode
+                // the iMUS/VOC audio. All of these subclass the generic container (or keep RawContent
+                // verbatim), so the file still rebuilds byte-identically.
                 BlockBase child;
                 if (tag == "SCRP")
                 {
@@ -149,6 +149,10 @@ namespace ScummEditor.Engine.Structures.DataFile
                 else if (tag == "CHAR")
                 {
                     child = new Charset(this);
+                }
+                else if (tag == "SOUN")
+                {
+                    child = new SoundBlockV7(this, "SOUN");
                 }
                 else
                 {

--- a/ScummEditor.Engine/Structures/DataFile/DiskBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/DiskBlock.cs
@@ -132,12 +132,23 @@ namespace ScummEditor.Engine.Structures.DataFile
         {
             if (IsKnownV7LflfTag(tag) && HasValidBlockSize(binaryReader, endPosition))
             {
-                // Global scripts are typed so the text pipeline can read them; the rest (SOUN/iMUS, AKOS
-                // costumes, CHAR) stay generic byte-preserved blocks. All keep their bytes for an exact
-                // rebuild.
-                BlockBase child = tag == "SCRP"
-                    ? (BlockBase)new ScriptBlock(this, "SCRP")
-                    : new RawContainerBlock(this, tag);
+                // Global scripts are typed so the text pipeline can read them; AKOS costumes are typed so
+                // the GUI shows the costume viewer (both stay byte-preserved via their container base).
+                // The rest (SOUN/iMUS, CHAR) stay generic byte-preserved blocks. All keep their bytes for
+                // an exact rebuild.
+                BlockBase child;
+                if (tag == "SCRP")
+                {
+                    child = new ScriptBlock(this, "SCRP");
+                }
+                else if (tag == "AKOS")
+                {
+                    child = new CostumeAkos(this, "AKOS");
+                }
+                else
+                {
+                    child = new RawContainerBlock(this, tag);
+                }
                 child.LoadFromBinaryReader(binaryReader);
                 Childrens.Add(child);
                 return;

--- a/ScummEditor.Engine/Structures/DataFile/DiskBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/DiskBlock.cs
@@ -133,9 +133,10 @@ namespace ScummEditor.Engine.Structures.DataFile
             if (IsKnownV7LflfTag(tag) && HasValidBlockSize(binaryReader, endPosition))
             {
                 // Global scripts are typed so the text pipeline can read them; AKOS costumes are typed so
-                // the GUI shows the costume viewer (both stay byte-preserved via their container base).
-                // The rest (SOUN/iMUS, CHAR) stay generic byte-preserved blocks. All keep their bytes for
-                // an exact rebuild.
+                // the GUI shows the costume viewer; CHAR fonts are typed as Charset so the font viewer and
+                // export/import work (the v7 in-resource charset has the same body layout as v5/v6). All
+                // of these keep their bytes verbatim, so the file still rebuilds byte-identically. The rest
+                // (SOUN/iMUS) stay generic byte-preserved blocks.
                 BlockBase child;
                 if (tag == "SCRP")
                 {
@@ -144,6 +145,10 @@ namespace ScummEditor.Engine.Structures.DataFile
                 else if (tag == "AKOS")
                 {
                     child = new CostumeAkos(this, "AKOS");
+                }
+                else if (tag == "CHAR")
+                {
+                    child = new Charset(this);
                 }
                 else
                 {

--- a/ScummEditor.Engine/Structures/DataFile/DiskBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/DiskBlock.cs
@@ -34,6 +34,13 @@ namespace ScummEditor.Engine.Structures.DataFile
             while (binaryReader.Position < endPosition)
             {
                 string typeRead = BinaryHelper.ConvertByteArrayToUTF8String(binaryReader.PeekBytes(4));
+
+                if (_gameInfo != null && _gameInfo.ScummVersion == 7)
+                {
+                    LoadV7Child(binaryReader, typeRead, endPosition);
+                    continue;
+                }
+
                 switch (typeRead)
                 {
                     case "COST":
@@ -111,6 +118,84 @@ namespace ScummEditor.Engine.Structures.DataFile
             {
                 child.SaveToBinaryWriter(binaryWriter);
             }
+        }
+
+        /// <summary>
+        /// Reads one v7 LFLF child. The LFLF holds the room (ROOM, already read) followed by its
+        /// resources (SCRP, SOUN/iMUS, AKOS costumes, CHAR), read with the generic recursive reader so
+        /// the file round-trips exactly and the AKOS/CHAR tags stay visible for index linking. Some
+        /// rooms (e.g. Full Throttle room 88) also store an UNTAGGED data table between two AKOS blocks;
+        /// that data is captured verbatim as a header-less raw block up to the next known resource, so
+        /// the rest of the LFLF still parses (it is not a stream of self-describing IFF blocks).
+        /// </summary>
+        private void LoadV7Child(Stream binaryReader, string tag, long endPosition)
+        {
+            if (IsKnownV7LflfTag(tag) && HasValidBlockSize(binaryReader, endPosition))
+            {
+                var child = new RawContainerBlock(this, tag);
+                child.LoadFromBinaryReader(binaryReader);
+                Childrens.Add(child);
+                return;
+            }
+
+            long gapEnd = FindNextV7BlockOffset(binaryReader, endPosition);
+            var gap = new RawDataBlock(this, (int)(gapEnd - binaryReader.Position));
+            gap.LoadFromBinaryReader(binaryReader);
+            Childrens.Add(gap);
+        }
+
+        /// <summary>The block tags that appear directly inside a v7 LFLF (room disk block).</summary>
+        private static bool IsKnownV7LflfTag(string tag)
+        {
+            return tag == "ROOM" || tag == "SCRP" || tag == "SOUN" || tag == "AKOS" || tag == "CHAR";
+        }
+
+        /// <summary>Peeks the block header at the current position; true when the size is well-formed
+        /// (&gt;= 8) and the block fits before <paramref name="endPosition"/>.</summary>
+        private static bool HasValidBlockSize(Stream binaryReader, long endPosition)
+        {
+            byte[] head = binaryReader.PeekBytes(8);
+            if (head.Length < 8)
+            {
+                return false;
+            }
+            uint size = (uint)((head[4] << 24) | (head[5] << 16) | (head[6] << 8) | head[7]);
+            return size >= 8 && binaryReader.Position + size <= endPosition;
+        }
+
+        /// <summary>
+        /// Scans forward (in memory) from the current position for the next known LFLF child block
+        /// (a known tag with a valid size). Returns <paramref name="endPosition"/> when there is none,
+        /// so the trailing data is captured to the end of the LFLF.
+        /// </summary>
+        private static long FindNextV7BlockOffset(Stream binaryReader, long endPosition)
+        {
+            long start = binaryReader.Position;
+            byte[] buffer = binaryReader.PeekBytes((int)(endPosition - start));
+            for (int i = 1; i + 8 <= buffer.Length; i++)
+            {
+                if (!IsKnownV7LflfTagBytes(buffer, i))
+                {
+                    continue;
+                }
+                uint size = (uint)((buffer[i + 4] << 24) | (buffer[i + 5] << 16) | (buffer[i + 6] << 8) | buffer[i + 7]);
+                if (size >= 8 && start + i + size <= endPosition)
+                {
+                    return start + i;
+                }
+            }
+            return endPosition;
+        }
+
+        private static bool IsKnownV7LflfTagBytes(byte[] b, int o)
+        {
+            return MatchTag(b, o, "ROOM") || MatchTag(b, o, "SCRP") || MatchTag(b, o, "SOUN")
+                || MatchTag(b, o, "AKOS") || MatchTag(b, o, "CHAR");
+        }
+
+        private static bool MatchTag(byte[] b, int o, string tag)
+        {
+            return b[o] == tag[0] && b[o + 1] == tag[1] && b[o + 2] == tag[2] && b[o + 3] == tag[3];
         }
 
         public RoomBlock GetROOM()

--- a/ScummEditor.Engine/Structures/DataFile/NotImplementedDataBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/NotImplementedDataBlock.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace ScummEditor.Engine.Structures.DataFile
 {
-    public class NotImplementedDataBlock : BlockBase
+    public class NotImplementedDataBlock : BlockBase, IRawContentBlock
     {
         public byte[] Contents { get; set; }
 

--- a/ScummEditor.Engine/Structures/DataFile/NutFont.cs
+++ b/ScummEditor.Engine/Structures/DataFile/NutFont.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+
+namespace ScummEditor.Engine.Structures.DataFile
+{
+    /*
+    NUT - SCUMM v7 external SMUSH font / sprite-sheet file (The Dig, Full Throttle). Unlike the CHAR
+    charset, a NUT file lives OUTSIDE the .LA0/.LA1 container, as its own file in the game folder
+    (FONT0.NUT, SCUMMFNT.NUT, BIGFONT.NUT, ...). It is a SMUSH animation container, one frame per glyph:
+
+      ANIM  (big-endian [tag:4]["BE size":4]) container of:
+        AHDR  (big-endian tag+size) header; number of glyphs = uint16 LE at AHDR + 10
+        FRME * numChars   (big-endian tag+size) one per glyph, each holding:
+          FOBJ  (big-endian tag+size) the frame object:
+            +8  uint16 LE  codec (1/3 = BOMP RLE, 21/44 = skip-copy RLE)
+            +10 int16  LE  x offset
+            +12 int16  LE  y offset
+            +14 uint16 LE  width
+            +16 uint16 LE  height
+            +18 4 bytes    (unused)
+            +22 ...        encoded pixel payload (length = FOBJ size - 14)
+
+    Glyph pixels are 8-bit indices into the game's runtime palette (NUT carries no palette of its own).
+    The whole file is kept verbatim (RawContent) and written back unchanged, so an unedited font always
+    round-trips byte-identically; only an edited glyph is re-encoded (NutImageEncoder rebuilds RawContent).
+    */
+    public class NutFont
+    {
+        public string FilePath { get; set; }
+        public byte[] RawContent { get; set; }
+
+        /// <summary>Glyph (frame) count declared in AHDR; equals Glyphs.Count when the file parses fully.</summary>
+        public int NumChars { get; private set; }
+
+        public List<NutGlyph> Glyphs { get; private set; } = new List<NutGlyph>();
+
+        /// <summary>True when the ANIM/AHDR header is well-formed and at least one glyph parsed.</summary>
+        public bool IsValid { get; private set; }
+
+        public void LoadFromFileBytes(byte[] fileBytes)
+        {
+            RawContent = fileBytes;
+            Reparse();
+        }
+
+        /// <summary>Re-reads the frame table from RawContent (after a glyph is re-encoded).</summary>
+        public void Reparse()
+        {
+            Glyphs = new List<NutGlyph>();
+            NumChars = 0;
+            IsValid = false;
+            byte[] data = RawContent;
+            if (data == null || data.Length < 24) return;
+
+            if (Tag(data, 0) != "ANIM" || Tag(data, 8) != "AHDR") return;
+
+            int ahdrSize = (int)ReadUInt32BE(data, 12);
+            NumChars = ReadUInt16LE(data, 18); // AHDR + 10
+
+            // First FRME follows the AHDR chunk (tag+size = 8 bytes), padded to an even boundary.
+            int p = 16 + ahdrSize;
+            if ((ahdrSize & 1) != 0) p++;
+
+            while (Glyphs.Count < NumChars && p + 8 <= data.Length)
+            {
+                if (Tag(data, p) != "FRME") break;
+                int frameSize = (int)ReadUInt32BE(data, p + 4);
+
+                var glyph = new NutGlyph { Index = Glyphs.Count, FrameOffset = p, FrameSize = frameSize };
+
+                int fp = p + 8; // FOBJ sits at the start of the FRME body
+                if (fp + 22 <= data.Length && Tag(data, fp) == "FOBJ")
+                {
+                    int fobjSize = (int)ReadUInt32BE(data, fp + 4);
+                    glyph.FobjOffset = fp;
+                    glyph.FobjSize = fobjSize;
+                    glyph.Codec = ReadUInt16LE(data, fp + 8);
+                    glyph.XOffset = (short)ReadUInt16LE(data, fp + 10);
+                    glyph.YOffset = (short)ReadUInt16LE(data, fp + 12);
+                    glyph.Width = ReadUInt16LE(data, fp + 14);
+                    glyph.Height = ReadUInt16LE(data, fp + 16);
+                    glyph.PayloadOffset = fp + 22;
+                    glyph.PayloadLength = fobjSize - 14;
+                    if (glyph.PayloadLength < 0 || glyph.PayloadOffset + glyph.PayloadLength > data.Length)
+                    {
+                        glyph.PayloadLength = 0; // malformed: leave it undecodable rather than over-read
+                    }
+                    else
+                    {
+                        glyph.HasFobj = true;
+                    }
+                }
+
+                Glyphs.Add(glyph);
+
+                long next = (long)p + 8 + frameSize;
+                if ((frameSize & 1) != 0) next++;
+                if (next <= p) break; // guard against a zero/negative advance
+                p = (int)next;
+            }
+
+            IsValid = Glyphs.Count > 0;
+        }
+
+        private static string Tag(byte[] data, int offset)
+        {
+            if (offset + 4 > data.Length) return string.Empty;
+            return string.Concat((char)data[offset], (char)data[offset + 1], (char)data[offset + 2], (char)data[offset + 3]);
+        }
+
+        private static int ReadUInt16LE(byte[] b, int o)
+        {
+            return b[o] | (b[o + 1] << 8);
+        }
+
+        private static uint ReadUInt32BE(byte[] b, int o)
+        {
+            return (uint)((b[o] << 24) | (b[o + 1] << 16) | (b[o + 2] << 8) | b[o + 3]);
+        }
+    }
+
+    /// <summary>One glyph (FRME/FOBJ) of a NUT font: its codec, dimensions and the byte range of its
+    /// encoded payload within the parent <see cref="NutFont.RawContent"/>.</summary>
+    public class NutGlyph
+    {
+        public int Index { get; set; }
+        public int Codec { get; set; }
+        public int XOffset { get; set; }
+        public int YOffset { get; set; }
+        public int Width { get; set; }
+        public int Height { get; set; }
+
+        public int FrameOffset { get; set; } // offset of the FRME tag in RawContent
+        public int FrameSize { get; set; }   // FRME chunk size (bytes after the FRME tag+size)
+        public int FobjOffset { get; set; }   // offset of the FOBJ tag
+        public int FobjSize { get; set; }
+        public int PayloadOffset { get; set; } // first encoded pixel byte
+        public int PayloadLength { get; set; }
+
+        /// <summary>True when a valid FOBJ was found (some FRMEs are empty placeholders).</summary>
+        public bool HasFobj { get; set; }
+
+        /// <summary>True when the glyph has decodable pixels.</summary>
+        public bool HasPixels { get { return HasFobj && Width > 0 && Height > 0; } }
+    }
+}

--- a/ScummEditor.Engine/Structures/DataFile/ObjectCode.cs
+++ b/ScummEditor.Engine/Structures/DataFile/ObjectCode.cs
@@ -278,6 +278,16 @@ namespace ScummEditor.Engine.Structures.DataFile
 
         private void ParseCodeHeader(int p, int length)
         {
+            // SCUMM v7 CDHD body has 8 bytes: version:32le, obj id:16le, parent:8, parent state:8.
+            // (v7 moved the position/size fields out of the code header; only the id is kept here.)
+            if (length == 8)
+            {
+                HasCodeHeader = true;
+                ObjectId = ReadUInt16(p + 4);
+                ParentObject = RawContent[p + 6];
+                return;
+            }
+
             // SCUMM v5 CDHD body has 13 bytes; x/y/w/h are bytes in 8-pixel units.
             //   obj id:16le, x:8, y:8, w:8, h:8, flags:8, parent:8, walk_x:16le, walk_y:16le, actor dir:8
             if (length == 13)

--- a/ScummEditor.Engine/Structures/DataFile/ObjectImageHeader.cs
+++ b/ScummEditor.Engine/Structures/DataFile/ObjectImageHeader.cs
@@ -44,9 +44,29 @@ namespace ScummEditor.Engine.Structures.DataFile
         public ushort NumHotspots { get; set; }
         public List<Hotspot> Hotspots { get; set; }
 
+        /// <summary>v7-only leading version word (0 on v5/v6).</summary>
+        public uint Version { get; set; }
+        /// <summary>v7-only 3 reserved bytes between height and actor direction (null on v5/v6).</summary>
+        public byte[] Unknown2 { get; set; }
+        /// <summary>v7-only actor direction byte (0 on v5/v6).</summary>
+        public byte ActorDirection { get; set; }
+
+        private bool IsV7
+        {
+            get { return _gameInfo != null && _gameInfo.ScummVersion == 7; }
+        }
+
         public override void CalculateBlockSize()
         {
             base.CalculateBlockSize();
+
+            if (IsV7)
+            {
+                // version:4 + obj_id:2 + image_count:2 + x:2 + y:2 + width:2 + height:2 + unk:3 +
+                // actordir:1 + hotspot_num:2 + hotspots:4*n
+                BlockSize += (uint)(20 + 2 + 4 * Hotspots.Count);
+                return;
+            }
 
             uint block = 0;
             block += 2; //id
@@ -72,6 +92,12 @@ namespace ScummEditor.Engine.Structures.DataFile
         {
             base.LoadFromBinaryReader(binaryReader);
 
+            if (IsV7)
+            {
+                LoadScummV7(binaryReader);
+                return;
+            }
+
             Id = binaryReader.ReadUint16();
             NumImages = binaryReader.ReadUint16();
             NumZPlanes = binaryReader.ReadUint16();
@@ -96,9 +122,62 @@ namespace ScummEditor.Engine.Structures.DataFile
             }
         }
 
+        /// <summary>
+        /// v7 IMHD: version:32le, obj_id:16le, image_count:16le, x:16le, y:16le, width:16le, height:16le,
+        /// 3 reserved bytes, actor dir:8, then (when present) hotspot_num:16le + that many int16 x/y
+        /// hotspots. The decoder only needs image_count (how many IMnn follow) and width/height.
+        /// </summary>
+        private void LoadScummV7(System.IO.Stream binaryReader)
+        {
+            long bodyEnd = BlockOffSet + BlockSize;
+
+            Version = binaryReader.ReadUint32();
+            Id = binaryReader.ReadUint16();
+            NumImages = binaryReader.ReadUint16();
+            X = binaryReader.ReadUint16();
+            Y = binaryReader.ReadUint16();
+            Width = binaryReader.ReadUint16();
+            Height = binaryReader.ReadUint16();
+            Unknown2 = binaryReader.ReadBytes(3);
+            ActorDirection = binaryReader.ReadByte1();
+
+            Hotspots = new List<Hotspot>();
+            if (binaryReader.Position + 2 <= bodyEnd)
+            {
+                NumHotspots = binaryReader.ReadUint16();
+                for (int i = 0; i < NumHotspots && binaryReader.Position + 4 <= bodyEnd; i++)
+                {
+                    var item = new Hotspot();
+                    item.X = binaryReader.ReadInt16();
+                    item.Y = binaryReader.ReadInt16();
+                    Hotspots.Add(item);
+                }
+            }
+        }
+
         public override void SaveToBinaryWriter(System.IO.Stream binaryWriter)
         {
             base.SaveToBinaryWriter(binaryWriter);
+
+            if (IsV7)
+            {
+                binaryWriter.Write(Version);
+                binaryWriter.Write(Id);
+                binaryWriter.Write(NumImages);
+                binaryWriter.Write(X);
+                binaryWriter.Write(Y);
+                binaryWriter.Write(Width);
+                binaryWriter.Write(Height);
+                binaryWriter.WriteBytes(Unknown2);
+                binaryWriter.WriteByte(ActorDirection);
+                binaryWriter.Write(NumHotspots);
+                foreach (Hotspot hotspot in Hotspots)
+                {
+                    binaryWriter.Write(hotspot.X);
+                    binaryWriter.Write(hotspot.Y);
+                }
+                return;
+            }
 
             binaryWriter.Write(Id);
             binaryWriter.Write(NumImages);

--- a/ScummEditor.Engine/Structures/DataFile/RawContainerBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/RawContainerBlock.cs
@@ -1,0 +1,174 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace ScummEditor.Engine.Structures.DataFile
+{
+    /// <summary>
+    /// A generic IFF block read recursively. After its header ([tag:4][size:4 BE]) the body is
+    /// inspected: if it is a sequence of well-formed sub-blocks that tile it exactly, each sub-block
+    /// is parsed (and may itself be a container); otherwise the body is kept verbatim as raw bytes.
+    /// Either way the block round-trips byte-for-byte, because a container writes its header plus its
+    /// children and a leaf writes its header plus its raw bytes.
+    ///
+    /// This is the SCUMM v7 work-horse: it gives a navigable tree for the blocks the editor does not
+    /// yet model (AKOS, SOUN/iMUS, SMAP, ZPxx, the v7 object headers, ...) while guaranteeing an
+    /// identical rebuild, so v7 games load, navigate and save before any block gets typed support.
+    /// </summary>
+    public class RawContainerBlock : BlockBase, IRawContentBlock
+    {
+        // Deep enough for the real v7 nesting (LECF>LFLF>ROOM>OBIM>IMnn>SMAP and AKOS>...), with a
+        // margin; the cap only stops a runaway recursion on pathological/misdetected data.
+        private const int MaxDepth = 10;
+
+        private readonly string _blockType;
+        private readonly int _depth;
+
+        /// <summary>The raw body bytes when this block is a leaf; null when it is a container (its
+        /// bytes live in <see cref="BlockBase.Childrens"/>).</summary>
+        public byte[] Contents { get; set; }
+
+        public RawContainerBlock(BlockBase parent, string blockType) : this(parent, blockType, 0) { }
+
+        private RawContainerBlock(BlockBase parent, string blockType, int depth) : base(parent)
+        {
+            _blockType = blockType;
+            _depth = depth;
+        }
+
+        public override string BlockType
+        {
+            get { return _blockType; }
+        }
+
+        /// <summary>True when this block is stored as raw bytes (no parsed children).</summary>
+        public bool IsLeaf
+        {
+            get { return Contents != null; }
+        }
+
+        public override void CalculateBlockSize()
+        {
+            if (Contents != null)
+            {
+                BlockSize = (uint)(HeaderLength + Contents.Length);
+                return;
+            }
+
+            base.CalculateBlockSize(); // header + recursive sum of children
+        }
+
+        public override void LoadFromBinaryReader(Stream binaryReader)
+        {
+            base.LoadFromBinaryReader(binaryReader); // reads & validates the [tag][size] header
+
+            int bodyLength = (int)BlockSize - HeaderLength;
+            if (bodyLength < 0)
+            {
+                bodyLength = 0;
+            }
+
+            byte[] body = binaryReader.ReadBytes(bodyLength);
+
+            if (_depth < MaxDepth && BodyTilesIntoBlocks(body))
+            {
+                ParseChildrenFromBody(body);
+                Contents = null;
+            }
+            else
+            {
+                Contents = body;
+            }
+        }
+
+        public override void SaveToBinaryWriter(Stream binaryWriter)
+        {
+            base.SaveToBinaryWriter(binaryWriter); // writes the [tag][size] header
+
+            if (Contents != null)
+            {
+                binaryWriter.WriteBytes(Contents);
+                return;
+            }
+
+            foreach (BlockBase child in Childrens)
+            {
+                child.SaveToBinaryWriter(binaryWriter);
+            }
+        }
+
+        /// <summary>
+        /// Parses the body as a sequence of child blocks. The children get body-relative offsets,
+        /// which is harmless: CalculateOffsets recomputes every offset from the tree on save, and only
+        /// the LFLF-level blocks (parsed from the real stream) take part in index linking.
+        /// </summary>
+        private void ParseChildrenFromBody(byte[] body)
+        {
+            using (var stream = new MemoryStream(body, false))
+            {
+                while (stream.Position < stream.Length)
+                {
+                    string tag = BinaryHelper.ConvertByteArrayToUTF8String(stream.PeekBytes(4));
+                    var child = new RawContainerBlock(this, tag, _depth + 1);
+                    child.LoadFromBinaryReader(stream);
+                    Childrens.Add(child);
+                }
+            }
+        }
+
+        /// <summary>
+        /// True when the body is one or more well-formed sub-blocks ([tag:4][size:4 BE], size &gt;= 8)
+        /// that tile it exactly. The tag must be printable text starting with a letter, so compressed
+        /// pixel/codec data (SMAP, AKCD, ...) is never mistaken for a container.
+        /// </summary>
+        private static bool BodyTilesIntoBlocks(byte[] body)
+        {
+            int position = 0;
+            int blockCount = 0;
+
+            while (position + 8 <= body.Length)
+            {
+                if (!IsLikelyTag(body, position))
+                {
+                    return false;
+                }
+
+                uint size = ReadBigEndianUInt32(body, position + 4);
+                if (size < 8 || position + size > body.Length)
+                {
+                    return false;
+                }
+
+                position += (int)size;
+                blockCount++;
+            }
+
+            return blockCount >= 1 && position == body.Length;
+        }
+
+        /// <summary>A SCUMM tag is 4 bytes of printable text (letters, digits, space, underscore)
+        /// whose first byte is a letter - covers tags like "RMIM", "iMUS" and "MAP ".</summary>
+        private static bool IsLikelyTag(byte[] body, int offset)
+        {
+            for (int i = 0; i < 4; i++)
+            {
+                byte c = body[offset + i];
+                bool isLetter = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+                bool isAllowed = isLetter || (c >= '0' && c <= '9') || c == ' ' || c == '_';
+                if (!isAllowed)
+                {
+                    return false;
+                }
+                if (i == 0 && !isLetter)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static uint ReadBigEndianUInt32(byte[] data, int offset)
+        {
+            return (uint)((data[offset] << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3]);
+        }
+    }
+}

--- a/ScummEditor.Engine/Structures/DataFile/RawDataBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/RawDataBlock.cs
@@ -8,7 +8,7 @@ namespace ScummEditor.Engine.Structures.DataFile
     /// A run of raw bytes inside a v4 container that is not a self-describing block (e.g. the
     /// trailing sound data of a room). It has no header of its own and is kept verbatim.
     /// </summary>
-    public class RawDataBlock : BlockBase
+    public class RawDataBlock : BlockBase, IRawContentBlock
     {
         private readonly int _length;
         public byte[] Contents { get; set; }

--- a/ScummEditor.Engine/Structures/DataFile/RoomBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/RoomBlock.cs
@@ -41,6 +41,37 @@ namespace ScummEditor.Engine.Structures.DataFile
                 case 6:
                     LoadScummV6(binaryReader);
                     break;
+                case 7:
+                    LoadScummV7(binaryReader);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Reads a v7 ROOM (The Dig, Full Throttle). Only the room header is typed (its body is the
+        /// 10-byte v7 layout); every other child - palettes, images, object blocks, scripts, boxes -
+        /// is read with the generic recursive reader, which navigates containers and keeps leaves
+        /// verbatim, so the room rebuilds byte-for-byte before any block gets typed v7 support.
+        /// </summary>
+        private void LoadScummV7(Stream binaryReader)
+        {
+            long endPosition = binaryReader.Position - 8 + BlockSize;
+
+            while (binaryReader.Position < endPosition)
+            {
+                string typeRead = BinaryHelper.ConvertByteArrayToUTF8String(binaryReader.PeekBytes(4));
+                if (typeRead == "RMHD")
+                {
+                    var RMHD = new RoomHeader(this);
+                    RMHD.LoadFromBinaryReader(binaryReader);
+                    Childrens.Add(RMHD);
+                }
+                else
+                {
+                    var child = new RawContainerBlock(this, typeRead);
+                    child.LoadFromBinaryReader(binaryReader);
+                    Childrens.Add(child);
+                }
             }
         }
 

--- a/ScummEditor.Engine/Structures/DataFile/RoomBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/RoomBlock.cs
@@ -85,6 +85,33 @@ namespace ScummEditor.Engine.Structures.DataFile
                         Childrens.Add(OBCD);
                         break;
 
+                    // Image blocks are typed so the image decoder/encoder and the GUI preview work on
+                    // v7. The SMAP strip codec, z-planes and APAL palette are identical to v5/v6; only
+                    // the headers (RMHD - done - and IMHD) carry the v7 layout. All keep their bytes.
+                    case "TRNS":
+                        var TRNS = new ValuePaddingBlock(this, "TRNS");
+                        TRNS.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(TRNS);
+                        break;
+
+                    case "PALS":
+                        var PALS = new PalettesData(this);
+                        PALS.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(PALS);
+                        break;
+
+                    case "RMIM":
+                        var RMIM = new RoomImage(this, this);
+                        RMIM.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(RMIM);
+                        break;
+
+                    case "OBIM":
+                        var OBIM = new ObjectImage(this);
+                        OBIM.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(OBIM);
+                        break;
+
                     default:
                         var child = new RawContainerBlock(this, typeRead);
                         child.LoadFromBinaryReader(binaryReader);

--- a/ScummEditor.Engine/Structures/DataFile/RoomBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/RoomBlock.cs
@@ -85,6 +85,40 @@ namespace ScummEditor.Engine.Structures.DataFile
                         Childrens.Add(OBCD);
                         break;
 
+                    // Room structural blocks: colour-cycle, walk-box data/matrix, scale slots and the
+                    // local-script count. v7 reuses the v5/v6 layout (the walk-box record is the same
+                    // 20-byte SIZEOF_BOX), so the existing typed blocks - which keep their bytes verbatim
+                    // and parse only for display - route them to the friendly viewers instead of raw hex.
+                    case "CYCL":
+                        var CYCL = new ColorCycles(this);
+                        CYCL.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(CYCL);
+                        break;
+
+                    case "BOXD":
+                        var BOXD = new BoxData(this);
+                        BOXD.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(BOXD);
+                        break;
+
+                    case "BOXM":
+                        var BOXM = new BoxMatrix(this);
+                        BOXM.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(BOXM);
+                        break;
+
+                    case "SCAL":
+                        var SCAL = new Scale(this);
+                        SCAL.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(SCAL);
+                        break;
+
+                    case "NLSC":
+                        var NLSC = new ValuePaddingBlock(this, "NLSC");
+                        NLSC.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(NLSC);
+                        break;
+
                     // Image blocks are typed so the image decoder/encoder and the GUI preview work on
                     // v7. The SMAP strip codec, z-planes and APAL palette are identical to v5/v6; only
                     // the headers (RMHD - done - and IMHD) carry the v7 layout. All keep their bytes.

--- a/ScummEditor.Engine/Structures/DataFile/RoomBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/RoomBlock.cs
@@ -60,17 +60,36 @@ namespace ScummEditor.Engine.Structures.DataFile
             while (binaryReader.Position < endPosition)
             {
                 string typeRead = BinaryHelper.ConvertByteArrayToUTF8String(binaryReader.PeekBytes(4));
-                if (typeRead == "RMHD")
+                switch (typeRead)
                 {
-                    var RMHD = new RoomHeader(this);
-                    RMHD.LoadFromBinaryReader(binaryReader);
-                    Childrens.Add(RMHD);
-                }
-                else
-                {
-                    var child = new RawContainerBlock(this, typeRead);
-                    child.LoadFromBinaryReader(binaryReader);
-                    Childrens.Add(child);
+                    case "RMHD":
+                        var RMHD = new RoomHeader(this);
+                        RMHD.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(RMHD);
+                        break;
+
+                    // Script and object-code blocks are typed so the text pipeline (which finds
+                    // ScriptBlock / ObjectCode children and disassembles their v6-compatible bytecode)
+                    // works on v7. They keep their raw bytes, so the room still rebuilds byte-for-byte.
+                    case "EXCD":
+                    case "ENCD":
+                    case "LSCR":
+                        var script = new ScriptBlock(this, typeRead);
+                        script.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(script);
+                        break;
+
+                    case "OBCD":
+                        var OBCD = new ObjectCode(this);
+                        OBCD.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(OBCD);
+                        break;
+
+                    default:
+                        var child = new RawContainerBlock(this, typeRead);
+                        child.LoadFromBinaryReader(binaryReader);
+                        Childrens.Add(child);
+                        break;
                 }
             }
         }

--- a/ScummEditor.Engine/Structures/DataFile/RoomHeader.cs
+++ b/ScummEditor.Engine/Structures/DataFile/RoomHeader.cs
@@ -2,20 +2,32 @@
 {
     /*
     RMHD - Room Header
-    width    : 2 bytes
-    height   : 2 bytes
-    num objs : 2 bytes
+    v4/v5/v6:                 v7 (The Dig, Full Throttle):
+      width    : 2 bytes        version  : 4 bytes (LE)
+      height   : 2 bytes        width    : 2 bytes
+      num objs : 2 bytes        height   : 2 bytes
+                                num objs : 2 bytes
+    The v7 body is 10 bytes (a leading version word was added); v8 widens the fields further and is
+    not handled here.
     */
 
     public class RoomHeader : BlockBase, IImageSize
     {
         public RoomHeader(BlockBase blockBase) : base(blockBase) { }
 
+        /// <summary>v7-only leading version word (0 on v4/v5/v6, which have no such field).</summary>
+        public uint Version { get; set; }
         public ushort Width { get; set; }
         public ushort Height { get; set; }
         public ushort NumObjects { get; set; }
 
-        // v4 calls this block "HD"; v5/v6 call it "RMHD". The body (width/height/numObjects) is the same.
+        private bool IsV7
+        {
+            get { return _gameInfo != null && _gameInfo.ScummVersion == 7; }
+        }
+
+        // v4 calls this block "HD"; v5/v6/v7 call it "RMHD". The body (width/height/numObjects) is the
+        // same, except v7 prefixes a 4-byte version word.
         public override string BlockType
         {
             get { return IsSmallHeader ? "HD" : "RMHD"; }
@@ -25,13 +37,17 @@
         {
             base.CalculateBlockSize();
 
-            BlockSize += 6;
+            BlockSize += IsV7 ? (uint)10 : 6;
         }
 
         public override void LoadFromBinaryReader(System.IO.Stream binaryReader)
         {
             base.LoadFromBinaryReader(binaryReader);
 
+            if (IsV7)
+            {
+                Version = binaryReader.ReadUint32();
+            }
             Width = binaryReader.ReadUint16();
             Height = binaryReader.ReadUint16();
             NumObjects = binaryReader.ReadUint16();
@@ -41,6 +57,10 @@
         {
             base.SaveToBinaryWriter(binaryWriter);
 
+            if (IsV7)
+            {
+                binaryWriter.Write(Version);
+            }
             binaryWriter.Write(Width);
             binaryWriter.Write(Height);
             binaryWriter.Write(NumObjects);

--- a/ScummEditor.Engine/Structures/DataFile/ScriptBlock.cs
+++ b/ScummEditor.Engine/Structures/DataFile/ScriptBlock.cs
@@ -51,8 +51,19 @@ namespace ScummEditor.Engine.Structures.DataFile
 
             if (_blockType == "LSCR" && RawContent.Length > 0)
             {
-                ScriptId = RawContent[0];
-                CodeOffset = 1;
+                // The local-script id is 1 byte on v5/v6, but 2 bytes (LE) on v7 (The Dig, Full Throttle
+                // have far more local scripts); the bytecode starts right after it. Using the v6 1-byte
+                // offset on v7 starts the disassembly one byte early and desyncs every local script.
+                if (_gameInfo != null && _gameInfo.ScummVersion == 7 && RawContent.Length >= 2)
+                {
+                    ScriptId = RawContent[0] | (RawContent[1] << 8);
+                    CodeOffset = 2;
+                }
+                else
+                {
+                    ScriptId = RawContent[0];
+                    CodeOffset = 1;
+                }
             }
         }
 

--- a/ScummEditor.Engine/Structures/DataFile/ScummDataFile.cs
+++ b/ScummEditor.Engine/Structures/DataFile/ScummDataFile.cs
@@ -6,9 +6,9 @@ namespace ScummEditor.Engine.Structures.DataFile
     //LECF - Main Container
     //  LOFF     - Room offsets table
     //  LFLF * n - Game Rooms.
-    public class ScummV5V6DataFile : BlockBase
+    public class ScummDataFile : BlockBase
     {
-        public ScummV5V6DataFile(BlockBase blockBase, GameInfo loadedGameInfo) : base(blockBase, loadedGameInfo) { }
+        public ScummDataFile(BlockBase blockBase, GameInfo loadedGameInfo) : base(blockBase, loadedGameInfo) { }
 
         public override string BlockType
         {

--- a/ScummEditor.Engine/Structures/DataFile/ScummV3OldBundleDataFile.cs
+++ b/ScummEditor.Engine/Structures/DataFile/ScummV3OldBundleDataFile.cs
@@ -19,7 +19,7 @@ namespace ScummEditor.Engine.Structures.DataFile
     write them back unchanged, so the file round-trips byte-for-byte; expose the chunk boundaries as
     a navigation overlay so the room/resource readers can find each chunk without re-tagging anything.
     */
-    public class ScummV3OldBundleDataFile : ScummV5V6DataFile
+    public class ScummV3OldBundleDataFile : ScummDataFile
     {
         public ScummV3OldBundleDataFile(BlockBase blockBase, GameInfo gameInfo) : base(blockBase, gameInfo) { }
 

--- a/ScummEditor.Engine/Structures/DataFile/ScummV3Small256DataFile.cs
+++ b/ScummEditor.Engine/Structures/DataFile/ScummV3Small256DataFile.cs
@@ -19,7 +19,7 @@ namespace ScummEditor.Engine.Structures.DataFile
     the whole v4 block machinery (ScummV4Blocks, ScummV4RoomBlock, ObjectCode, CostumeV4, SoundBlockV4)
     is reused unchanged; the index gives resource positions as file-absolute offsets (RO at 0).
     */
-    public class ScummV3Small256DataFile : ScummV5V6DataFile, IScummRoomContainer
+    public class ScummV3Small256DataFile : ScummDataFile, IScummRoomContainer
     {
         public ScummV3Small256DataFile(BlockBase blockBase, GameInfo gameInfo) : base(blockBase, gameInfo) { }
 

--- a/ScummEditor.Engine/Structures/DataFile/ScummV4DataFile.cs
+++ b/ScummEditor.Engine/Structures/DataFile/ScummV4DataFile.cs
@@ -19,7 +19,7 @@ namespace ScummEditor.Engine.Structures.DataFile
     (LE / LF / RO) are walked, so the file round-trips identically. Typed parsing of the inner
     blocks is layered on top in later steps.
     */
-    public class ScummV4DataFile : ScummV5V6DataFile
+    public class ScummV4DataFile : ScummDataFile
     {
         public ScummV4DataFile(BlockBase blockBase, GameInfo gameInfo) : base(blockBase, gameInfo) { }
 

--- a/ScummEditor.Engine/Structures/DataFile/SoundBlockV7.cs
+++ b/ScummEditor.Engine/Structures/DataFile/SoundBlockV7.cs
@@ -1,0 +1,15 @@
+namespace ScummEditor.Engine.Structures.DataFile
+{
+    /// <summary>
+    /// A SCUMM v7 SOUN sound resource (The Dig, Full Throttle). Structurally it is just the generic IFF
+    /// container - The Dig wraps an iMUS digital-audio resource (MAP/FRMT/DATA), Full Throttle stores a
+    /// Creative Voice File (VOC) - so it reuses RawContainerBlock unchanged for a byte-exact round-trip.
+    /// The distinct type exists only so the GUI routes it to the v7 sound viewer (which decodes the iMUS
+    /// PCM or the VOC to WAV for preview/export) instead of the generic hex view - the same pattern the
+    /// v5/v6 SoundBlock and the v7 CostumeAkos / Charset blocks use.
+    /// </summary>
+    public class SoundBlockV7 : RawContainerBlock
+    {
+        public SoundBlockV7(BlockBase parent, string blockType) : base(parent, blockType) { }
+    }
+}

--- a/ScummEditor.Engine/Structures/GameInfo.cs
+++ b/ScummEditor.Engine/Structures/GameInfo.cs
@@ -100,5 +100,13 @@ namespace ScummEditor.Engine.Structures
         /// MONSTER.SOU instead).
         /// </summary>
         public List<string> BundleFiles { get; set; }
+
+        /// <summary>The Dig's external localized in-game text file (LANGUAGE.BND), present only in the
+        /// non-English editions. Null otherwise.</summary>
+        public string LanguageBundlePath { get; set; }
+
+        /// <summary>External .TRS text files (cutscene-subtitle / UI strings): The Dig DIGTXT.TRS/DIG.TRS,
+        /// Full Throttle's per-scene .TRS. Null/empty for non-v7.</summary>
+        public List<string> TrsFiles { get; set; }
     }
 }

--- a/ScummEditor.Engine/Structures/GameInfo.cs
+++ b/ScummEditor.Engine/Structures/GameInfo.cs
@@ -86,5 +86,12 @@ namespace ScummEditor.Engine.Structures
         /// unlike v5/v6 which embed CHAR blocks in the data file). Null/empty for v5/v6.
         /// </summary>
         public List<string> FontFiles { get; set; }
+
+        /// <summary>
+        /// External .NUT SMUSH font files (v7 The Dig / Full Throttle keep their SMUSH/subtitle fonts as
+        /// separate files next to the .LA0/.LA1 container, e.g. FONT0.NUT, SCUMMFNT.NUT). Null/empty for
+        /// every other engine.
+        /// </summary>
+        public List<string> NutFontFiles { get; set; }
     }
 }

--- a/ScummEditor.Engine/Structures/GameInfo.cs
+++ b/ScummEditor.Engine/Structures/GameInfo.cs
@@ -93,5 +93,12 @@ namespace ScummEditor.Engine.Structures
         /// every other engine.
         /// </summary>
         public List<string> NutFontFiles { get; set; }
+
+        /// <summary>
+        /// External iMUSE sound bundle files (.BUN), e.g. The Dig's DIGMUSIC.BUN / DIGVOICE.BUN sitting next
+        /// to the .LA0/.LA1 container. Null/empty when the game has none (Full Throttle keeps speech in
+        /// MONSTER.SOU instead).
+        /// </summary>
+        public List<string> BundleFiles { get; set; }
     }
 }

--- a/ScummEditor.Engine/Structures/ILocalizedTextFile.cs
+++ b/ScummEditor.Engine/Structures/ILocalizedTextFile.cs
@@ -24,5 +24,11 @@ namespace ScummEditor.Engine.Structures
 
         /// <summary>Applies edits from a KEY&lt;TAB&gt;TEXT dump; returns a short report.</summary>
         string ImportFromText(string content);
+
+        /// <summary>Normalises a string just edited in the GUI to this file's structural rules before it is
+        /// stored as an entry's Text, so the value written back stays faithful to the file's format: a
+        /// LANGUAGE.BND collapses any newline to a space (one message per line), a .TRS converts newlines to
+        /// the file's own native terminator (so editing a Mac LF file does not silently turn it into CRLF).</summary>
+        string NormalizeEditedText(string text);
     }
 }

--- a/ScummEditor.Engine/Structures/ILocalizedTextFile.cs
+++ b/ScummEditor.Engine/Structures/ILocalizedTextFile.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace ScummEditor.Engine.Structures
+{
+    /// <summary>
+    /// An external localized-text file (The Dig LANGUAGE.BND or a .TRS subtitle/UI file). Exposes its
+    /// editable strings as keyed entries, rebuilds the file bytes from the (possibly edited) entries
+    /// byte-identically when unchanged, and round-trips through a plain KEY&lt;TAB&gt;TEXT export/import.
+    /// </summary>
+    public interface ILocalizedTextFile
+    {
+        string FilePath { get; }
+        string FileName { get; }
+        bool IsValid { get; }
+
+        /// <summary>The editable strings. Editing an entry's Text and then calling BuildContent applies it.</summary>
+        IReadOnlyList<LocalizedTextEntry> Entries { get; }
+
+        /// <summary>The current file bytes (the template with edited entries re-encoded in place).</summary>
+        byte[] BuildContent();
+
+        /// <summary>Dumps the strings as KEY&lt;TAB&gt;TEXT lines for external editing.</summary>
+        string ExportToText();
+
+        /// <summary>Applies edits from a KEY&lt;TAB&gt;TEXT dump; returns a short report.</summary>
+        string ImportFromText(string content);
+    }
+}

--- a/ScummEditor.Engine/Structures/IRawContentBlock.cs
+++ b/ScummEditor.Engine/Structures/IRawContentBlock.cs
@@ -1,0 +1,12 @@
+namespace ScummEditor.Engine.Structures
+{
+    /// <summary>
+    /// A block whose body is kept as raw bytes (or null when the block is a parsed container that
+    /// holds its bytes in its children). Lets the GUI show a hex view for the generic byte-preserved
+    /// blocks (NotImplementedDataBlock and the v7 RawContainerBlock / RawDataBlock / RawIndexBlock).
+    /// </summary>
+    public interface IRawContentBlock
+    {
+        byte[] Contents { get; }
+    }
+}

--- a/ScummEditor.Engine/Structures/ImuseBundleFile.cs
+++ b/ScummEditor.Engine/Structures/ImuseBundleFile.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace ScummEditor.Engine.Structures
+{
+    /// <summary>One entry in an iMUSE bundle: a named sound resource at [Offset, Offset+Size) in the file.</summary>
+    public class ImuseBundleEntry
+    {
+        public string Name { get; set; }
+        public int Offset { get; set; }
+        public int Size { get; set; }
+    }
+
+    /// <summary>
+    /// A SCUMM v7 external iMUSE sound bundle (The Dig's DIGMUSIC.BUN / DIGVOICE.BUN). The original shipped
+    /// bundles begin with the tag "LB83" and hold a directory of named entries, each a COMP-compressed (or
+    /// plain iMUS) sound resource. The directory is parsed lazily and entries are read on demand, so the
+    /// 130-260 MB file is never loaded whole. Decompressing an entry (ImuseBundleDecoder) rebuilds its iMUS
+    /// resource; ImuseAudioDecoder then turns that into WAV.
+    /// Layout (ScummVM dimuse_bndmgr.cpp): header tag(4 BE) + dirOffset(4 BE) + numFiles(4 BE); the
+    /// directory at dirOffset is numFiles entries of [8-byte name][4-byte ext][offset:4 BE][size:4 BE].
+    /// </summary>
+    public class ImuseBundleFile
+    {
+        public string FilePath { get; private set; }
+        public List<ImuseBundleEntry> Entries { get; private set; } = new List<ImuseBundleEntry>();
+        public bool IsValid { get; private set; }
+
+        private bool _parsed;
+
+        public ImuseBundleFile(string filePath)
+        {
+            FilePath = filePath;
+        }
+
+        /// <summary>Reads the bundle directory once (header + entry table). Safe to call repeatedly.</summary>
+        public void EnsureParsed()
+        {
+            if (_parsed) return;
+            _parsed = true;
+
+            try
+            {
+                using (var fs = new FileStream(FilePath, FileMode.Open, FileAccess.Read))
+                {
+                    string tag = ReadTag(fs);
+                    if (tag != "LB83" && tag != "LB23")
+                    {
+                        return; // not an iMUSE bundle we understand
+                    }
+                    int dirOffset = ReadUInt32BE(fs);
+                    int numFiles = ReadUInt32BE(fs);
+                    if (numFiles <= 0 || numFiles > 100000) return;
+
+                    fs.Seek(dirOffset, SeekOrigin.Begin);
+                    for (int i = 0; i < numFiles; i++)
+                    {
+                        // LB83: 8-byte name + 4-byte extension (null-padded); LB23: a single 24-byte name.
+                        string name;
+                        if (tag == "LB23")
+                        {
+                            name = ReadFixedString(fs, 24);
+                        }
+                        else
+                        {
+                            string baseName = ReadFixedString(fs, 8);
+                            string ext = ReadFixedString(fs, 4);
+                            name = ext.Length > 0 ? baseName + "." + ext : baseName;
+                        }
+                        int offset = ReadUInt32BE(fs);
+                        int size = ReadUInt32BE(fs);
+                        Entries.Add(new ImuseBundleEntry { Name = name, Offset = offset, Size = size });
+                    }
+                    IsValid = true;
+                }
+            }
+            catch (IOException)
+            {
+                // Leave IsValid false; the viewer reports an unreadable bundle rather than crashing.
+            }
+        }
+
+        /// <summary>Reads an entry's raw bytes (the COMP chunk, or a plain iMUS resource) from the file.</summary>
+        public byte[] ReadEntryRaw(int index)
+        {
+            EnsureParsed();
+            if (index < 0 || index >= Entries.Count) return null;
+
+            ImuseBundleEntry e = Entries[index];
+            using (var fs = new FileStream(FilePath, FileMode.Open, FileAccess.Read))
+            {
+                if (e.Offset < 0 || e.Offset >= fs.Length) return null;
+                int size = e.Size;
+                if (e.Offset + (long)size > fs.Length) size = (int)(fs.Length - e.Offset);
+                if (size <= 0) return null;
+
+                fs.Seek(e.Offset, SeekOrigin.Begin);
+                var buffer = new byte[size];
+                int read = 0;
+                while (read < size)
+                {
+                    int n = fs.Read(buffer, read, size - read);
+                    if (n <= 0) break;
+                    read += n;
+                }
+                return buffer;
+            }
+        }
+
+        private static string ReadTag(Stream s)
+        {
+            var b = new byte[4];
+            if (s.Read(b, 0, 4) != 4) return string.Empty;
+            return string.Concat((char)b[0], (char)b[1], (char)b[2], (char)b[3]);
+        }
+
+        private static string ReadFixedString(Stream s, int length)
+        {
+            var b = new byte[length];
+            int read = s.Read(b, 0, length);
+            var sb = new System.Text.StringBuilder();
+            for (int i = 0; i < read; i++)
+            {
+                if (b[i] == 0) break;
+                sb.Append((char)b[i]);
+            }
+            return sb.ToString();
+        }
+
+        private static int ReadUInt32BE(Stream s)
+        {
+            var b = new byte[4];
+            if (s.Read(b, 0, 4) != 4) return 0;
+            return (b[0] << 24) | (b[1] << 16) | (b[2] << 8) | b[3];
+        }
+    }
+}

--- a/ScummEditor.Engine/Structures/ImuseBundleFile.cs
+++ b/ScummEditor.Engine/Structures/ImuseBundleFile.cs
@@ -51,6 +51,9 @@ namespace ScummEditor.Engine.Structures
                     int dirOffset = ReadUInt32BE(fs);
                     int numFiles = ReadUInt32BE(fs);
                     if (numFiles <= 0 || numFiles > 100000) return;
+                    // ReadUInt32BE returns a signed int; a corrupt >2GB offset would wrap negative and make
+                    // Seek throw. Guard the directory offset against the real file bounds instead.
+                    if (dirOffset < 0 || dirOffset > fs.Length) return;
 
                     fs.Seek(dirOffset, SeekOrigin.Begin);
                     for (int i = 0; i < numFiles; i++)

--- a/ScummEditor.Engine/Structures/IndexFile/RawIndexBlock.cs
+++ b/ScummEditor.Engine/Structures/IndexFile/RawIndexBlock.cs
@@ -1,0 +1,51 @@
+using System.IO;
+
+namespace ScummEditor.Engine.Structures.IndexFile
+{
+    /// <summary>
+    /// A SCUMM index block kept verbatim (tag + raw body). Used for the v7 index blocks that carry no
+    /// data-file offsets and so need no interpretation for editing: RNAM (room names), MAXS (engine
+    /// maximums + version strings), DOBJ (global object owner/class table), AARY (arrays) and the
+    /// v7-only ANAM (audio resource names). They are read and written back byte-for-byte; only the
+    /// resource directories (DROO/DSCR/DSOU/DCOS/DCHR), whose offsets move when blocks are edited, are
+    /// parsed into typed objects.
+    /// </summary>
+    public class RawIndexBlock : BlockBase, IRawContentBlock
+    {
+        private readonly string _blockType;
+        public byte[] Contents { get; set; }
+
+        public RawIndexBlock(GameInfo gameInfo, string blockType) : base(null, gameInfo)
+        {
+            _blockType = blockType;
+        }
+
+        public override string BlockType
+        {
+            get { return _blockType; }
+        }
+
+        public override void CalculateBlockSize()
+        {
+            BlockSize = (uint)(HeaderLength + Contents.Length);
+        }
+
+        public override void LoadFromBinaryReader(Stream binaryReader)
+        {
+            base.LoadFromBinaryReader(binaryReader); // reads & validates the [tag][size] header
+
+            int bodyLength = (int)BlockSize - HeaderLength;
+            if (bodyLength < 0)
+            {
+                bodyLength = 0;
+            }
+            Contents = binaryReader.ReadBytes(bodyLength);
+        }
+
+        public override void SaveToBinaryWriter(Stream binaryWriter)
+        {
+            base.SaveToBinaryWriter(binaryWriter);
+            binaryWriter.WriteBytes(Contents);
+        }
+    }
+}

--- a/ScummEditor.Engine/Structures/IndexFile/ScummIndexFile.cs
+++ b/ScummEditor.Engine/Structures/IndexFile/ScummIndexFile.cs
@@ -4,7 +4,7 @@ using ScummEditor.Engine.Exceptions;
 
 namespace ScummEditor.Engine.Structures.IndexFile
 {
-    public class ScummV5V6IndexFile
+    public class ScummIndexFile
     {
         private readonly GameInfo _gameInfo;
         public RoomNamesV5V6 RNAM { get; set; }
@@ -17,7 +17,7 @@ namespace ScummEditor.Engine.Structures.IndexFile
         public DirectoryOfObjects DOBJ { get; set; }
         public DirectoryOfArrays AARY { get; set; }
 
-        public ScummV5V6IndexFile(GameInfo gameInfo)
+        public ScummIndexFile(GameInfo gameInfo)
         {
             _gameInfo = gameInfo;
         }

--- a/ScummEditor.Engine/Structures/IndexFile/ScummV3OldBundleIndexFile.cs
+++ b/ScummEditor.Engine/Structures/IndexFile/ScummV3OldBundleIndexFile.cs
@@ -20,7 +20,7 @@ namespace ScummEditor.Engine.Structures.IndexFile
     unchanged; the typed directories below are a navigation/edit overlay that records, per entry, the
     room number, the offset, and the byte position of the offset word (so a future edit can rewrite it).
     */
-    public class ScummV3OldBundleIndexFile : ScummV5V6IndexFile
+    public class ScummV3OldBundleIndexFile : ScummIndexFile
     {
         public ScummV3OldBundleIndexFile(GameInfo gameInfo) : base(gameInfo) { }
 

--- a/ScummEditor.Engine/Structures/IndexFile/ScummV4IndexFile.cs
+++ b/ScummEditor.Engine/Structures/IndexFile/ScummV4IndexFile.cs
@@ -19,7 +19,7 @@ namespace ScummEditor.Engine.Structures.IndexFile
     For now the six blocks are kept byte-for-byte so the index round-trips identically; typed
     parsing (room names, directory entries) is layered on top in later steps.
     */
-    public class ScummV4IndexFile : ScummV5V6IndexFile
+    public class ScummV4IndexFile : ScummIndexFile
     {
         public List<BlockBase> Blocks { get; private set; }
 

--- a/ScummEditor.Engine/Structures/IndexFile/ScummV7IndexFile.cs
+++ b/ScummEditor.Engine/Structures/IndexFile/ScummV7IndexFile.cs
@@ -1,0 +1,85 @@
+using System.IO;
+using ScummEditor.Engine.Exceptions;
+
+namespace ScummEditor.Engine.Structures.IndexFile
+{
+    /// <summary>
+    /// Index reader for the SCUMM v7 games (The Dig, Full Throttle): the GAME.LA0 file. Its block
+    /// order is RNAM, MAXS, DROO, DSCR, DSOU, DCOS, DCHR, DOBJ, AARY, ANAM - the same set as v6 plus
+    /// the v7-only ANAM (audio resource names). The file is plaintext (not XOR-encrypted).
+    ///
+    /// Only the five resource directories (DROO/DSCR/DSOU/DCOS/DCHR) are parsed into typed objects,
+    /// because their offsets must be recomputed when a block is edited; their on-disk layout is the
+    /// same [count][room numbers][offsets] as v5/v6, so the existing DirectoryOf* readers serve them.
+    /// The remaining blocks hold no data-file offsets and are kept verbatim. The typed DROO/DSCR/DSOU/
+    /// DCOS/DCHR properties are inherited from <see cref="ScummV5V6IndexFile"/> so the shared v5/v6
+    /// index-linking code (in ScummGameDataV5V6) works unchanged.
+    /// </summary>
+    public class ScummV7IndexFile : ScummV5V6IndexFile
+    {
+        public RawIndexBlock RawRNAM { get; private set; }
+        public RawIndexBlock RawMAXS { get; private set; }
+        public RawIndexBlock RawDOBJ { get; private set; }
+        public RawIndexBlock RawAARY { get; private set; }
+
+        /// <summary>v7-only directory of audio resource names (for the .BUN bundles).</summary>
+        public RawIndexBlock RawANAM { get; private set; }
+
+        public ScummV7IndexFile(GameInfo gameInfo) : base(gameInfo) { }
+
+        public override void LoadFromBinaryReader(Stream binaryReader)
+        {
+            RawRNAM = ReadRawBlock(binaryReader, "RNAM");
+            RawMAXS = ReadRawBlock(binaryReader, "MAXS");
+
+            DROO = new DirectoryOfRooms(null, GameInfo);
+            DROO.LoadFromBinaryReader(binaryReader);
+
+            DSCR = new DirectoryOfScripts(null, GameInfo);
+            DSCR.LoadFromBinaryReader(binaryReader);
+
+            DSOU = new DirectoryOfSounds(null, GameInfo);
+            DSOU.LoadFromBinaryReader(binaryReader);
+
+            DCOS = new DirectoryOfCostumes(null, GameInfo);
+            DCOS.LoadFromBinaryReader(binaryReader);
+
+            DCHR = new DirectoryOfCharsets(null, GameInfo);
+            DCHR.LoadFromBinaryReader(binaryReader);
+
+            RawDOBJ = ReadRawBlock(binaryReader, "DOBJ");
+            RawAARY = ReadRawBlock(binaryReader, "AARY");
+            RawANAM = ReadRawBlock(binaryReader, "ANAM");
+
+            if (binaryReader.Length != binaryReader.Position)
+            {
+                throw new InvalidFileFormatException(string.Format(
+                    "The v7 index file could not be read completely. There are {0} bytes left.",
+                    binaryReader.Length - binaryReader.Position));
+            }
+        }
+
+        public override void SaveToBinaryWriter(Stream binaryWriter)
+        {
+            RawRNAM.SaveToBinaryWriter(binaryWriter);
+            RawMAXS.SaveToBinaryWriter(binaryWriter);
+            DROO.SaveToBinaryWriter(binaryWriter);
+            DSCR.SaveToBinaryWriter(binaryWriter);
+            DSOU.SaveToBinaryWriter(binaryWriter);
+            DCOS.SaveToBinaryWriter(binaryWriter);
+            DCHR.SaveToBinaryWriter(binaryWriter);
+            RawDOBJ.SaveToBinaryWriter(binaryWriter);
+            RawAARY.SaveToBinaryWriter(binaryWriter);
+            RawANAM.SaveToBinaryWriter(binaryWriter);
+
+            binaryWriter.Flush();
+        }
+
+        private RawIndexBlock ReadRawBlock(Stream binaryReader, string expectedTag)
+        {
+            var block = new RawIndexBlock(GameInfo, expectedTag);
+            block.LoadFromBinaryReader(binaryReader);
+            return block;
+        }
+    }
+}

--- a/ScummEditor.Engine/Structures/IndexFile/ScummV7IndexFile.cs
+++ b/ScummEditor.Engine/Structures/IndexFile/ScummV7IndexFile.cs
@@ -12,10 +12,10 @@ namespace ScummEditor.Engine.Structures.IndexFile
     /// because their offsets must be recomputed when a block is edited; their on-disk layout is the
     /// same [count][room numbers][offsets] as v5/v6, so the existing DirectoryOf* readers serve them.
     /// The remaining blocks hold no data-file offsets and are kept verbatim. The typed DROO/DSCR/DSOU/
-    /// DCOS/DCHR properties are inherited from <see cref="ScummV5V6IndexFile"/> so the shared v5/v6
+    /// DCOS/DCHR properties are inherited from <see cref="ScummIndexFile"/> so the shared v5/v6
     /// index-linking code (in ScummGameDataV5V6) works unchanged.
     /// </summary>
-    public class ScummV7IndexFile : ScummV5V6IndexFile
+    public class ScummV7IndexFile : ScummIndexFile
     {
         public RawIndexBlock RawRNAM { get; private set; }
         public RawIndexBlock RawMAXS { get; private set; }

--- a/ScummEditor.Engine/Structures/LanguageBundleFile.cs
+++ b/ScummEditor.Engine/Structures/LanguageBundleFile.cs
@@ -65,7 +65,7 @@ namespace ScummEditor.Engine.Structures
                     }
                     else if (first == (byte)'e' && len == 1)
                     {
-                        Encoded = true; // messages are XOR 0x13 (h/j/c CJK markers leave them plain)
+                        Encoded = true; // messages are XOR 0x13 (h/j/c are content-type markers only, not encoding control)
                     }
                     else if (first == (byte)'@')
                     {
@@ -123,7 +123,7 @@ namespace ScummEditor.Engine.Structures
             sb.Append("# ").Append(FileName).Append(" - one line per string: KEY<TAB>TEXT. Edit the TEXT only.\r\n");
             foreach (LocalizedTextEntry e in _entries)
             {
-                sb.Append(e.Key).Append('\t').Append(e.Text.Replace("\r", " ").Replace("\n", " ")).Append("\r\n");
+                sb.Append(e.Key).Append('\t').Append(NormalizeSingleLine(e.Text)).Append("\r\n");
             }
             return sb.ToString();
         }
@@ -131,15 +131,17 @@ namespace ScummEditor.Engine.Structures
         public string ImportFromText(string content)
         {
             var map = new Dictionary<string, string>();
-            foreach (string raw in content.Replace("\r\n", "\n").Split('\n'))
+            // Normalise every line ending (incl. a lone CR) before splitting, so a dump saved by any editor
+            // parses; a BND message is single-line, so collapse any stray newline in the value to a space.
+            foreach (string raw in content.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n'))
             {
                 if (raw.Length == 0 || raw[0] == '#') continue;
                 int tab = raw.IndexOf('\t');
                 if (tab <= 0) continue;
-                map[raw.Substring(0, tab)] = raw.Substring(tab + 1);
+                map[raw.Substring(0, tab)] = NormalizeSingleLine(raw.Substring(tab + 1));
             }
 
-            int changed = 0;
+            int changed = 0, unmappable = 0;
             foreach (LocalizedTextEntry e in _entries)
             {
                 string text;
@@ -147,9 +149,21 @@ namespace ScummEditor.Engine.Structures
                 {
                     e.Text = text;
                     changed++;
+                    unmappable += LocalizedTextEntry.CountUnmappable(text);
                 }
             }
-            return string.Format("{0} of {1} strings updated.", changed, _entries.Count);
+            string report = string.Format("{0} of {1} strings updated.", changed, _entries.Count);
+            if (unmappable > 0)
+            {
+                report += string.Format("\nWARNING: {0} character(s) are outside the game's 8-bit code page and will be saved as '?'.", unmappable);
+            }
+            return report;
+        }
+
+        /// <inheritdoc/>
+        public string NormalizeEditedText(string text)
+        {
+            return NormalizeSingleLine(text);
         }
 
         private string Decode(byte[] b, int start, int end)
@@ -165,12 +179,22 @@ namespace ScummEditor.Engine.Structures
 
         private byte[] Encode(string text)
         {
-            byte[] msg = Encoding.Latin1.GetBytes(text ?? string.Empty);
+            byte[] msg = Encoding.Latin1.GetBytes(NormalizeSingleLine(text));
             if (Encoded)
             {
                 for (int i = 0; i < msg.Length; i++) msg[i] ^= XorKey;
             }
             return msg;
+        }
+
+        /// <summary>LANGUAGE.BND holds exactly one message per line - ScummVM reads a message only up to the
+        /// first CR/LF (string.cpp:2135) - so any newline the user typed in the editor is collapsed to a
+        /// space, both on export and when the bytes are rebuilt, to keep the file's line-based structure
+        /// intact (a raw newline would split one message into two on the next load).</summary>
+        private static string NormalizeSingleLine(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return string.Empty;
+            return text.Replace("\r\n", " ").Replace("\r", " ").Replace("\n", " ");
         }
 
         /// <summary>Finds the content end (before the line terminator) and the start of the next line.</summary>

--- a/ScummEditor.Engine/Structures/LanguageBundleFile.cs
+++ b/ScummEditor.Engine/Structures/LanguageBundleFile.cs
@@ -1,0 +1,193 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace ScummEditor.Engine.Structures
+{
+    /// <summary>
+    /// The Dig's external localized-text file (LANGUAGE.BND), where the translated in-game strings live for
+    /// the non-English editions. Line-based text (verified vs ScummVM string.cpp:2042): a leading marker
+    /// line `e` means the messages are XOR 0x13 encoded; `@TAG` opens a base tag (room/scope); `#NN` a
+    /// subtag count (ignored); and `NNN/<message>` is string index NNN whose message (the part AFTER the
+    /// slash, to end-of-line) is the (encoded) text. The runtime key is "TAG.NNN".
+    ///
+    /// The whole file is kept as the template (OriginalContent); only the message bytes of edited entries
+    /// are re-encoded and spliced, so an unedited bundle rebuilds byte-identically. Text is stored as a
+    /// Latin-1 string (a 1:1 byte&lt;-&gt;char mapping) so the round-trip is exact; the bytes are the game's
+    /// DOS code page, so accents render as their code-page glyphs rather than Unicode (a future enhancement
+    /// could apply the game's charmap for display).
+    /// </summary>
+    public class LanguageBundleFile : ILocalizedTextFile
+    {
+        private const byte XorKey = 0x13;
+
+        public string FilePath { get; private set; }
+        public byte[] OriginalContent { get; private set; }
+        public bool IsValid { get; private set; }
+        public bool Encoded { get; private set; }
+
+        private readonly List<LocalizedTextEntry> _entries = new List<LocalizedTextEntry>();
+        public IReadOnlyList<LocalizedTextEntry> Entries { get { return _entries; } }
+        public string FileName { get { return Path.GetFileName(FilePath); } }
+
+        public LanguageBundleFile(string filePath)
+        {
+            FilePath = filePath;
+        }
+
+        public void Load(byte[] bytes)
+        {
+            OriginalContent = bytes;
+            Parse();
+        }
+
+        private void Parse()
+        {
+            _entries.Clear();
+            Encoded = false;
+            IsValid = false;
+            byte[] b = OriginalContent;
+            if (b == null || b.Length == 0) return;
+
+            string baseTag = string.Empty;
+            int pos = 0;
+            while (pos < b.Length)
+            {
+                int contentEnd, lineEnd;
+                LineBounds(b, pos, out contentEnd, out lineEnd);
+                int len = contentEnd - pos;
+                if (len > 0)
+                {
+                    byte first = b[pos];
+                    if (first == (byte)'!')
+                    {
+                        // unknown marker - ignore
+                    }
+                    else if (first == (byte)'e' && len == 1)
+                    {
+                        Encoded = true; // messages are XOR 0x13 (h/j/c CJK markers leave them plain)
+                    }
+                    else if (first == (byte)'@')
+                    {
+                        baseTag = Encoding.Latin1.GetString(b, pos + 1, len - 1);
+                    }
+                    else if (first == (byte)'#')
+                    {
+                        // subtag count - ignore
+                    }
+                    else if (first >= (byte)'0' && first <= (byte)'9')
+                    {
+                        int slash = IndexOf(b, pos, contentEnd, (byte)'/');
+                        if (slash >= 0)
+                        {
+                            string idx = Encoding.Latin1.GetString(b, pos, slash - pos);
+                            int msgStart = slash + 1;
+                            _entries.Add(new LocalizedTextEntry
+                            {
+                                Key = baseTag + "." + idx,
+                                Text = Decode(b, msgStart, contentEnd),
+                                TextStart = msgStart,
+                                TextEnd = contentEnd,
+                            });
+                        }
+                    }
+                    // any other line: ignored here, copied verbatim by BuildContent
+                }
+                pos = lineEnd;
+            }
+            IsValid = _entries.Count > 0;
+        }
+
+        /// <summary>Rebuilds the file bytes: everything verbatim except each entry's message region, which is
+        /// re-encoded from the (possibly edited) Text. Byte-identical when no Text changed.</summary>
+        public byte[] BuildContent()
+        {
+            using (var ms = new MemoryStream())
+            {
+                int pos = 0;
+                foreach (LocalizedTextEntry e in _entries)
+                {
+                    ms.Write(OriginalContent, pos, e.TextStart - pos); // verbatim up to (and incl) the "NNN/"
+                    byte[] enc = Encode(e.Text);
+                    ms.Write(enc, 0, enc.Length);
+                    pos = e.TextEnd;                                   // skip the original message bytes
+                }
+                ms.Write(OriginalContent, pos, OriginalContent.Length - pos); // tail
+                return ms.ToArray();
+            }
+        }
+
+        public string ExportToText()
+        {
+            var sb = new StringBuilder();
+            sb.Append("# ").Append(FileName).Append(" - one line per string: KEY<TAB>TEXT. Edit the TEXT only.\r\n");
+            foreach (LocalizedTextEntry e in _entries)
+            {
+                sb.Append(e.Key).Append('\t').Append(e.Text.Replace("\r", " ").Replace("\n", " ")).Append("\r\n");
+            }
+            return sb.ToString();
+        }
+
+        public string ImportFromText(string content)
+        {
+            var map = new Dictionary<string, string>();
+            foreach (string raw in content.Replace("\r\n", "\n").Split('\n'))
+            {
+                if (raw.Length == 0 || raw[0] == '#') continue;
+                int tab = raw.IndexOf('\t');
+                if (tab <= 0) continue;
+                map[raw.Substring(0, tab)] = raw.Substring(tab + 1);
+            }
+
+            int changed = 0;
+            foreach (LocalizedTextEntry e in _entries)
+            {
+                string text;
+                if (map.TryGetValue(e.Key, out text) && text != e.Text)
+                {
+                    e.Text = text;
+                    changed++;
+                }
+            }
+            return string.Format("{0} of {1} strings updated.", changed, _entries.Count);
+        }
+
+        private string Decode(byte[] b, int start, int end)
+        {
+            int len = end - start;
+            var msg = new byte[len];
+            for (int i = 0; i < len; i++)
+            {
+                msg[i] = Encoded ? (byte)(b[start + i] ^ XorKey) : b[start + i];
+            }
+            return Encoding.Latin1.GetString(msg);
+        }
+
+        private byte[] Encode(string text)
+        {
+            byte[] msg = Encoding.Latin1.GetBytes(text ?? string.Empty);
+            if (Encoded)
+            {
+                for (int i = 0; i < msg.Length; i++) msg[i] ^= XorKey;
+            }
+            return msg;
+        }
+
+        /// <summary>Finds the content end (before the line terminator) and the start of the next line.</summary>
+        private static void LineBounds(byte[] b, int pos, out int contentEnd, out int lineEnd)
+        {
+            int i = pos;
+            while (i < b.Length && b[i] != (byte)'\r' && b[i] != (byte)'\n') i++;
+            contentEnd = i;
+            if (i < b.Length && b[i] == (byte)'\r') i++;
+            if (i < b.Length && b[i] == (byte)'\n') i++;
+            lineEnd = i;
+        }
+
+        private static int IndexOf(byte[] b, int start, int end, byte value)
+        {
+            for (int i = start; i < end; i++) if (b[i] == value) return i;
+            return -1;
+        }
+    }
+}

--- a/ScummEditor.Engine/Structures/LanguageBundleFile.cs
+++ b/ScummEditor.Engine/Structures/LanguageBundleFile.cs
@@ -26,6 +26,11 @@ namespace ScummEditor.Engine.Structures
         public bool IsValid { get; private set; }
         public bool Encoded { get; private set; }
 
+        /// <summary>The CJK content marker the bundle declares, if any: 'j' Japanese, 'h' Korean (Hangul),
+        /// 'c' Chinese (ScummVM string.cpp:2103-2108); '\0' for the Western (alphabetic) editions. A direct,
+        /// reliable language signal that the word heuristic cannot give for the double-byte scripts.</summary>
+        public char CjkMarker { get; private set; }
+
         private readonly List<LocalizedTextEntry> _entries = new List<LocalizedTextEntry>();
         public IReadOnlyList<LocalizedTextEntry> Entries { get { return _entries; } }
         public string FileName { get { return Path.GetFileName(FilePath); } }
@@ -45,6 +50,7 @@ namespace ScummEditor.Engine.Structures
         {
             _entries.Clear();
             Encoded = false;
+            CjkMarker = '\0';
             IsValid = false;
             byte[] b = OriginalContent;
             if (b == null || b.Length == 0) return;
@@ -66,6 +72,10 @@ namespace ScummEditor.Engine.Structures
                     else if (first == (byte)'e' && len == 1)
                     {
                         Encoded = true; // messages are XOR 0x13 (h/j/c are content-type markers only, not encoding control)
+                    }
+                    else if (len == 1 && (first == (byte)'h' || first == (byte)'j' || first == (byte)'c'))
+                    {
+                        CjkMarker = (char)first; // double-byte script marker: 'h' Korean, 'j' Japanese, 'c' Chinese
                     }
                     else if (first == (byte)'@')
                     {

--- a/ScummEditor.Engine/Structures/LocalizedTextEntry.cs
+++ b/ScummEditor.Engine/Structures/LocalizedTextEntry.cs
@@ -10,5 +10,21 @@ namespace ScummEditor.Engine.Structures
         // Byte range of the (encoded) text within the file's original bytes, used to rebuild it in place.
         internal int TextStart;
         internal int TextEnd;
+
+        /// <summary>Counts characters that cannot be stored in the game's 8-bit code page - the Latin-1
+        /// encoder writes them as '?' - so an import can warn about, e.g., smart quotes pasted from a word
+        /// processor that would silently corrupt the saved text.</summary>
+        internal static int CountUnmappable(string text)
+        {
+            int n = 0;
+            if (text != null)
+            {
+                foreach (char c in text)
+                {
+                    if (c > 0xFF) n++;
+                }
+            }
+            return n;
+        }
     }
 }

--- a/ScummEditor.Engine/Structures/LocalizedTextEntry.cs
+++ b/ScummEditor.Engine/Structures/LocalizedTextEntry.cs
@@ -1,0 +1,14 @@
+namespace ScummEditor.Engine.Structures
+{
+    /// <summary>One editable localized string: a stable key (room.index or define name) and its text.
+    /// Shared by the external localized-text files (The Dig LANGUAGE.BND and the .TRS subtitle files).</summary>
+    public class LocalizedTextEntry
+    {
+        public string Key { get; set; }
+        public string Text { get; set; }
+
+        // Byte range of the (encoded) text within the file's original bytes, used to rebuild it in place.
+        internal int TextStart;
+        internal int TextEnd;
+    }
+}

--- a/ScummEditor.Engine/Structures/NutFontResource.cs
+++ b/ScummEditor.Engine/Structures/NutFontResource.cs
@@ -1,0 +1,12 @@
+using ScummEditor.Engine.Structures.DataFile;
+
+namespace ScummEditor.Engine.Structures
+{
+    /// <summary>One loaded external .NUT SMUSH font (v7 The Dig / Full Throttle) paired with the file it
+    /// came from. The counterpart of <see cref="FontResource"/> for the in-container CHAR charsets.</summary>
+    public class NutFontResource
+    {
+        public string FilePath { get; set; }
+        public NutFont Font { get; set; }
+    }
+}

--- a/ScummEditor.Engine/Structures/ScummGame.cs
+++ b/ScummEditor.Engine/Structures/ScummGame.cs
@@ -13,6 +13,8 @@ namespace ScummEditor.Engine.Structures
         Loom = 8,                  // SCUMM v4 (Loom CD); also the SCUMM v3 Loom EGA (00.LFL + NN.LFL)
         IndianaJones3 = 9,         // SCUMM v3 - Indiana Jones and the Last Crusade
         ZakMcKracken = 10,         // SCUMM v3 - Zak McKracken (FM Towns / enhanced); also v1/v2 Zak (00.LFL + NN.LFL)
-        ManiacMansion = 11         // SCUMM v1/v2 - Maniac Mansion (00.LFL + NN.LFL)
+        ManiacMansion = 11,        // SCUMM v1/v2 - Maniac Mansion (00.LFL + NN.LFL)
+        TheDig = 12,               // SCUMM v7 - The Dig (GAME.LA0 + GAME.LA1)
+        FullThrottle = 13          // SCUMM v7 - Full Throttle (GAME.LA0 + GAME.LA1)
     }
 }

--- a/ScummEditor.Engine/Structures/ScummGameData.cs
+++ b/ScummEditor.Engine/Structures/ScummGameData.cs
@@ -36,6 +36,10 @@ namespace ScummEditor.Engine.Structures
         /// <summary>External .NUT SMUSH fonts (v7 The Dig / Full Throttle); empty for every other engine.</summary>
         public List<NutFontResource> NutFonts { get; private set; } = new List<NutFontResource>();
 
+        /// <summary>External localized-text files (v7 The Dig LANGUAGE.BND + the .TRS subtitle/UI files);
+        /// empty for every other engine.</summary>
+        public List<ILocalizedTextFile> LocalizedTextFiles { get; private set; } = new List<ILocalizedTextFile>();
+
         /// <summary>Loads the v3 9N.LFL charset files (always plaintext) into V3Charsets.</summary>
         protected void LoadV3Charsets()
         {
@@ -215,6 +219,16 @@ namespace ScummEditor.Engine.Structures
                 if (font.Font != null && font.Font.RawContent != null && !string.IsNullOrEmpty(font.FilePath))
                 {
                     File.WriteAllBytes(font.FilePath, font.Font.RawContent);
+                }
+            }
+
+            // Write back the external localized-text files (v7 LANGUAGE.BND + .TRS); BuildContent re-encodes
+            // only the edited strings, so an untouched file writes back byte-identically.
+            foreach (ILocalizedTextFile text in LocalizedTextFiles)
+            {
+                if (text != null && !string.IsNullOrEmpty(text.FilePath))
+                {
+                    File.WriteAllBytes(text.FilePath, text.BuildContent());
                 }
             }
         }

--- a/ScummEditor.Engine/Structures/ScummGameData.cs
+++ b/ScummEditor.Engine/Structures/ScummGameData.cs
@@ -66,6 +66,12 @@ namespace ScummEditor.Engine.Structures
         /// <summary>Creates the right per-engine instance for the detected game (not yet loaded).</summary>
         public static ScummGameData Create(GameInfo gameInfo)
         {
+            if (gameInfo != null && gameInfo.ScummVersion == 7)
+            {
+                // The Dig / Full Throttle: same IFF container as v5/v6 (so it extends the v5/v6 loader),
+                // with a v7 index (ANAM block, 130-byte MAXS) and AKOS costumes.
+                return new ScummGameDataV7();
+            }
             if (gameInfo != null && gameInfo.ScummVersion == 4)
             {
                 return new ScummGameDataV4();

--- a/ScummEditor.Engine/Structures/ScummGameData.cs
+++ b/ScummEditor.Engine/Structures/ScummGameData.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using ScummEditor.Engine.Encoders;
@@ -45,8 +46,22 @@ namespace ScummEditor.Engine.Structures
             }
             foreach (string path in LoadedGameInfo.FontFiles)
             {
+                byte[] bytes;
+                try
+                {
+                    bytes = File.ReadAllBytes(path);
+                }
+                catch (IOException)
+                {
+                    continue; // a charset file enumerated at detection is now missing/locked: skip it, still load the game
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    continue;
+                }
+
                 var charset = new CharsetV3 { FilePath = path };
-                charset.LoadFromFileBytes(File.ReadAllBytes(path));
+                charset.LoadFromFileBytes(bytes);
                 V3Charsets.Add(charset);
             }
         }

--- a/ScummEditor.Engine/Structures/ScummGameData.cs
+++ b/ScummEditor.Engine/Structures/ScummGameData.cs
@@ -32,6 +32,9 @@ namespace ScummEditor.Engine.Structures
         /// <summary>Standalone v3 charset files (9N.LFL); empty for v4/v5/v6 (which use Fonts/Charset).</summary>
         public List<CharsetV3> V3Charsets { get; private set; } = new List<CharsetV3>();
 
+        /// <summary>External .NUT SMUSH fonts (v7 The Dig / Full Throttle); empty for every other engine.</summary>
+        public List<NutFontResource> NutFonts { get; private set; } = new List<NutFontResource>();
+
         /// <summary>Loads the v3 9N.LFL charset files (always plaintext) into V3Charsets.</summary>
         protected void LoadV3Charsets()
         {
@@ -187,6 +190,16 @@ namespace ScummEditor.Engine.Structures
                 if (!string.IsNullOrEmpty(charset.FilePath))
                 {
                     File.WriteAllBytes(charset.FilePath, charset.RawContent);
+                }
+            }
+
+            // Write back the external .NUT SMUSH fonts (v7), each its own file = the font bytes verbatim
+            // (only edited glyphs were re-encoded; an untouched font writes back byte-identically).
+            foreach (NutFontResource font in NutFonts)
+            {
+                if (font.Font != null && font.Font.RawContent != null && !string.IsNullOrEmpty(font.FilePath))
+                {
+                    File.WriteAllBytes(font.FilePath, font.Font.RawContent);
                 }
             }
         }

--- a/ScummEditor.Engine/Structures/ScummGameData.cs
+++ b/ScummEditor.Engine/Structures/ScummGameData.cs
@@ -18,10 +18,10 @@ namespace ScummEditor.Engine.Structures
     {
         public GameInfo LoadedGameInfo { get; set; }
 
-        public ScummV5V6IndexFile IndexFile { get; set; }
+        public ScummIndexFile IndexFile { get; set; }
 
         /// <summary>The first (or only) data container. For multi-disk v4 games see <see cref="DataDisks"/>.</summary>
-        public ScummV5V6DataFile DataFile { get; set; }
+        public ScummDataFile DataFile { get; set; }
 
         /// <summary>Every loaded data container (one per file). v5/v6 has a single entry.</summary>
         public List<DataDisk> DataDisks { get; private set; } = new List<DataDisk>();
@@ -145,7 +145,7 @@ namespace ScummEditor.Engine.Structures
             foreach (string path in paths)
             {
                 var stream = new XoredFileStream(LoadedGameInfo.XorKey, path, FileMode.Open, FileAccess.Read);
-                ScummV5V6DataFile tree = CreateDataFile();
+                ScummDataFile tree = CreateDataFile();
                 tree.LoadFromBinaryReader(stream);
                 stream.Close();
 
@@ -225,10 +225,10 @@ namespace ScummEditor.Engine.Structures
         }
 
         /// <summary>Builds the data-container tree for this engine (v4 small-header vs v5/v6 IFF).</summary>
-        protected abstract ScummV5V6DataFile CreateDataFile();
+        protected abstract ScummDataFile CreateDataFile();
 
         /// <summary>Builds the index-file reader for this engine.</summary>
-        protected abstract ScummV5V6IndexFile CreateIndexFile();
+        protected abstract ScummIndexFile CreateIndexFile();
 
         /// <summary>Hook run after the data files are loaded (e.g. v4 loads its standalone fonts).</summary>
         protected virtual void AfterLoad() { }

--- a/ScummEditor.Engine/Structures/ScummGameDataV3OldBundle.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV3OldBundle.cs
@@ -12,12 +12,12 @@ namespace ScummEditor.Engine.Structures
     /// </summary>
     public class ScummGameDataV3OldBundle : ScummGameData
     {
-        protected override ScummV5V6DataFile CreateDataFile()
+        protected override ScummDataFile CreateDataFile()
         {
             return new ScummV3OldBundleDataFile(null, LoadedGameInfo);
         }
 
-        protected override ScummV5V6IndexFile CreateIndexFile()
+        protected override ScummIndexFile CreateIndexFile()
         {
             return new ScummV3OldBundleIndexFile(LoadedGameInfo);
         }

--- a/ScummEditor.Engine/Structures/ScummGameDataV3Small256.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV3Small256.cs
@@ -15,12 +15,12 @@ namespace ScummEditor.Engine.Structures
     /// </summary>
     public class ScummGameDataV3Small256 : ScummGameData
     {
-        protected override ScummV5V6DataFile CreateDataFile()
+        protected override ScummDataFile CreateDataFile()
         {
             return new ScummV3Small256DataFile(null, LoadedGameInfo);
         }
 
-        protected override ScummV5V6IndexFile CreateIndexFile()
+        protected override ScummIndexFile CreateIndexFile()
         {
             // The v4 index reader types 0S/0N/0C and keeps the rest verbatim; the v3 index is the
             // same flat block sequence minus the RN block, so it parses unchanged.

--- a/ScummEditor.Engine/Structures/ScummGameDataV4.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV4.cs
@@ -14,12 +14,12 @@ namespace ScummEditor.Engine.Structures
     /// </summary>
     public class ScummGameDataV4 : ScummGameData
     {
-        protected override ScummV5V6DataFile CreateDataFile()
+        protected override ScummDataFile CreateDataFile()
         {
             return new ScummV4DataFile(null, LoadedGameInfo);
         }
 
-        protected override ScummV5V6IndexFile CreateIndexFile()
+        protected override ScummIndexFile CreateIndexFile()
         {
             return new ScummV4IndexFile(LoadedGameInfo);
         }
@@ -254,7 +254,7 @@ namespace ScummEditor.Engine.Structures
         /// <summary>Where a v4 room lives: its disk container plus the LF/RO blocks.</summary>
         private class V4RoomLocation
         {
-            public ScummV5V6DataFile Disk;
+            public ScummDataFile Disk;
             public ScummV4DiskBlock Lf;
             public ScummV4RoomBlock Ro;
         }

--- a/ScummEditor.Engine/Structures/ScummGameDataV4.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV4.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -41,8 +42,22 @@ namespace ScummEditor.Engine.Structures
 
             foreach (string path in LoadedGameInfo.FontFiles)
             {
+                byte[] bytes;
+                try
+                {
+                    bytes = File.ReadAllBytes(path);
+                }
+                catch (IOException)
+                {
+                    continue; // a 90x.LFL font enumerated at detection is now missing/locked: skip it, still load the game
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    continue;
+                }
+
                 var charset = new Charset(null, LoadedGameInfo);
-                charset.LoadFromFileBytes(File.ReadAllBytes(path));
+                charset.LoadFromFileBytes(bytes);
                 Fonts.Add(new FontResource { FilePath = path, Charset = charset });
             }
         }

--- a/ScummEditor.Engine/Structures/ScummGameDataV5V6.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV5V6.cs
@@ -23,14 +23,14 @@ namespace ScummEditor.Engine.Structures
             get { return "COST"; }
         }
 
-        protected override ScummV5V6DataFile CreateDataFile()
+        protected override ScummDataFile CreateDataFile()
         {
-            return new ScummV5V6DataFile(null, LoadedGameInfo);
+            return new ScummDataFile(null, LoadedGameInfo);
         }
 
-        protected override ScummV5V6IndexFile CreateIndexFile()
+        protected override ScummIndexFile CreateIndexFile()
         {
-            return new ScummV5V6IndexFile(LoadedGameInfo);
+            return new ScummIndexFile(LoadedGameInfo);
         }
 
         protected override void LinkDataAndIndexFile()

--- a/ScummEditor.Engine/Structures/ScummGameDataV5V6.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV5V6.cs
@@ -13,6 +13,16 @@ namespace ScummEditor.Engine.Structures
     /// </summary>
     public class ScummGameDataV5V6 : ScummGameData
     {
+        /// <summary>
+        /// Tag of the costume blocks the costume directory (DCOS) links to. v5/v6 store costumes as
+        /// "COST"; v7 stores them as "AKOS" (see <see cref="ScummGameDataV7"/>). Used by the
+        /// index-linking so the same code serves both engines.
+        /// </summary>
+        protected virtual string CostumeBlockType
+        {
+            get { return "COST"; }
+        }
+
         protected override ScummV5V6DataFile CreateDataFile()
         {
             return new ScummV5V6DataFile(null, LoadedGameInfo);
@@ -47,7 +57,7 @@ namespace ScummEditor.Engine.Structures
                     matchSounds.ForEach(r => r.ItemId = sound.UniqueId);
                 }
 
-                List<BlockBase> costumes = diskBlock.Childrens.Where(s => s.BlockType == "COST").ToList();
+                List<BlockBase> costumes = diskBlock.Childrens.Where(s => s.BlockType == CostumeBlockType).ToList();
                 foreach (var costume in costumes)
                 {
                     List<DirectoryItem> matchCostumes = IndexFile.DCOS.Rooms.Where(x => x.Offset == (costume.BlockOffSet - roomOffset)).ToList();
@@ -95,7 +105,7 @@ namespace ScummEditor.Engine.Structures
                     matchSounds.ForEach(r => r.Offset = (uint)(sound.BlockOffSet - roomOffset));
                 }
 
-                List<BlockBase> costumes = diskBlock.Childrens.Where(s => s.BlockType == "COST").ToList();
+                List<BlockBase> costumes = diskBlock.Childrens.Where(s => s.BlockType == CostumeBlockType).ToList();
                 foreach (var costume in costumes)
                 {
                     List<DirectoryItem> matchCostumes = IndexFile.DCOS.Rooms.Where(x => x.ItemId == costume.UniqueId).ToList();

--- a/ScummEditor.Engine/Structures/ScummGameDataV7.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV7.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+using ScummEditor.Engine.Structures.DataFile;
+using ScummEditor.Engine.Structures.IndexFile;
+
+namespace ScummEditor.Engine.Structures
+{
+    /// <summary>
+    /// Game data for the SCUMM v7 engine (The Dig, Full Throttle). The container is the same IFF
+    /// "big header" LECF/LOFF/LFLF/ROOM tree as v5/v6, so the v5/v6 data file and save/offset code are
+    /// reused; v7 differs only in:
+    ///   - the index file (GAME.LA0): an extra ANAM block and a 130-byte MAXS, handled by
+    ///     <see cref="ScummV7IndexFile"/>;
+    ///   - costumes stored as AKOS blocks instead of COST (so the costume directory DCOS links to the
+    ///     AKOS blocks - see <see cref="CostumeBlockType"/>);
+    ///   - no whole-file XOR encryption (the GameInfo keys are 0).
+    /// The version-specific block parsing (the 10-byte v7 room header, the generic reader for AKOS /
+    /// SOUN / object blocks) lives in the data-file block classes, switched on GameInfo.ScummVersion.
+    /// </summary>
+    public class ScummGameDataV7 : ScummGameDataV5V6
+    {
+        protected override ScummV5V6IndexFile CreateIndexFile()
+        {
+            return new ScummV7IndexFile(LoadedGameInfo);
+        }
+
+        protected override string CostumeBlockType
+        {
+            get { return "AKOS"; }
+        }
+
+        /// <summary>
+        /// Links the index directories to the data blocks like v5/v6, but matches each resource to its
+        /// directory entry by BOTH the room number AND the offset relative to the ROOM block. Two
+        /// different rooms can legitimately hold a resource at the same relative offset (verified in real
+        /// data: The Dig's DCOS costumes, Full Throttle's DSOU sounds), so the v5/v6 offset-only match
+        /// would cross-link them and relocate the wrong entry on a size-changing edit. The room number
+        /// comes from the LOFF table (its entries survive edits), matched by the ROOM block's offset.
+        /// </summary>
+        protected override void LinkDataAndIndexFile()
+        {
+            RoomOffsetTable loff = DataFile.GetLOFF();
+            foreach (DiskBlock diskBlock in DataFile.GetLFLFs())
+            {
+                long roomOffset = diskBlock.GetROOM().BlockOffSet;
+
+                RoomOffsetTableItem loffEntry = loff.Rooms.FirstOrDefault(r => r.OffSet == roomOffset);
+                if (loffEntry == null)
+                {
+                    continue;
+                }
+                int roomNumber = loffEntry.Id;
+
+                // The room directory (DROO) stores absolute LFLF offsets, which are unique, so it needs
+                // no room scoping.
+                IndexFile.DROO.Rooms.Where(x => x.Offset == diskBlock.BlockOffSet).ToList()
+                    .ForEach(r => r.ItemId = diskBlock.UniqueId);
+
+                LinkRoomResources(IndexFile.DSCR, diskBlock, "SCRP", roomNumber, roomOffset);
+                LinkRoomResources(IndexFile.DSOU, diskBlock, "SOUN", roomNumber, roomOffset);
+                LinkRoomResources(IndexFile.DCOS, diskBlock, CostumeBlockType, roomNumber, roomOffset);
+                LinkRoomResources(IndexFile.DCHR, diskBlock, "CHAR", roomNumber, roomOffset);
+            }
+        }
+
+        /// <summary>
+        /// Links one room's resources of a given block type to their directory entries, scoped by BOTH
+        /// the room number and the offset relative to the ROOM block. Each matched entry gets the block's
+        /// UniqueId, which the (shared) FixUpIndexOffsets uses to relocate it on save.
+        /// </summary>
+        private static void LinkRoomResources(DirectoryOfItems directory, DiskBlock diskBlock, string blockType, int roomNumber, long roomOffset)
+        {
+            foreach (BlockBase block in diskBlock.Childrens.Where(b => b.BlockType == blockType))
+            {
+                uint relativeOffset = (uint)(block.BlockOffSet - roomOffset);
+                directory.Rooms.Where(x => x.Number == roomNumber && x.Offset == relativeOffset).ToList()
+                    .ForEach(r => r.ItemId = block.UniqueId);
+            }
+        }
+    }
+}

--- a/ScummEditor.Engine/Structures/ScummGameDataV7.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV7.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Linq;
 using ScummEditor.Engine.Structures.DataFile;
 using ScummEditor.Engine.Structures.IndexFile;
@@ -26,6 +27,29 @@ namespace ScummEditor.Engine.Structures
         protected override string CostumeBlockType
         {
             get { return "AKOS"; }
+        }
+
+        /// <summary>Loads the external .NUT SMUSH fonts that sit next to the .LA0/.LA1 container.</summary>
+        protected override void AfterLoad()
+        {
+            base.AfterLoad();
+            LoadNutFonts();
+        }
+
+        private void LoadNutFonts()
+        {
+            NutFonts.Clear();
+            if (LoadedGameInfo.NutFontFiles == null)
+            {
+                return;
+            }
+
+            foreach (string path in LoadedGameInfo.NutFontFiles)
+            {
+                var font = new NutFont { FilePath = path };
+                font.LoadFromFileBytes(File.ReadAllBytes(path));
+                NutFonts.Add(new NutFontResource { FilePath = path, Font = font });
+            }
         }
 
         /// <summary>

--- a/ScummEditor.Engine/Structures/ScummGameDataV7.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV7.cs
@@ -45,9 +45,19 @@ namespace ScummEditor.Engine.Structures
 
             if (!string.IsNullOrEmpty(LoadedGameInfo.LanguageBundlePath) && File.Exists(LoadedGameInfo.LanguageBundlePath))
             {
-                var bundle = new LanguageBundleFile(LoadedGameInfo.LanguageBundlePath);
-                bundle.Load(File.ReadAllBytes(LoadedGameInfo.LanguageBundlePath));
-                LocalizedTextFiles.Add(bundle);
+                try
+                {
+                    var bundle = new LanguageBundleFile(LoadedGameInfo.LanguageBundlePath);
+                    bundle.Load(File.ReadAllBytes(LoadedGameInfo.LanguageBundlePath));
+                    LocalizedTextFiles.Add(bundle);
+                }
+                catch (IOException)
+                {
+                    // LANGUAGE.BND vanished/locked between detection and load: skip it, still load the game
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
             }
 
             if (LoadedGameInfo.TrsFiles != null)
@@ -64,6 +74,9 @@ namespace ScummEditor.Engine.Structures
                     catch (IOException)
                     {
                         // a .TRS that vanished/locked between detection and load: skip, still load the game
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
                     }
                 }
             }

--- a/ScummEditor.Engine/Structures/ScummGameDataV7.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV7.cs
@@ -18,7 +18,7 @@ namespace ScummEditor.Engine.Structures
     /// </summary>
     public class ScummGameDataV7 : ScummGameDataV5V6
     {
-        protected override ScummV5V6IndexFile CreateIndexFile()
+        protected override ScummIndexFile CreateIndexFile()
         {
             return new ScummV7IndexFile(LoadedGameInfo);
         }

--- a/ScummEditor.Engine/Structures/ScummGameDataV7.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV7.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using ScummEditor.Engine.Structures.DataFile;
@@ -46,8 +47,22 @@ namespace ScummEditor.Engine.Structures
 
             foreach (string path in LoadedGameInfo.NutFontFiles)
             {
+                byte[] bytes;
+                try
+                {
+                    bytes = File.ReadAllBytes(path);
+                }
+                catch (IOException)
+                {
+                    continue; // a .NUT enumerated at detection is now missing/locked: skip it, still load the game
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    continue;
+                }
+
                 var font = new NutFont { FilePath = path };
-                font.LoadFromFileBytes(File.ReadAllBytes(path));
+                font.LoadFromFileBytes(bytes); // a malformed NUT parses to IsValid=false, it does not throw
                 NutFonts.Add(new NutFontResource { FilePath = path, Font = font });
             }
         }

--- a/ScummEditor.Engine/Structures/ScummGameDataV7.cs
+++ b/ScummEditor.Engine/Structures/ScummGameDataV7.cs
@@ -35,6 +35,38 @@ namespace ScummEditor.Engine.Structures
         {
             base.AfterLoad();
             LoadNutFonts();
+            LoadLocalizedText();
+        }
+
+        /// <summary>Loads The Dig's LANGUAGE.BND (localized in-game text) and the .TRS subtitle/UI files.</summary>
+        private void LoadLocalizedText()
+        {
+            LocalizedTextFiles.Clear();
+
+            if (!string.IsNullOrEmpty(LoadedGameInfo.LanguageBundlePath) && File.Exists(LoadedGameInfo.LanguageBundlePath))
+            {
+                var bundle = new LanguageBundleFile(LoadedGameInfo.LanguageBundlePath);
+                bundle.Load(File.ReadAllBytes(LoadedGameInfo.LanguageBundlePath));
+                LocalizedTextFiles.Add(bundle);
+            }
+
+            if (LoadedGameInfo.TrsFiles != null)
+            {
+                foreach (string path in LoadedGameInfo.TrsFiles)
+                {
+                    if (!File.Exists(path)) continue;
+                    try
+                    {
+                        var trs = new TrsFile(path);
+                        trs.Load(File.ReadAllBytes(path));
+                        LocalizedTextFiles.Add(trs);
+                    }
+                    catch (IOException)
+                    {
+                        // a .TRS that vanished/locked between detection and load: skip, still load the game
+                    }
+                }
+            }
         }
 
         private void LoadNutFonts()

--- a/ScummEditor.Engine/Structures/ScummGameNames.cs
+++ b/ScummEditor.Engine/Structures/ScummGameNames.cs
@@ -23,6 +23,8 @@ namespace ScummEditor.Engine.Structures
                 case ScummGame.FateOfAtlantis: return "Indiana Jones and the Fate of Atlantis";
                 case ScummGame.DayOfTheTentacle: return "Day of the Tentacle";
                 case ScummGame.SamAndMax: return "Sam & Max Hit the Road";
+                case ScummGame.TheDig: return "The Dig";
+                case ScummGame.FullThrottle: return "Full Throttle";
                 case ScummGame.None: return "None";
                 default: return game.ToString(); // never silently "None" for a real, newly-added game
             }

--- a/ScummEditor.Engine/Structures/SpeechSouFile.cs
+++ b/ScummEditor.Engine/Structures/SpeechSouFile.cs
@@ -6,17 +6,23 @@ namespace ScummEditor.Engine.Structures
 {
     /*
     MONSTER.SOU / "game".SOU (FM Towns) - the speech and sound-effects container of the
-    talkie editions:
+    talkie editions. Verified vs ScummVM sound.cpp:572-588:
 
       "SOU " + uint32 (always 0)
       repeated entries:
-        "VCTL" + size:32be       (size includes the 8-byte header; body = lip-sync
-                                   timestamps, 2 bytes each)
-        Creative VOC file         ("Creative Voice File\x1A" header + typed blocks,
-                                   terminated by a 0x00 block)
+        [optional] "VCTL" + size:32be   (lip-sync block; VTTL in the effects files; size
+                                          includes the 8-byte header; body = lip-sync
+                                          timestamps, 2 bytes each)
+        [optional] "VTLK" + size:32be   (a wrapper around the VOC; size includes the 8-byte
+                                          header; Full Throttle uses it, the older talkie
+                                          editions do not)
+        Creative VOC file               ("Creative Voice File\x1A" header + typed blocks,
+                                          terminated by a 0x00 block)
 
-    The file is parsed lazily and only the block headers are read (the files reach
-    hundreds of MB); the audio bytes are loaded on demand per entry.
+    So an entry is, in order: an optional lip-sync block, an optional VTLK wrapper, then the
+    VOC. Some entries (DOTT) start directly with the VOC. The file is parsed lazily and only
+    the block headers are read (the files reach hundreds of MB); the audio bytes are loaded
+    on demand per entry.
     */
     public class SpeechSouFile
     {
@@ -79,17 +85,16 @@ namespace ScummEditor.Engine.Structures
                         Offset = entryOffset
                     };
 
-                    // Most entries start with a lip-sync block: VCTL in the talkie files,
-                    // VTTL in the sound-effects files. Some entries (seen in DOTT) have no
-                    // lip-sync block at all and start directly with the Creative VOC data.
+                    // An entry optionally starts with a lip-sync block (VCTL in the talkie files,
+                    // VTTL in the effects files). Some entries (DOTT) have none and start directly
+                    // with the VOC data.
                     bool isLipSyncTag = (tag[0] == 'V' && (tag[1] == 'C' || tag[1] == 'T') && tag[2] == 'T' && tag[3] == 'L');
-                    bool isBareVoc = (tag[0] == 'C' && tag[1] == 'r' && tag[2] == 'e' && tag[3] == 'a');
 
                     if (isLipSyncTag)
                     {
                         var sizeBytes = new byte[4];
                         if (stream.Read(sizeBytes, 0, 4) != 4) break;
-                        int blockSize = (sizeBytes[0] << 24) | (sizeBytes[1] << 16) | (sizeBytes[2] << 8) | sizeBytes[3];
+                        int blockSize = ReadBE32(sizeBytes);
                         if (blockSize < 8 || entryOffset + blockSize > stream.Length)
                         {
                             ParseError = string.Format("Invalid lip-sync block size at offset 0x{0:X}.", entryOffset);
@@ -98,26 +103,120 @@ namespace ScummEditor.Engine.Structures
 
                         entry.LipSyncCount = (blockSize - 8) / 2;
                         stream.Seek(entryOffset + blockSize, SeekOrigin.Begin);
+
+                        // read the tag of the block that follows the lip-sync block (a VTLK wrapper or the VOC)
+                        if (stream.Position + 4 > stream.Length || stream.Read(tag, 0, 4) != 4) break;
+                    }
+
+                    // The VOC may be wrapped in a VTLK block (Full Throttle) or follow directly (the older
+                    // talkie editions / DOTT).
+                    bool isVtlk = (tag[0] == 'V' && tag[1] == 'T' && tag[2] == 'L' && tag[3] == 'K');
+                    bool isBareVoc = (tag[0] == 'C' && tag[1] == 'r' && tag[2] == 'e' && tag[3] == 'a');
+
+                    if (isVtlk)
+                    {
+                        long vtlkOffset = stream.Position - 4;
+                        var sizeBytes = new byte[4];
+                        if (stream.Read(sizeBytes, 0, 4) != 4) break;
+                        int blockSize = ReadBE32(sizeBytes);
+                        if (blockSize < 8 || vtlkOffset + blockSize > stream.Length)
+                        {
+                            ParseError = string.Format("Invalid VTLK block size at offset 0x{0:X}.", vtlkOffset);
+                            return;
+                        }
+
+                        // The VTLK size is the authoritative entry boundary - ScummVM seeks by the offsets it
+                        // is given rather than walking the VOC, and Full Throttle's VOC bytes do not always
+                        // walk cleanly to a 0x00 terminator. The Creative VOC begins right after the 8-byte
+                        // VTLK header; the sample rate / duration are read best-effort and never abort.
+                        long vtlkEnd = vtlkOffset + blockSize;
+                        entry.VocOffset = stream.Position;
+                        entry.VocLength = (int)(vtlkEnd - entry.VocOffset);
+                        ReadVocMetadata(stream, entry, vtlkEnd);
+                        stream.Seek(vtlkEnd, SeekOrigin.Begin);
                     }
                     else if (isBareVoc)
                     {
-                        stream.Seek(entryOffset, SeekOrigin.Begin); // the VOC walk re-reads its header
+                        stream.Seek(stream.Position - 4, SeekOrigin.Begin); // rewind so the VOC walk re-reads its header
+                        if (!WalkVocFile(stream, entry))
+                        {
+                            ParseError = string.Format("Invalid VOC data at offset 0x{0:X}.", entry.VocOffset);
+                            return;
+                        }
                     }
                     else
                     {
                         ParseError = string.Format(
-                            "Unexpected data at offset 0x{0:X}: expected a VCTL/VTTL block or VOC data.", entryOffset);
-                        return;
-                    }
-
-                    if (!WalkVocFile(stream, entry))
-                    {
-                        ParseError = string.Format("Invalid VOC data at offset 0x{0:X}.", entry.VocOffset);
+                            "Unexpected data at offset 0x{0:X}: expected a VCTL/VTTL/VTLK block or VOC data.", stream.Position - 4);
                         return;
                     }
 
                     Entries.Add(entry);
                 }
+            }
+        }
+
+        private static int ReadBE32(byte[] b)
+        {
+            return (b[0] << 24) | (b[1] << 16) | (b[2] << 8) | b[3];
+        }
+
+        /// <summary>
+        /// Best-effort read of a VTLK-wrapped VOC's sample rate and (approximate) duration, bounded by the
+        /// VTLK block's end. Never fails the parse: the VTLK size already delimits the entry, so this only
+        /// fills the UI hint columns. It reads the sample rate from the first sound block (reliable) and
+        /// sums PCM bytes up to the first VOC terminator or the VTLK end (whichever comes first), so a VOC
+        /// whose trailing bytes do not walk to a clean terminator still yields a usable rate and duration.
+        /// </summary>
+        private static void ReadVocMetadata(FileStream stream, SpeechSouEntry entry, long limit)
+        {
+            long start = entry.VocOffset;
+            var vocHeader = new byte[26];
+            stream.Seek(start, SeekOrigin.Begin);
+            if (stream.Read(vocHeader, 0, 26) != 26) return;
+            for (int i = 0; i < VocSignature.Length; i++)
+            {
+                if (vocHeader[i] != (byte)VocSignature[i]) return;
+            }
+
+            int firstBlockOffset = vocHeader[20] | (vocHeader[21] << 8);
+            if (firstBlockOffset < 26) firstBlockOffset = 26;
+            long pos = start + firstBlockOffset;
+
+            long pcmBytes = 0;
+            var blockHeader = new byte[4];
+            while (pos + 4 <= limit)
+            {
+                stream.Seek(pos, SeekOrigin.Begin);
+                if (stream.Read(blockHeader, 0, 1) != 1) break;
+                byte blockType = blockHeader[0];
+                if (blockType == 0x00 || blockType > 9) break; // terminator, or no longer a valid VOC block
+
+                if (stream.Read(blockHeader, 1, 3) != 3) break;
+                int blockLength = blockHeader[1] | (blockHeader[2] << 8) | (blockHeader[3] << 16);
+                long bodyStart = pos + 4;
+                if (bodyStart + blockLength > limit) break;
+
+                if (blockType == 1 && blockLength >= 2) // sound data: timeConstant + codec + samples
+                {
+                    int timeConstant = stream.ReadByte();
+                    if (entry.SampleRate == 0 && timeConstant >= 0 && timeConstant < 256)
+                    {
+                        entry.SampleRate = 1000000 / (256 - timeConstant);
+                    }
+                    pcmBytes += blockLength - 2;
+                }
+                else if (blockType == 2) // continuation of the previous sound data
+                {
+                    pcmBytes += blockLength;
+                }
+
+                pos = bodyStart + blockLength;
+            }
+
+            if (entry.SampleRate > 0)
+            {
+                entry.DurationSeconds = pcmBytes / (double)entry.SampleRate;
             }
         }
 

--- a/ScummEditor.Engine/Structures/TrsFile.cs
+++ b/ScummEditor.Engine/Structures/TrsFile.cs
@@ -29,6 +29,7 @@ namespace ScummEditor.Engine.Structures
 
         private byte[] _body;        // decoded body (the template the entries index into)
         private byte[] _header;      // the 16-byte ETRS header (empty when not encoded)
+        private string _lineEnding = "\r\n"; // the body's native line terminator, restored on import
         private readonly List<LocalizedTextEntry> _entries = new List<LocalizedTextEntry>();
 
         public IReadOnlyList<LocalizedTextEntry> Entries { get { return _entries; } }
@@ -61,6 +62,7 @@ namespace ScummEditor.Engine.Structures
                 _body = bytes;
             }
 
+            _lineEnding = DetectLineEnding(_body);
             Parse();
             IsValid = _entries.Count > 0;
         }
@@ -143,7 +145,8 @@ namespace ScummEditor.Engine.Structures
         public string ImportFromText(string content)
         {
             var map = new Dictionary<string, string>();
-            foreach (string raw in content.Replace("\r\n", "\n").Split('\n'))
+            // Normalise every line ending (incl. a lone CR) before splitting on lines, so a dump saved by any editor parses.
+            foreach (string raw in content.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n'))
             {
                 if (raw.Length == 0 || raw[0] == '#') continue;
                 int tab = raw.IndexOf('\t');
@@ -151,20 +154,56 @@ namespace ScummEditor.Engine.Structures
                 map[raw.Substring(0, tab)] = Unescape(raw.Substring(tab + 1));
             }
 
-            int changed = 0;
+            int changed = 0, unmappable = 0, rejected = 0;
             foreach (LocalizedTextEntry e in _entries)
             {
                 string text;
-                if (map.TryGetValue(e.Key, out text) && text != e.Text)
+                if (!map.TryGetValue(e.Key, out text) || text == e.Text) continue;
+                if (StartsAnyLineWithDefine(text))
                 {
-                    e.Text = text;
-                    changed++;
+                    rejected++; // a line beginning with "#define" re-parses as a new entry boundary, corrupting the file
+                    continue;
                 }
+                e.Text = text;
+                changed++;
+                unmappable += LocalizedTextEntry.CountUnmappable(text);
             }
-            return string.Format("{0} of {1} strings updated.", changed, _entries.Count);
+            string report = string.Format("{0} of {1} strings updated.", changed, _entries.Count);
+            if (rejected > 0)
+            {
+                report += string.Format("\nWARNING: {0} string(s) skipped - text with a line beginning \"#define\" would corrupt the .TRS structure.", rejected);
+            }
+            if (unmappable > 0)
+            {
+                report += string.Format("\nWARNING: {0} character(s) are outside the game's 8-bit code page and will be saved as '?'.", unmappable);
+            }
+            return report;
+        }
+
+        /// <inheritdoc/>
+        public string NormalizeEditedText(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return text ?? string.Empty;
+            // Re-express whatever the GUI produced (Windows Forms forces CRLF) in the file's native ending,
+            // so editing a Mac LF-LF .TRS does not silently rewrite every line to CRLF.
+            return text.Replace("\r\n", "\n").Replace("\r", "\n").Replace("\n", _lineEnding);
         }
 
         // ---- helpers ----
+
+        /// <summary>True if any line of the (edited) text begins with "#define" - such a line would be
+        /// re-parsed as a new entry boundary on the next load, merging/splitting entries and corrupting
+        /// the file. The original game files never put "#define" inside a string, so a real edit never
+        /// trips this; it guards against a stray "#define" introduced through the import dump.</summary>
+        private static bool StartsAnyLineWithDefine(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return false;
+            foreach (string line in text.Replace("\r\n", "\n").Replace("\r", "\n").Split('\n'))
+            {
+                if (line.StartsWith("#define")) return true;
+            }
+            return false;
+        }
 
         private static bool IsDefineLine(byte[] b, int start, int contentEnd)
         {
@@ -189,7 +228,7 @@ namespace ScummEditor.Engine.Structures
             return s.Replace("\\", "\\\\").Replace("\r\n", "\\n").Replace("\r", "\\n").Replace("\n", "\\n").Replace("\t", "\\t");
         }
 
-        private static string Unescape(string s)
+        private string Unescape(string s)
         {
             var sb = new StringBuilder(s.Length);
             for (int i = 0; i < s.Length; i++)
@@ -197,7 +236,7 @@ namespace ScummEditor.Engine.Structures
                 if (s[i] == '\\' && i + 1 < s.Length)
                 {
                     char n = s[++i];
-                    if (n == 'n') sb.Append("\r\n");
+                    if (n == 'n') sb.Append(_lineEnding); // restore the file's own line terminator (CRLF, or LF on Mac)
                     else if (n == 't') sb.Append('\t');
                     else if (n == '\\') sb.Append('\\');
                     else { sb.Append('\\'); sb.Append(n); }
@@ -205,6 +244,19 @@ namespace ScummEditor.Engine.Structures
                 else sb.Append(s[i]);
             }
             return sb.ToString();
+        }
+
+        /// <summary>The body's native line terminator. Restoring it on import keeps an edited string in the
+        /// file's own convention (Windows CRLF, the Steam Mac The Dig's LF) so the export/import round-trip
+        /// stays byte-identical instead of forcing every line to CRLF.</summary>
+        private static string DetectLineEnding(byte[] body)
+        {
+            for (int i = 0; i < body.Length; i++)
+            {
+                if (body[i] == (byte)'\n') return "\n";
+                if (body[i] == (byte)'\r') return (i + 1 < body.Length && body[i + 1] == (byte)'\n') ? "\r\n" : "\r";
+            }
+            return "\r\n";
         }
 
         private static void LineBounds(byte[] b, int pos, out int contentEnd, out int lineEnd)

--- a/ScummEditor.Engine/Structures/TrsFile.cs
+++ b/ScummEditor.Engine/Structures/TrsFile.cs
@@ -1,0 +1,227 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace ScummEditor.Engine.Structures
+{
+    /// <summary>
+    /// A SCUMM v7 .TRS text resource: the cutscene-subtitle and UI strings (The Dig DIGTXT.TRS / DIG.TRS,
+    /// Full Throttle's per-scene ACCIDENT.TRS / MINEROAD.TRS / ...). A .TRS is either plain text or, when it
+    /// starts with the tag "ETRS", a 16-byte header followed by an XOR-0xCC encoded body (verified vs
+    /// ScummVM smush_player.cpp getStrings). The decoded body is a series of `#define NAME id` blocks, each
+    /// followed by the string text (which may span several lines and contain SMUSH codes like ^f01^c001).
+    ///
+    /// Each block is one editable entry (Key = the define identifier, Text = the lines that follow it up to
+    /// the next #define). The decoded body is the template; only edited entries' text is spliced, then the
+    /// body is re-encoded (XOR 0xCC + the original header) if it was ETRS - so an unedited file rebuilds
+    /// byte-identically. Text is stored as Latin-1 for an exact round-trip.
+    /// </summary>
+    public class TrsFile : ILocalizedTextFile
+    {
+        private const byte XorKey = 0xCC;
+        private const int EtrsHeaderLength = 16;
+        private static readonly byte[] EtrsTag = { (byte)'E', (byte)'T', (byte)'R', (byte)'S' };
+
+        public string FilePath { get; private set; }
+        public byte[] OriginalContent { get; private set; }
+        public bool Encoded { get; private set; } // ETRS / XOR 0xCC
+        public bool IsValid { get; private set; }
+
+        private byte[] _body;        // decoded body (the template the entries index into)
+        private byte[] _header;      // the 16-byte ETRS header (empty when not encoded)
+        private readonly List<LocalizedTextEntry> _entries = new List<LocalizedTextEntry>();
+
+        public IReadOnlyList<LocalizedTextEntry> Entries { get { return _entries; } }
+        public string FileName { get { return Path.GetFileName(FilePath); } }
+
+        public TrsFile(string filePath)
+        {
+            FilePath = filePath;
+        }
+
+        public void Load(byte[] bytes)
+        {
+            OriginalContent = bytes;
+            _entries.Clear();
+            Encoded = false;
+            IsValid = false;
+            if (bytes == null || bytes.Length == 0) return;
+
+            if (StartsWith(bytes, EtrsTag) && bytes.Length > EtrsHeaderLength)
+            {
+                Encoded = true;
+                _header = new byte[EtrsHeaderLength];
+                System.Array.Copy(bytes, 0, _header, 0, EtrsHeaderLength);
+                _body = new byte[bytes.Length - EtrsHeaderLength];
+                for (int i = 0; i < _body.Length; i++) _body[i] = (byte)(bytes[EtrsHeaderLength + i] ^ XorKey);
+            }
+            else
+            {
+                _header = System.Array.Empty<byte>();
+                _body = bytes;
+            }
+
+            Parse();
+            IsValid = _entries.Count > 0;
+        }
+
+        private void Parse()
+        {
+            // Collect the byte offsets of every line that starts with "#define".
+            var defineLineStarts = new List<int>();
+            var defineLineEnds = new List<int>();   // start of the line AFTER the #define line
+            var defineContentEnds = new List<int>();
+            int pos = 0;
+            while (pos < _body.Length)
+            {
+                int contentEnd, lineEnd;
+                LineBounds(_body, pos, out contentEnd, out lineEnd);
+                if (IsDefineLine(_body, pos, contentEnd))
+                {
+                    defineLineStarts.Add(pos);
+                    defineContentEnds.Add(contentEnd);
+                    defineLineEnds.Add(lineEnd);
+                }
+                pos = lineEnd;
+            }
+
+            var usedKeys = new HashSet<string>();
+            for (int i = 0; i < defineLineStarts.Count; i++)
+            {
+                int textStart = defineLineEnds[i];
+                int textEnd = (i + 1 < defineLineStarts.Count) ? defineLineStarts[i + 1] : _body.Length;
+
+                string key = MakeKey(_body, defineLineStarts[i], defineContentEnds[i]);
+                if (!usedKeys.Add(key)) key = key + " #" + i; // disambiguate the rare duplicate
+
+                _entries.Add(new LocalizedTextEntry
+                {
+                    Key = key,
+                    Text = Encoding.Latin1.GetString(_body, textStart, textEnd - textStart),
+                    TextStart = textStart,
+                    TextEnd = textEnd,
+                });
+            }
+        }
+
+        public byte[] BuildContent()
+        {
+            byte[] body;
+            using (var ms = new MemoryStream())
+            {
+                int pos = 0;
+                foreach (LocalizedTextEntry e in _entries)
+                {
+                    ms.Write(_body, pos, e.TextStart - pos);          // verbatim incl. the "#define ..." line
+                    byte[] text = Encoding.Latin1.GetBytes(e.Text ?? string.Empty);
+                    ms.Write(text, 0, text.Length);
+                    pos = e.TextEnd;
+                }
+                ms.Write(_body, pos, _body.Length - pos);
+                body = ms.ToArray();
+            }
+
+            if (!Encoded) return body;
+
+            var outBytes = new byte[_header.Length + body.Length];
+            System.Array.Copy(_header, 0, outBytes, 0, _header.Length);
+            for (int i = 0; i < body.Length; i++) outBytes[_header.Length + i] = (byte)(body[i] ^ XorKey);
+            return outBytes;
+        }
+
+        public string ExportToText()
+        {
+            var sb = new StringBuilder();
+            sb.Append("# ").Append(FileName).Append(" - KEY<TAB>TEXT, one per line; newlines escaped as \\n. Edit TEXT only.\r\n");
+            foreach (LocalizedTextEntry e in _entries)
+            {
+                sb.Append(e.Key).Append('\t').Append(Escape(e.Text)).Append("\r\n");
+            }
+            return sb.ToString();
+        }
+
+        public string ImportFromText(string content)
+        {
+            var map = new Dictionary<string, string>();
+            foreach (string raw in content.Replace("\r\n", "\n").Split('\n'))
+            {
+                if (raw.Length == 0 || raw[0] == '#') continue;
+                int tab = raw.IndexOf('\t');
+                if (tab <= 0) continue;
+                map[raw.Substring(0, tab)] = Unescape(raw.Substring(tab + 1));
+            }
+
+            int changed = 0;
+            foreach (LocalizedTextEntry e in _entries)
+            {
+                string text;
+                if (map.TryGetValue(e.Key, out text) && text != e.Text)
+                {
+                    e.Text = text;
+                    changed++;
+                }
+            }
+            return string.Format("{0} of {1} strings updated.", changed, _entries.Count);
+        }
+
+        // ---- helpers ----
+
+        private static bool IsDefineLine(byte[] b, int start, int contentEnd)
+        {
+            const string token = "#define";
+            if (contentEnd - start < token.Length) return false;
+            for (int i = 0; i < token.Length; i++) if (b[start + i] != (byte)token[i]) return false;
+            return true;
+        }
+
+        /// <summary>Normalised define identifier ("#define  TRS_BTN_YES   80" -> "TRS_BTN_YES 80").</summary>
+        private static string MakeKey(byte[] b, int start, int contentEnd)
+        {
+            string line = Encoding.Latin1.GetString(b, start, contentEnd - start);
+            string rest = line.Substring("#define".Length).Trim();
+            string[] parts = rest.Split((char[])null, System.StringSplitOptions.RemoveEmptyEntries);
+            return string.Join(" ", parts);
+        }
+
+        private static string Escape(string s)
+        {
+            if (s == null) return string.Empty;
+            return s.Replace("\\", "\\\\").Replace("\r\n", "\\n").Replace("\r", "\\n").Replace("\n", "\\n").Replace("\t", "\\t");
+        }
+
+        private static string Unescape(string s)
+        {
+            var sb = new StringBuilder(s.Length);
+            for (int i = 0; i < s.Length; i++)
+            {
+                if (s[i] == '\\' && i + 1 < s.Length)
+                {
+                    char n = s[++i];
+                    if (n == 'n') sb.Append("\r\n");
+                    else if (n == 't') sb.Append('\t');
+                    else if (n == '\\') sb.Append('\\');
+                    else { sb.Append('\\'); sb.Append(n); }
+                }
+                else sb.Append(s[i]);
+            }
+            return sb.ToString();
+        }
+
+        private static void LineBounds(byte[] b, int pos, out int contentEnd, out int lineEnd)
+        {
+            int i = pos;
+            while (i < b.Length && b[i] != (byte)'\r' && b[i] != (byte)'\n') i++;
+            contentEnd = i;
+            if (i < b.Length && b[i] == (byte)'\r') i++;
+            if (i < b.Length && b[i] == (byte)'\n') i++;
+            lineEnd = i;
+        }
+
+        private static bool StartsWith(byte[] b, byte[] prefix)
+        {
+            if (b.Length < prefix.Length) return false;
+            for (int i = 0; i < prefix.Length; i++) if (b[i] != prefix[i]) return false;
+            return true;
+        }
+    }
+}

--- a/ScummEditor.Gui/FilePacker.cs
+++ b/ScummEditor.Gui/FilePacker.cs
@@ -451,6 +451,12 @@ namespace ScummEditor.Gui
                 string report = HasV3Charsets()
                     ? CharsetV3PngCodec.ExportAll(scummFile.V3Charsets, dlg.SelectedPath)
                     : CharsetPngCodec.ExportAll(scummFile.GetAllEditableCharsets(), dlg.SelectedPath);
+                if (HasNutFonts())
+                {
+                    // v7 also has external .NUT SMUSH fonts (the in-container CHAR charsets are covered above).
+                    report += Environment.NewLine + Environment.NewLine
+                        + NutFontPngCodec.ExportAll(scummFile.NutFonts, dlg.SelectedPath);
+                }
                 MessageBox.Show(this, report, "Export game fonts", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             catch (Exception ex)
@@ -464,6 +470,12 @@ namespace ScummEditor.Gui
         private bool HasV3Charsets()
         {
             return scummFile != null && scummFile.V3Charsets != null && scummFile.V3Charsets.Count > 0;
+        }
+
+        /// <summary>True when the game has external .NUT SMUSH fonts (v7 The Dig / Full Throttle).</summary>
+        private bool HasNutFonts()
+        {
+            return scummFile != null && scummFile.NutFonts != null && scummFile.NutFonts.Count > 0;
         }
 
         private void importGameFontsToolStripMenuItem_Click(object sender, EventArgs e)
@@ -492,6 +504,11 @@ namespace ScummEditor.Gui
                 string report = HasV3Charsets()
                     ? CharsetV3PngCodec.ImportAll(scummFile.V3Charsets, dlg.SelectedPath)
                     : CharsetPngCodec.ImportAll(scummFile.GetAllEditableCharsets(), dlg.SelectedPath);
+                if (HasNutFonts())
+                {
+                    report += Environment.NewLine + Environment.NewLine
+                        + NutFontPngCodec.ImportAll(scummFile.NutFonts, dlg.SelectedPath);
+                }
                 MessageBox.Show(this,
                     report + Environment.NewLine + "Use 'Save Changes' to write the changes to the game files.",
                     "Import game fonts", MessageBoxButtons.OK, MessageBoxIcon.Information);

--- a/ScummEditor.Gui/Gui/AkosCostumeControl.cs
+++ b/ScummEditor.Gui/Gui/AkosCostumeControl.cs
@@ -65,10 +65,9 @@ namespace ScummEditor.Gui
             var topBar = new Panel { Dock = DockStyle.Top, Height = 54 };
             _exportButton = new Button { Text = "Export PNG", Width = 90, Left = 3, Top = 3, Enabled = false };
             _exportButton.Click += ExportClick;
-            // Import re-encodes the cel back into the costume (codec 1 BYLE-RLE / codec 5 BOMP). It requires
-            // an INDEXED PNG so the costume-colour indices are preserved exactly, independent of the display
-            // palette (re-export from this viewer, edit without converting to RGB). Codec 16 (MAJMIN) is not
-            // encodable yet, so Import is disabled for those costumes.
+            // Import re-encodes the cel back into the costume (codec 1 BYLE-RLE / 5 BOMP / 16 MAJMIN). It
+            // requires an INDEXED PNG so the costume-colour indices are preserved exactly, independent of
+            // the display palette (re-export from this viewer, edit without converting to RGB).
             _importButton = new Button { Text = "Import PNG", Width = 90, Left = 99, Top = 3, Enabled = false };
             _importButton.Click += ImportClick;
             var paletteLabel = new Label { Text = "Palette:", AutoSize = true, Left = 198, Top = 8 };

--- a/ScummEditor.Gui/Gui/AkosCostumeControl.cs
+++ b/ScummEditor.Gui/Gui/AkosCostumeControl.cs
@@ -5,6 +5,7 @@ using System.Drawing.Imaging;
 using System.Linq;
 using System.Windows.Forms;
 using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Exceptions;
 using ScummEditor.Engine.Structures;
 using ScummEditor.Engine.Structures.DataFile;
 
@@ -28,6 +29,7 @@ namespace ScummEditor.Gui
         private readonly Label _info;
         private readonly ComboBox _paletteBox;
         private readonly Button _exportButton;
+        private readonly Button _importButton;
 
         private BlockBase _akos;
         private int _currentCelIndex = -1;
@@ -54,19 +56,22 @@ namespace ScummEditor.Gui
             _picture = new PictureBox { SizeMode = PictureBoxSizeMode.AutoSize };
             _scroll.Controls.Add(_picture);
 
-            // Two-row top bar: row 1 = export + palette selector, row 2 = codec / cel info.
+            // Two-row top bar: row 1 = export/import + palette selector, row 2 = codec / cel info.
             var topBar = new Panel { Dock = DockStyle.Top, Height = 54 };
-            // Export only for now: per-cel IMPORT needs the AKOS cel ENCODERS (codec 1 BYLE-RLE, 5 BOMP,
-            // 16 MAJMIN) plus re-splicing AKCD + fixing AKOF/AKCI/sizes + the LFLF/LECF offsets - that is
-            // the Phase D "encode" step, still to come. Until then this viewer is read-only (no Import
-            // button), matching how each phase ships decode first, then the matching encoder.
             _exportButton = new Button { Text = "Export PNG", Width = 90, Left = 3, Top = 3, Enabled = false };
             _exportButton.Click += ExportClick;
-            var paletteLabel = new Label { Text = "Palette:", AutoSize = true, Left = 99, Top = 8 };
-            _paletteBox = new ComboBox { Left = 150, Top = 4, Width = 260, DropDownStyle = ComboBoxStyle.DropDownList };
+            // Import re-encodes the cel back into the costume (codec 1 BYLE-RLE / codec 5 BOMP). It requires
+            // an INDEXED PNG so the costume-colour indices are preserved exactly, independent of the display
+            // palette (re-export from this viewer, edit without converting to RGB). Codec 16 (MAJMIN) is not
+            // encodable yet, so Import is disabled for those costumes.
+            _importButton = new Button { Text = "Import PNG", Width = 90, Left = 99, Top = 3, Enabled = false };
+            _importButton.Click += ImportClick;
+            var paletteLabel = new Label { Text = "Palette:", AutoSize = true, Left = 198, Top = 8 };
+            _paletteBox = new ComboBox { Left = 249, Top = 4, Width = 240, DropDownStyle = ComboBoxStyle.DropDownList };
             _paletteBox.SelectedIndexChanged += (s, e) => RenderCurrent();
             _info = new Label { Left = 3, Top = 32, AutoSize = true, Text = string.Empty };
             topBar.Controls.Add(_exportButton);
+            topBar.Controls.Add(_importButton);
             topBar.Controls.Add(paletteLabel);
             topBar.Controls.Add(_paletteBox);
             topBar.Controls.Add(_info);
@@ -97,6 +102,7 @@ namespace ScummEditor.Gui
             ClearImage();
             _currentCelIndex = -1;
             _exportButton.Enabled = false;
+            _importButton.Enabled = false;
             _info.Text = string.Empty;
             if (_akos == null) return;
 
@@ -181,6 +187,7 @@ namespace ScummEditor.Gui
         {
             ClearImage();
             _exportButton.Enabled = false;
+            _importButton.Enabled = false;
             if (_akos == null || _currentCelIndex < 0)
             {
                 _info.Text = _codecInfo;
@@ -205,7 +212,8 @@ namespace ScummEditor.Gui
                 }
                 _picture.Image = cel;
                 _exportButton.Enabled = true;
-                _info.Text = celInfo;
+                _importButton.Enabled = AkosImageEncoder.CanEncode(_akos); // codec 1/5 only
+                _info.Text = celInfo + (_importButton.Enabled ? string.Empty : "  (import N/A: codec not encodable yet)");
             }
             catch (Exception ex)
             {
@@ -236,6 +244,57 @@ namespace ScummEditor.Gui
             catch (Exception ex)
             {
                 MessageBox.Show(ex.Message, "Export failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+        }
+
+        /// <summary>
+        /// Re-encodes an INDEXED PNG back into the selected cel (codec 1/5) via AkosImageEncoder. An indexed
+        /// PNG is required so the costume-colour indexes are preserved exactly, independent of the display
+        /// palette - so the round-trip is correct even for costumes whose colours are set at runtime.
+        /// </summary>
+        private void ImportClick(object sender, EventArgs e)
+        {
+            if (_akos == null || _currentCelIndex < 0) return;
+            if (!AkosImageEncoder.CanEncode(_akos))
+            {
+                MessageBox.Show("This costume's cel codec cannot be re-encoded yet (import supports codec 1 / 5).",
+                    "Import", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            using (var dialog = new OpenFileDialog { Filter = "PNG Files|*.png" })
+            {
+                if (dialog.ShowDialog() != DialogResult.OK) return;
+
+                int celToReselect = _currentCelIndex;
+                try
+                {
+                    using (var bitmap = (Bitmap)Image.FromFile(dialog.FileName))
+                    {
+                        if (!IndexedImageHelper.IsIndexed(bitmap))
+                        {
+                            MessageBox.Show(
+                                "The image must be an INDEXED (palette-based) PNG so the costume's colour indexes are preserved. " +
+                                "Re-export this cel from the editor and edit it without converting it to RGB/truecolor.",
+                                "Import", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                            return;
+                        }
+                        byte[,] indices = IndexedImageHelper.GetIndexMatrix(bitmap);
+                        AkosImageEncoder.ReplaceCel(_akos, _currentCelIndex, indices);
+                    }
+                }
+                catch (ImageEncodeException ex)
+                {
+                    MessageBox.Show(ex.Message, "Import failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+
+                // Re-parse the costume (the AKCD/AKOF changed) and keep the user on the edited cel.
+                SetAndRefreshData(_akos);
+                if (celToReselect < _tree.Nodes.Count) _tree.SelectedNode = _tree.Nodes[celToReselect];
+
+                MessageBox.Show("Cel imported. Use \"Save changes\" to write it back to the game files.",
+                    "Import", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
         }
 

--- a/ScummEditor.Gui/Gui/AkosCostumeControl.cs
+++ b/ScummEditor.Gui/Gui/AkosCostumeControl.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Linq;
+using System.Windows.Forms;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+
+namespace ScummEditor.Gui
+{
+    /// <summary>
+    /// Viewer for a SCUMM v7 AKOS costume (The Dig, Full Throttle): the costume's cels (frames) listed
+    /// on the left, the decoded cel on the right, with PNG export. It renders via AkosImageDecoder, which
+    /// decodes cel codecs 1 (BYLE RLE), 5 (BOMP) and 16 (MAJMIN). Codec 1/5 cels carry their own colours
+    /// (RGBS); codec 16 cels are masks with no colours of their own, so a palette combobox lets the user
+    /// render any cel against a chosen room palette (how the costume looks in that room). AKOS interleaves
+    /// real frames with tiny 1x1/2x1 placeholder cels for unused animation slots - those show as their
+    /// real (near-empty) size and are labelled, so a "blank" preview is understood, not mistaken for a bug.
+    /// </summary>
+    public class AkosCostumeControl : BlockBaseControl
+    {
+        private readonly SplitContainer _split;
+        private readonly TreeView _tree;
+        private readonly Panel _scroll;
+        private readonly PictureBox _picture;
+        private readonly Label _info;
+        private readonly ComboBox _paletteBox;
+        private readonly Button _exportButton;
+
+        private BlockBase _akos;
+        private int _currentCelIndex = -1;
+        private string _codecInfo = string.Empty;
+        private bool _splitterApplied;
+
+        /// <summary>A render-palette choice for the combobox; Palette null means the costume's own colours.</summary>
+        private class PaletteChoice
+        {
+            public string Name;
+            public Color[] Palette;
+            public override string ToString() { return Name; }
+        }
+
+        public AkosCostumeControl()
+        {
+            _split = new SplitContainer { Dock = DockStyle.Fill, Orientation = Orientation.Vertical };
+
+            _tree = new TreeView { Dock = DockStyle.Fill, HideSelection = false };
+            _tree.AfterSelect += TreeAfterSelect;
+            _split.Panel1.Controls.Add(_tree);
+
+            _scroll = new Panel { Dock = DockStyle.Fill, AutoScroll = true, BackColor = Color.LightGray };
+            _picture = new PictureBox { SizeMode = PictureBoxSizeMode.AutoSize };
+            _scroll.Controls.Add(_picture);
+
+            // Two-row top bar: row 1 = export + palette selector, row 2 = codec / cel info.
+            var topBar = new Panel { Dock = DockStyle.Top, Height = 54 };
+            // Export only for now: per-cel IMPORT needs the AKOS cel ENCODERS (codec 1 BYLE-RLE, 5 BOMP,
+            // 16 MAJMIN) plus re-splicing AKCD + fixing AKOF/AKCI/sizes + the LFLF/LECF offsets - that is
+            // the Phase D "encode" step, still to come. Until then this viewer is read-only (no Import
+            // button), matching how each phase ships decode first, then the matching encoder.
+            _exportButton = new Button { Text = "Export PNG", Width = 90, Left = 3, Top = 3, Enabled = false };
+            _exportButton.Click += ExportClick;
+            var paletteLabel = new Label { Text = "Palette:", AutoSize = true, Left = 99, Top = 8 };
+            _paletteBox = new ComboBox { Left = 150, Top = 4, Width = 260, DropDownStyle = ComboBoxStyle.DropDownList };
+            _paletteBox.SelectedIndexChanged += (s, e) => RenderCurrent();
+            _info = new Label { Left = 3, Top = 32, AutoSize = true, Text = string.Empty };
+            topBar.Controls.Add(_exportButton);
+            topBar.Controls.Add(paletteLabel);
+            topBar.Controls.Add(_paletteBox);
+            topBar.Controls.Add(_info);
+
+            _split.Panel2.Controls.Add(_scroll);
+            _split.Panel2.Controls.Add(topBar);
+
+            Controls.Add(_split);
+            _split.BringToFront();
+        }
+
+        protected override void OnSizeChanged(EventArgs e)
+        {
+            base.OnSizeChanged(e);
+            if (_split != null && !_splitterApplied && _split.Width > 200)
+            {
+                _split.SplitterDistance = 150;
+                _splitterApplied = true;
+            }
+        }
+
+        public override void SetAndRefreshData(BlockBase blockBase)
+        {
+            base.SetAndRefreshData(blockBase);
+
+            _akos = blockBase;
+            _tree.Nodes.Clear();
+            ClearImage();
+            _currentCelIndex = -1;
+            _exportButton.Enabled = false;
+            _info.Text = string.Empty;
+            if (_akos == null) return;
+
+            int codec = AkosImageDecoder.GetCodec(_akos);
+            int celCount = AkosImageDecoder.GetCelCount(_akos);
+            _codecInfo = string.Format("codec {0}, {1} cels", codec, celCount);
+
+            for (int i = 0; i < celCount; i++)
+            {
+                Size sz = AkosImageDecoder.GetCelSize(_akos, i);
+                bool placeholder = sz.Width * sz.Height <= 4; // AKOS uses tiny 1x1/2x1 cels for unused slots
+                string text = string.Format("Cel {0} ({1}x{2}){3}", i, sz.Width, sz.Height, placeholder ? " - empty" : string.Empty);
+                var node = _tree.Nodes.Add(text);
+                node.Tag = i;
+            }
+
+            BuildPaletteChoices();
+
+            if (_tree.Nodes.Count > 0)
+            {
+                _tree.SelectedNode = _tree.Nodes[0];
+            }
+        }
+
+        /// <summary>
+        /// Populates the palette combobox: "Costume (own colours)" first, then every room palette in the
+        /// game (so a codec-16 mask, which has no colours of its own, can be shown in a real room palette).
+        /// </summary>
+        private void BuildPaletteChoices()
+        {
+            _paletteBox.Items.Clear();
+            _paletteBox.Items.Add(new PaletteChoice { Name = "Costume (own colours)", Palette = null });
+
+            try
+            {
+                var lflf = _akos.Parent as DiskBlock;
+                var lecf = lflf != null ? lflf.Parent : null;
+                if (lecf != null)
+                {
+                    int roomIndex = 0;
+                    foreach (DiskBlock disk in lecf.Childrens.OfType<DiskBlock>())
+                    {
+                        RoomBlock room = disk.GetROOM();
+                        PalettesData pals = room != null ? room.GetPALS() : null;
+                        var wrap = pals != null ? pals.GetWRAP() : null;
+                        List<PaletteData> apals = wrap != null ? wrap.GetAPALs() : null;
+                        if (apals != null)
+                        {
+                            for (int p = 0; p < apals.Count; p++)
+                            {
+                                string name = apals.Count > 1
+                                    ? string.Format("Room {0} - palette {1}", roomIndex, p)
+                                    : string.Format("Room {0}", roomIndex);
+                                _paletteBox.Items.Add(new PaletteChoice { Name = name, Palette = apals[p].Colors });
+                            }
+                        }
+                        roomIndex++;
+                    }
+                }
+            }
+            catch
+            {
+                // Palette enumeration is best-effort; the costume's own colours always remain available.
+            }
+
+            _paletteBox.SelectedIndex = 0;
+        }
+
+        private Color[] SelectedPalette()
+        {
+            var choice = _paletteBox.SelectedItem as PaletteChoice;
+            return choice != null ? choice.Palette : null;
+        }
+
+        private void TreeAfterSelect(object sender, TreeViewEventArgs e)
+        {
+            _currentCelIndex = (e.Node != null && e.Node.Tag is int) ? (int)e.Node.Tag : -1;
+            RenderCurrent();
+        }
+
+        /// <summary>Decodes and shows the selected cel with the selected palette. Tiny placeholder cels and
+        /// decode failures are reported in the info label instead of leaving a mysteriously blank panel.</summary>
+        private void RenderCurrent()
+        {
+            ClearImage();
+            _exportButton.Enabled = false;
+            if (_akos == null || _currentCelIndex < 0)
+            {
+                _info.Text = _codecInfo;
+                return;
+            }
+
+            Size sz = AkosImageDecoder.GetCelSize(_akos, _currentCelIndex);
+            string celInfo = string.Format("{0}  |  Cel {1}: {2}x{3}", _codecInfo, _currentCelIndex, sz.Width, sz.Height);
+            if (sz.Width * sz.Height <= 4)
+            {
+                _info.Text = celInfo + " - empty placeholder cel (unused animation slot)";
+                return;
+            }
+
+            try
+            {
+                Bitmap cel = AkosImageDecoder.DecodeCel(_akos, _currentCelIndex, SelectedPalette());
+                if (cel == null)
+                {
+                    _info.Text = celInfo + " - not decodable (unsupported codec)";
+                    return;
+                }
+                _picture.Image = cel;
+                _exportButton.Enabled = true;
+                _info.Text = celInfo;
+            }
+            catch (Exception ex)
+            {
+                _info.Text = celInfo + " - decode failed: " + ex.Message;
+            }
+        }
+
+        private void ExportClick(object sender, EventArgs e)
+        {
+            if (_akos == null || _currentCelIndex < 0) return;
+
+            try
+            {
+                using (Bitmap cel = AkosImageDecoder.DecodeCel(_akos, _currentCelIndex, SelectedPalette()))
+                {
+                    if (cel == null) return;
+                    using (var dialog = new SaveFileDialog
+                    {
+                        Filter = "PNG Files|*.png",
+                        FileName = string.Format("Costume Cel#{0}.png", _currentCelIndex)
+                    })
+                    {
+                        if (dialog.ShowDialog() != DialogResult.OK) return;
+                        cel.Save(dialog.FileName, ImageFormat.Png);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Export failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+        }
+
+        /// <summary>Disposes the current preview bitmap (a fresh GDI bitmap is decoded per cel/palette).</summary>
+        private void ClearImage()
+        {
+            if (_picture.Image != null)
+            {
+                _picture.Image.Dispose();
+                _picture.Image = null;
+            }
+        }
+    }
+}

--- a/ScummEditor.Gui/Gui/AkosCostumeControl.cs
+++ b/ScummEditor.Gui/Gui/AkosCostumeControl.cs
@@ -122,38 +122,36 @@ namespace ScummEditor.Gui
         }
 
         /// <summary>
-        /// Populates the palette combobox: "Costume (own colours)" first, then every room palette in the
-        /// game (so a codec-16 mask, which has no colours of its own, can be shown in a real room palette).
+        /// Populates the palette combobox with only the palettes that actually apply to this costume: its
+        /// OWN colours (RGBS, codec 1/5) - or a grayscale ramp when it has none (codec-16 masks/full-screen
+        /// animations carry no RGBS; their true colours come from a runtime palette) - plus the palette(s)
+        /// of the costume's OWN room (the ROOM in the same LFLF). Other rooms' palettes are not offered:
+        /// a costume is drawn with its own colours or its room's, not an arbitrary room's.
         /// </summary>
         private void BuildPaletteChoices()
         {
             _paletteBox.Items.Clear();
-            _paletteBox.Items.Add(new PaletteChoice { Name = "Costume (own colours)", Palette = null });
+
+            bool ownPalette = AkosImageDecoder.HasOwnPalette(_akos);
+            _paletteBox.Items.Add(new PaletteChoice
+            {
+                Name = ownPalette ? "Costume (own colours)" : "Grayscale (costume has no palette)",
+                Palette = null,
+            });
 
             try
             {
                 var lflf = _akos.Parent as DiskBlock;
-                var lecf = lflf != null ? lflf.Parent : null;
-                if (lecf != null)
+                RoomBlock room = lflf != null ? lflf.GetROOM() : null;
+                PalettesData pals = room != null ? room.GetPALS() : null;
+                var wrap = pals != null ? pals.GetWRAP() : null;
+                List<PaletteData> apals = wrap != null ? wrap.GetAPALs() : null;
+                if (apals != null)
                 {
-                    int roomIndex = 0;
-                    foreach (DiskBlock disk in lecf.Childrens.OfType<DiskBlock>())
+                    for (int p = 0; p < apals.Count; p++)
                     {
-                        RoomBlock room = disk.GetROOM();
-                        PalettesData pals = room != null ? room.GetPALS() : null;
-                        var wrap = pals != null ? pals.GetWRAP() : null;
-                        List<PaletteData> apals = wrap != null ? wrap.GetAPALs() : null;
-                        if (apals != null)
-                        {
-                            for (int p = 0; p < apals.Count; p++)
-                            {
-                                string name = apals.Count > 1
-                                    ? string.Format("Room {0} - palette {1}", roomIndex, p)
-                                    : string.Format("Room {0}", roomIndex);
-                                _paletteBox.Items.Add(new PaletteChoice { Name = name, Palette = apals[p].Colors });
-                            }
-                        }
-                        roomIndex++;
+                        string name = apals.Count > 1 ? string.Format("Room palette {0}", p) : "Room palette";
+                        _paletteBox.Items.Add(new PaletteChoice { Name = name, Palette = apals[p].Colors });
                     }
                 }
             }

--- a/ScummEditor.Gui/Gui/AkosCostumeControl.cs
+++ b/ScummEditor.Gui/Gui/AkosCostumeControl.cs
@@ -36,6 +36,11 @@ namespace ScummEditor.Gui
         private string _codecInfo = string.Empty;
         private bool _splitterApplied;
 
+        // Cache of "palettes referenced by a literal setCurrentPalette(roomN) in a script", computed once
+        // per loaded game (keyed by the LECF root) - a view-only candidate source for codec-16 cels.
+        private BlockBase _scriptPaletteRoot;
+        private List<KeyValuePair<int, Color[]>> _scriptPalettes;
+
         /// <summary>A render-palette choice for the combobox; Palette null means the costume's own colours.</summary>
         private class PaletteChoice
         {
@@ -166,7 +171,90 @@ namespace ScummEditor.Gui
                 // Palette enumeration is best-effort; the costume's own colours always remain available.
             }
 
+            // Candidate palettes that scripts load via a literal setCurrentPalette(roomN): a codec-16
+            // cel (no palette of its own) is often shown under the palette a cutscene loads, so offer those.
+            try
+            {
+                var lecf = (_akos.Parent as DiskBlock)?.Parent;
+                EnsureScriptPalettes(lecf);
+                if (_scriptPalettes != null)
+                {
+                    foreach (var sp in _scriptPalettes)
+                    {
+                        _paletteBox.Items.Add(new PaletteChoice { Name = "Script palette: room " + sp.Key, Palette = sp.Value });
+                    }
+                }
+            }
+            catch
+            {
+                // best-effort; never block the viewer on the script scan.
+            }
+
             _paletteBox.SelectedIndex = 0;
+        }
+
+        /// <summary>
+        /// Builds (once per loaded game) the list of palettes that scripts load via a literal
+        /// setCurrentPalette(roomN): scan every script for the reference, then map room N to its palette
+        /// through the LOFF room-offset table (room id -> ROOM offset -> that room's APAL). View-only.
+        /// </summary>
+        private void EnsureScriptPalettes(BlockBase lecf)
+        {
+            if (ReferenceEquals(lecf, _scriptPaletteRoot)) return;
+            _scriptPaletteRoot = lecf;
+            _scriptPalettes = new List<KeyValuePair<int, Color[]>>();
+            if (lecf == null) return;
+
+            var roomRefs = new HashSet<int>();
+            CollectScriptPaletteRooms(lecf, roomRefs);
+            if (roomRefs.Count == 0) return;
+
+            var loff = lecf.Childrens.OfType<RoomOffsetTable>().FirstOrDefault();
+            if (loff == null) return;
+
+            // ROOM block offset -> that room's first APAL palette.
+            var offsetToPalette = new Dictionary<long, Color[]>();
+            foreach (DiskBlock disk in lecf.Childrens.OfType<DiskBlock>())
+            {
+                RoomBlock room = disk.GetROOM();
+                if (room == null) continue;
+                Color[] pal = TryGetRoomPalette(room);
+                if (pal != null) offsetToPalette[room.BlockOffSet] = pal;
+            }
+
+            var added = new HashSet<int>();
+            foreach (RoomOffsetTableItem item in loff.Rooms)
+            {
+                if (!roomRefs.Contains(item.Id) || added.Contains(item.Id)) continue;
+                Color[] pal;
+                if (offsetToPalette.TryGetValue(item.OffSet, out pal))
+                {
+                    _scriptPalettes.Add(new KeyValuePair<int, Color[]>(item.Id, pal));
+                    added.Add(item.Id);
+                }
+            }
+        }
+
+        private static void CollectScriptPaletteRooms(BlockBase node, HashSet<int> rooms)
+        {
+            var script = node as ScriptBlock;
+            if (script != null && script.RawContent != null)
+            {
+                foreach (int r in ScriptPaletteScanner.FindCurrentPaletteRooms(script.RawContent, script.CodeOffset))
+                {
+                    rooms.Add(r);
+                }
+            }
+            foreach (BlockBase child in node.Childrens)
+            {
+                CollectScriptPaletteRooms(child, rooms);
+            }
+        }
+
+        private static Color[] TryGetRoomPalette(RoomBlock room)
+        {
+            try { return room.GetPALS().GetWRAP().GetAPALs()[0].Colors; }
+            catch { return null; }
         }
 
         private Color[] SelectedPalette()

--- a/ScummEditor.Gui/Gui/ExportResources.cs
+++ b/ScummEditor.Gui/Gui/ExportResources.cs
@@ -23,6 +23,16 @@ namespace ScummEditor.Gui
             if (string.IsNullOrEmpty(ExportLocation.Text)) return;
             if (!Directory.Exists(ExportLocation.Text)) return;
 
+            // SCUMM v7 (The Dig, Full Throttle) images/costumes are not decoded yet (the room blocks are
+            // kept as generic byte-preserved blocks), so the v5/v6 batch would crash on them. Refuse
+            // cleanly until typed v7 image/costume support lands.
+            if (_scummFile.LoadedGameInfo != null && _scummFile.LoadedGameInfo.ScummVersion == 7)
+            {
+                MessageBox.Show(this, "Graphics export is not yet available for SCUMM v7 (The Dig, Full Throttle).",
+                    "Export game graphics", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
             string location = ExportLocation.Text;
 
             Cursor = Cursors.WaitCursor;

--- a/ScummEditor.Gui/Gui/ExportResources.cs
+++ b/ScummEditor.Gui/Gui/ExportResources.cs
@@ -23,16 +23,6 @@ namespace ScummEditor.Gui
             if (string.IsNullOrEmpty(ExportLocation.Text)) return;
             if (!Directory.Exists(ExportLocation.Text)) return;
 
-            // SCUMM v7 (The Dig, Full Throttle) images/costumes are not decoded yet (the room blocks are
-            // kept as generic byte-preserved blocks), so the v5/v6 batch would crash on them. Refuse
-            // cleanly until typed v7 image/costume support lands.
-            if (_scummFile.LoadedGameInfo != null && _scummFile.LoadedGameInfo.ScummVersion == 7)
-            {
-                MessageBox.Show(this, "Graphics export is not yet available for SCUMM v7 (The Dig, Full Throttle).",
-                    "Export game graphics", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                return;
-            }
-
             string location = ExportLocation.Text;
 
             Cursor = Cursors.WaitCursor;

--- a/ScummEditor.Gui/Gui/ImportResources.cs
+++ b/ScummEditor.Gui/Gui/ImportResources.cs
@@ -39,16 +39,6 @@ namespace ScummEditor.Gui
             if (string.IsNullOrEmpty(ImportLocation.Text)) return;
             if (!Directory.Exists(ImportLocation.Text)) return;
 
-            // SCUMM v7 (The Dig, Full Throttle) images/costumes are not decoded yet (the room blocks are
-            // kept as generic byte-preserved blocks), so the v5/v6 batch would crash on them. Refuse
-            // cleanly until typed v7 image/costume support lands.
-            if (_scummFile.LoadedGameInfo != null && _scummFile.LoadedGameInfo.ScummVersion == 7)
-            {
-                MessageBox.Show(this, "Graphics import is not yet available for SCUMM v7 (The Dig, Full Throttle).",
-                    "Import game graphics", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                return;
-            }
-
             string location = ImportLocation.Text;
 
             Cursor = Cursors.WaitCursor;

--- a/ScummEditor.Gui/Gui/ImportResources.cs
+++ b/ScummEditor.Gui/Gui/ImportResources.cs
@@ -39,6 +39,16 @@ namespace ScummEditor.Gui
             if (string.IsNullOrEmpty(ImportLocation.Text)) return;
             if (!Directory.Exists(ImportLocation.Text)) return;
 
+            // SCUMM v7 (The Dig, Full Throttle) images/costumes are not decoded yet (the room blocks are
+            // kept as generic byte-preserved blocks), so the v5/v6 batch would crash on them. Refuse
+            // cleanly until typed v7 image/costume support lands.
+            if (_scummFile.LoadedGameInfo != null && _scummFile.LoadedGameInfo.ScummVersion == 7)
+            {
+                MessageBox.Show(this, "Graphics import is not yet available for SCUMM v7 (The Dig, Full Throttle).",
+                    "Import game graphics", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
             string location = ImportLocation.Text;
 
             Cursor = Cursors.WaitCursor;

--- a/ScummEditor.Gui/Gui/ImuseBundleControl.cs
+++ b/ScummEditor.Gui/Gui/ImuseBundleControl.cs
@@ -1,0 +1,221 @@
+using System;
+using System.IO;
+using System.Media;
+using System.Windows.Forms;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+
+namespace ScummEditor.Gui
+{
+    /// <summary>
+    /// Viewer for a SCUMM v7 external iMUSE sound bundle (The Dig's DIGMUSIC.BUN / DIGVOICE.BUN): lists
+    /// every named entry and, on demand, decompresses the selected one (ImuseBundleDecoder -> iMUS ->
+    /// ImuseAudioDecoder) to a PCM WAV it can play (System.Media.SoundPlayer) or export (one, or all). The
+    /// bundle is parsed lazily and entries are read on demand, so the 130-260 MB file is not loaded whole.
+    /// </summary>
+    public class ImuseBundleControl : UserControl
+    {
+        private readonly Label _info;
+        private readonly DataGridView _grid;
+        private readonly Button _playButton;
+        private readonly Button _stopButton;
+        private readonly Button _exportButton;
+        private readonly Button _exportAllButton;
+
+        private ImuseBundleFile _bundle;
+        private SoundPlayer _player;
+
+        public ImuseBundleControl()
+        {
+            var bar = new Panel { Dock = DockStyle.Top, Height = 30 };
+            _playButton = new Button { Text = "Play", Width = 70, Left = 3, Top = 3 };
+            _playButton.Click += (s, e) => PlaySelected();
+            _stopButton = new Button { Text = "Stop", Width = 70, Left = 76, Top = 3 };
+            _stopButton.Click += (s, e) => StopPlayback();
+            _exportButton = new Button { Text = "Export WAV", Width = 90, Left = 149, Top = 3 };
+            _exportButton.Click += (s, e) => ExportSelected();
+            _exportAllButton = new Button { Text = "Export all", Width = 90, Left = 242, Top = 3 };
+            _exportAllButton.Click += (s, e) => ExportAll();
+            bar.Controls.Add(_playButton);
+            bar.Controls.Add(_stopButton);
+            bar.Controls.Add(_exportButton);
+            bar.Controls.Add(_exportAllButton);
+
+            _info = new Label { Dock = DockStyle.Top, Height = 22, TextAlign = System.Drawing.ContentAlignment.MiddleLeft };
+
+            _grid = new DataGridView
+            {
+                Dock = DockStyle.Fill,
+                ReadOnly = true,
+                AllowUserToAddRows = false,
+                AllowUserToDeleteRows = false,
+                RowHeadersVisible = false,
+                SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+                MultiSelect = false,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.AllCells
+            };
+            _grid.CellDoubleClick += (s, e) => { if (e.RowIndex >= 0) PlaySelected(); };
+
+            Controls.Add(_grid);
+            Controls.Add(_info);
+            Controls.Add(bar);
+        }
+
+        public void SetData(ImuseBundleFile bundle)
+        {
+            StopPlayback();
+            _bundle = bundle;
+
+            Cursor previous = Cursor.Current;
+            Cursor.Current = Cursors.WaitCursor;
+            try { _bundle.EnsureParsed(); }
+            finally { Cursor.Current = previous; }
+
+            _info.Text = string.Format("{0}  -  {1} entries{2}",
+                Path.GetFileName(_bundle.FilePath), _bundle.Entries.Count,
+                _bundle.IsValid ? string.Empty : "  (could not read the bundle)");
+
+            _grid.Columns.Clear();
+            _grid.Rows.Clear();
+            AddColumn("#");
+            AddColumn("Name");
+            AddColumn("Bytes");
+            for (int i = 0; i < _bundle.Entries.Count; i++)
+            {
+                ImuseBundleEntry e = _bundle.Entries[i];
+                _grid.Rows.Add(i, e.Name, e.Size);
+            }
+        }
+
+        private void AddColumn(string header)
+        {
+            _grid.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                HeaderText = header,
+                AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells,
+                SortMode = DataGridViewColumnSortMode.NotSortable,
+                ReadOnly = true
+            });
+        }
+
+        private int SelectedIndex()
+        {
+            if (_bundle == null || _grid.CurrentRow == null) return -1;
+            int i = _grid.CurrentRow.Index;
+            return (i >= 0 && i < _bundle.Entries.Count) ? i : -1;
+        }
+
+        private byte[] DecodeToWav(int index)
+        {
+            byte[] raw = _bundle.ReadEntryRaw(index);
+            return raw == null ? null : ImuseBundleDecoder.ToWav(raw);
+        }
+
+        private void PlaySelected()
+        {
+            int i = SelectedIndex();
+            if (i < 0) return;
+            try
+            {
+                byte[] wav = DecodeToWav(i);
+                if (wav == null)
+                {
+                    MessageBox.Show(this, "This entry could not be decoded (unsupported codec).",
+                        "Play", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+                StopPlayback();
+                _player = new SoundPlayer(new MemoryStream(wav));
+                _player.Play();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "Could not play the entry: " + ex.Message, "Play",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void StopPlayback()
+        {
+            if (_player != null)
+            {
+                try { _player.Stop(); } catch { /* nothing to stop */ }
+                _player.Dispose();
+                _player = null;
+            }
+        }
+
+        private void ExportSelected()
+        {
+            int i = SelectedIndex();
+            if (i < 0) return;
+
+            using (var dlg = new SaveFileDialog
+            {
+                Filter = "WAV audio (*.wav)|*.wav",
+                FileName = SafeName(_bundle.Entries[i].Name) + ".wav"
+            })
+            {
+                if (dlg.ShowDialog(this) != DialogResult.OK) return;
+                try
+                {
+                    byte[] wav = DecodeToWav(i);
+                    if (wav == null)
+                    {
+                        MessageBox.Show(this, "This entry could not be decoded.", "Export WAV",
+                            MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        return;
+                    }
+                    File.WriteAllBytes(dlg.FileName, wav);
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(this, "Export failed: " + ex.Message, "Export WAV",
+                        MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+        }
+
+        private void ExportAll()
+        {
+            if (_bundle == null || _bundle.Entries.Count == 0) return;
+            using (var dlg = new FolderBrowserDialog { Description = "Folder to save one WAV per bundle entry" })
+            {
+                if (dlg.ShowDialog(this) != DialogResult.OK) return;
+
+                int exported = 0, failed = 0;
+                Cursor previous = Cursor.Current;
+                Cursor.Current = Cursors.WaitCursor;
+                try
+                {
+                    for (int i = 0; i < _bundle.Entries.Count; i++)
+                    {
+                        try
+                        {
+                            byte[] wav = DecodeToWav(i);
+                            if (wav == null) { failed++; continue; }
+                            string path = Path.Combine(dlg.SelectedPath,
+                                string.Format("{0:D4}_{1}.wav", i, SafeName(_bundle.Entries[i].Name)));
+                            File.WriteAllBytes(path, wav);
+                            exported++;
+                        }
+                        catch (Exception) { failed++; }
+                    }
+                }
+                finally { Cursor.Current = previous; }
+
+                MessageBox.Show(this,
+                    string.Format("{0} entries exported to:\n{1}{2}", exported, dlg.SelectedPath,
+                        failed > 0 ? "\n\n" + failed + " entries could not be decoded." : ""),
+                    "Export all", MessageBoxButtons.OK,
+                    failed > 0 ? MessageBoxIcon.Warning : MessageBoxIcon.Information);
+            }
+        }
+
+        private static string SafeName(string name)
+        {
+            foreach (char c in Path.GetInvalidFileNameChars()) name = name.Replace(c, '_');
+            return name;
+        }
+    }
+}

--- a/ScummEditor.Gui/Gui/LocalizedTextControl.cs
+++ b/ScummEditor.Gui/Gui/LocalizedTextControl.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Windows.Forms;
+using ScummEditor.Engine.Encoders;
 using ScummEditor.Engine.Structures;
 
 namespace ScummEditor.Gui
@@ -14,9 +15,11 @@ namespace ScummEditor.Gui
     /// dumps the strings as KEY&lt;TAB&gt;TEXT for editing in an external (code-page-aware) editor; Import
     /// applies an edited dump.
     ///
-    /// Text is byte-faithful (Latin-1): accented bytes are the game's DOS code page, so high bytes render
-    /// raw here - for accent-correct editing use Export/Import with a CP850/CP860-aware editor. (A future
-    /// refinement can apply the game's charmap for in-place display.)
+    /// Text is stored byte-faithfully (Latin-1), but the grid and editor DISPLAY it through the edition's
+    /// DOS code page (set by SetData from the detected language - CP850 for every Western v7 edition,
+    /// including Portuguese), so its accents render correctly and an edit is re-encoded back to those exact
+    /// bytes. The double-byte CJK editions pass code page 0, stay raw, and the box is view-only. The Export
+    /// dump is the raw code-page bytes, for editing in an external CP850-aware editor.
     /// </summary>
     public class LocalizedTextControl : UserControl
     {
@@ -29,6 +32,7 @@ namespace ScummEditor.Gui
         private ILocalizedTextFile _file;
         private LocalizedTextEntry _current;
         private bool _loadingDetail;
+        private int _codePage; // DOS code page for display (0 = show the raw bytes, e.g. CJK)
 
         public LocalizedTextControl()
         {
@@ -78,9 +82,10 @@ namespace ScummEditor.Gui
             HandleCreated += (s, e) => { try { split.SplitterDistance = (int)(split.Height * 0.6); } catch { } };
         }
 
-        public void SetData(ILocalizedTextFile file)
+        public void SetData(ILocalizedTextFile file, int codePage)
         {
             _file = file;
+            _codePage = codePage;
             _current = null;
             _detail.Clear();
 
@@ -96,13 +101,18 @@ namespace ScummEditor.Gui
                 return;
             }
 
-            _info.Text = string.Format("{0}  -  {1} strings{2}", _file.FileName, _file.Entries.Count,
-                _file.IsValid ? string.Empty : "  (no editable strings found)");
+            // Without a single-byte code page (CJK / unknown) the text is shown as raw bytes that cannot be
+            // edited in place without corrupting the double-byte data, so the box is view-only there - the
+            // Export/Import buttons (raw bytes) remain the way to translate those editions.
+            _detail.ReadOnly = _codePage == 0;
+            string viewOnly = _detail.ReadOnly && _file.IsValid ? "  (view only - use Export/Import to edit)" : string.Empty;
+            _info.Text = string.Format("{0}  -  {1} strings{2}{3}", _file.FileName, _file.Entries.Count,
+                _file.IsValid ? string.Empty : "  (no editable strings found)", viewOnly);
             _exportButton.Enabled = _importButton.Enabled = _file.IsValid;
 
             foreach (LocalizedTextEntry e in _file.Entries)
             {
-                _grid.Rows.Add(e.Key, Preview(e.Text));
+                _grid.Rows.Add(e.Key, Preview(Display(e.Text)));
             }
             if (_grid.Rows.Count > 0) _grid.Rows[0].Selected = true;
             LoadDetail();
@@ -132,19 +142,20 @@ namespace ScummEditor.Gui
             if (entry == _current) return;
             _current = entry;
             _loadingDetail = true;
-            _detail.Text = entry != null ? entry.Text : string.Empty;
+            _detail.Text = entry != null ? Display(entry.Text) : string.Empty;
             _loadingDetail = false;
         }
 
         private void CommitDetail()
         {
             if (_loadingDetail || _current == null) return;
-            // Windows Forms forces CRLF in the TextBox; let the file normalise it to its own structure (a
-            // .TRS keeps its native ending - LF for the Mac edition; a LANGUAGE.BND collapses it to a space).
-            _current.Text = _file.NormalizeEditedText(_detail.Text);
+            // Re-encode the edited display text to the game's code page bytes, then let the file normalise
+            // line endings to its own structure (a .TRS keeps its native ending - LF for the Mac edition; a
+            // LANGUAGE.BND collapses it to a space). Windows Forms forces CRLF in the TextBox.
+            _current.Text = _file.NormalizeEditedText(DosCodePageText.FromDisplay(_detail.Text, _codePage));
             if (_grid.CurrentRow != null && _grid.CurrentRow.Index >= 0)
             {
-                _grid.CurrentRow.Cells[1].Value = Preview(_current.Text);
+                _grid.CurrentRow.Cells[1].Value = Preview(_detail.Text);
             }
         }
 
@@ -162,8 +173,8 @@ namespace ScummEditor.Gui
                 {
                     File.WriteAllText(dlg.FileName, _file.ExportToText(), Encoding.Latin1);
                     MessageBox.Show(this, "Strings exported to:\n" + dlg.FileName +
-                        "\n\nEdit the text after each tab. The file is in the game's DOS code page (open it as " +
-                        "CP850, or CP860 for Portuguese). Then Import text.",
+                        "\n\nEdit the text after each tab. The file is in the game's DOS code page - open it as " +
+                        "CP850 (Western European, the code page SCUMM v7 uses). Then Import text.",
                         "Export text", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
                 catch (Exception ex)
@@ -182,7 +193,7 @@ namespace ScummEditor.Gui
                 try
                 {
                     string report = _file.ImportFromText(File.ReadAllText(dlg.FileName, Encoding.Latin1));
-                    SetData(_file); // refresh the grid from the updated entries
+                    SetData(_file, _codePage); // refresh the grid from the updated entries
                     MessageBox.Show(this, report + "\n\nUse \"Save changes\" to write it back to the game file.",
                         "Import text", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
@@ -191,6 +202,12 @@ namespace ScummEditor.Gui
                     MessageBox.Show(this, "Import failed: " + ex.Message, "Import text", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
+        }
+
+        /// <summary>The byte-faithful entry text shown through the edition's DOS code page (raw when code page 0).</summary>
+        private string Display(string text)
+        {
+            return DosCodePageText.ToDisplay(text, _codePage);
         }
 
         private static string Preview(string text)

--- a/ScummEditor.Gui/Gui/LocalizedTextControl.cs
+++ b/ScummEditor.Gui/Gui/LocalizedTextControl.cs
@@ -1,0 +1,203 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Windows.Forms;
+using ScummEditor.Engine.Structures;
+
+namespace ScummEditor.Gui
+{
+    /// <summary>
+    /// Viewer/editor for a SCUMM v7 external localized-text file - The Dig's LANGUAGE.BND (translated
+    /// in-game dialogue) or a .TRS subtitle/UI file. Lists every string (Key + a one-line preview) in a
+    /// grid; the selected string's full text is editable in the box below. Edits update the in-memory
+    /// entries, which the global "Save changes" writes back (byte-identical when nothing changed). Export
+    /// dumps the strings as KEY&lt;TAB&gt;TEXT for editing in an external (code-page-aware) editor; Import
+    /// applies an edited dump.
+    ///
+    /// Text is byte-faithful (Latin-1): accented bytes are the game's DOS code page, so high bytes render
+    /// raw here - for accent-correct editing use Export/Import with a CP850/CP860-aware editor. (A future
+    /// refinement can apply the game's charmap for in-place display.)
+    /// </summary>
+    public class LocalizedTextControl : UserControl
+    {
+        private readonly Label _info;
+        private readonly DataGridView _grid;
+        private readonly TextBox _detail;
+        private readonly Button _exportButton;
+        private readonly Button _importButton;
+
+        private ILocalizedTextFile _file;
+        private LocalizedTextEntry _current;
+        private bool _loadingDetail;
+
+        public LocalizedTextControl()
+        {
+            var bar = new Panel { Dock = DockStyle.Top, Height = 30 };
+            _exportButton = new Button { Text = "Export text", Width = 100, Left = 3, Top = 3 };
+            _exportButton.Click += (s, e) => ExportClick();
+            _importButton = new Button { Text = "Import text", Width = 100, Left = 106, Top = 3 };
+            _importButton.Click += (s, e) => ImportClick();
+            bar.Controls.Add(_exportButton);
+            bar.Controls.Add(_importButton);
+
+            _info = new Label { Dock = DockStyle.Top, Height = 22, TextAlign = System.Drawing.ContentAlignment.MiddleLeft };
+
+            var split = new SplitContainer { Dock = DockStyle.Fill, Orientation = Orientation.Horizontal };
+
+            _grid = new DataGridView
+            {
+                Dock = DockStyle.Fill,
+                ReadOnly = true,
+                AllowUserToAddRows = false,
+                AllowUserToDeleteRows = false,
+                RowHeadersVisible = false,
+                SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+                MultiSelect = false,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.None
+            };
+            _grid.SelectionChanged += (s, e) => LoadDetail();
+            split.Panel1.Controls.Add(_grid);
+
+            _detail = new TextBox
+            {
+                Dock = DockStyle.Fill,
+                Multiline = true,
+                ScrollBars = ScrollBars.Both,
+                WordWrap = false,
+                AcceptsReturn = true,
+                AcceptsTab = false,
+                Font = new System.Drawing.Font(System.Drawing.FontFamily.GenericMonospace, 9f)
+            };
+            _detail.TextChanged += (s, e) => CommitDetail();
+            split.Panel2.Controls.Add(_detail);
+
+            Controls.Add(split);
+            Controls.Add(_info);
+            Controls.Add(bar);
+
+            HandleCreated += (s, e) => { try { split.SplitterDistance = (int)(split.Height * 0.6); } catch { } };
+        }
+
+        public void SetData(ILocalizedTextFile file)
+        {
+            _file = file;
+            _current = null;
+            _detail.Clear();
+
+            _grid.Columns.Clear();
+            _grid.Rows.Clear();
+            AddColumn("Key", 220);
+            AddColumn("Text", 600);
+
+            if (_file == null)
+            {
+                _info.Text = "(no file)";
+                _exportButton.Enabled = _importButton.Enabled = false;
+                return;
+            }
+
+            _info.Text = string.Format("{0}  -  {1} strings{2}", _file.FileName, _file.Entries.Count,
+                _file.IsValid ? string.Empty : "  (no editable strings found)");
+            _exportButton.Enabled = _importButton.Enabled = _file.IsValid;
+
+            foreach (LocalizedTextEntry e in _file.Entries)
+            {
+                _grid.Rows.Add(e.Key, Preview(e.Text));
+            }
+            if (_grid.Rows.Count > 0) _grid.Rows[0].Selected = true;
+            LoadDetail();
+        }
+
+        private void AddColumn(string header, int width)
+        {
+            _grid.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                HeaderText = header,
+                Width = width,
+                SortMode = DataGridViewColumnSortMode.NotSortable,
+                ReadOnly = true
+            });
+        }
+
+        private LocalizedTextEntry SelectedEntry()
+        {
+            if (_file == null || _grid.CurrentRow == null) return null;
+            int i = _grid.CurrentRow.Index;
+            return (i >= 0 && i < _file.Entries.Count) ? _file.Entries[i] : null;
+        }
+
+        private void LoadDetail()
+        {
+            LocalizedTextEntry entry = SelectedEntry();
+            if (entry == _current) return;
+            _current = entry;
+            _loadingDetail = true;
+            _detail.Text = entry != null ? entry.Text : string.Empty;
+            _loadingDetail = false;
+        }
+
+        private void CommitDetail()
+        {
+            if (_loadingDetail || _current == null) return;
+            // The TextBox uses \r\n line endings, matching the DOS .TRS / .BND files.
+            _current.Text = _detail.Text;
+            if (_grid.CurrentRow != null && _grid.CurrentRow.Index >= 0)
+            {
+                _grid.CurrentRow.Cells[1].Value = Preview(_current.Text);
+            }
+        }
+
+        private void ExportClick()
+        {
+            if (_file == null) return;
+            using (var dlg = new SaveFileDialog
+            {
+                Filter = "Text (*.txt)|*.txt|All files|*.*",
+                FileName = Path.GetFileNameWithoutExtension(_file.FileName) + ".txt"
+            })
+            {
+                if (dlg.ShowDialog(this) != DialogResult.OK) return;
+                try
+                {
+                    File.WriteAllText(dlg.FileName, _file.ExportToText(), Encoding.Latin1);
+                    MessageBox.Show(this, "Strings exported to:\n" + dlg.FileName +
+                        "\n\nEdit the text after each tab. The file is in the game's DOS code page (open it as " +
+                        "CP850, or CP860 for Portuguese). Then Import text.",
+                        "Export text", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(this, "Export failed: " + ex.Message, "Export text", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+        }
+
+        private void ImportClick()
+        {
+            if (_file == null) return;
+            using (var dlg = new OpenFileDialog { Filter = "Text (*.txt)|*.txt|All files|*.*" })
+            {
+                if (dlg.ShowDialog(this) != DialogResult.OK) return;
+                try
+                {
+                    string report = _file.ImportFromText(File.ReadAllText(dlg.FileName, Encoding.Latin1));
+                    SetData(_file); // refresh the grid from the updated entries
+                    MessageBox.Show(this, report + "\n\nUse \"Save changes\" to write it back to the game file.",
+                        "Import text", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(this, "Import failed: " + ex.Message, "Import text", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+        }
+
+        private static string Preview(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return string.Empty;
+            int nl = text.IndexOfAny(new[] { '\r', '\n' });
+            string line = nl >= 0 ? text.Substring(0, nl) : text;
+            return line.Length > 120 ? line.Substring(0, 120) + " ..." : line + (nl >= 0 ? " ..." : string.Empty);
+        }
+    }
+}

--- a/ScummEditor.Gui/Gui/LocalizedTextControl.cs
+++ b/ScummEditor.Gui/Gui/LocalizedTextControl.cs
@@ -139,8 +139,9 @@ namespace ScummEditor.Gui
         private void CommitDetail()
         {
             if (_loadingDetail || _current == null) return;
-            // The TextBox uses \r\n line endings, matching the DOS .TRS / .BND files.
-            _current.Text = _detail.Text;
+            // Windows Forms forces CRLF in the TextBox; let the file normalise it to its own structure (a
+            // .TRS keeps its native ending - LF for the Mac edition; a LANGUAGE.BND collapses it to a space).
+            _current.Text = _file.NormalizeEditedText(_detail.Text);
             if (_grid.CurrentRow != null && _grid.CurrentRow.Index >= 0)
             {
                 _grid.CurrentRow.Cells[1].Value = Preview(_current.Text);

--- a/ScummEditor.Gui/Gui/NotImplementedDataBlockControl.cs
+++ b/ScummEditor.Gui/Gui/NotImplementedDataBlockControl.cs
@@ -14,7 +14,10 @@ namespace ScummEditor.Gui
 {
     public partial class NotImplementedDataBlockControl : BlockBaseControl
     {
-        private NotImplementedDataBlock _notImplementedDataBlock;
+        // Any byte-preserved block: NotImplementedDataBlock (v4-v6) and the v7 RawContainerBlock /
+        // RawDataBlock / RawIndexBlock. Contents is null for a RawContainerBlock that parsed children
+        // (a container) - it then has no raw bytes of its own, so an empty hex view is shown.
+        private IRawContentBlock _rawBlock;
 
         public NotImplementedDataBlockControl()
         {
@@ -25,7 +28,7 @@ namespace ScummEditor.Gui
         public override void SetAndRefreshData(BlockBase blockBase)
         {
             base.SetAndRefreshData(blockBase);
-            _notImplementedDataBlock = (NotImplementedDataBlock)blockBase;
+            _rawBlock = (IRawContentBlock)blockBase;
 
             if (AutomaticLoadData.Checked)
             {
@@ -40,7 +43,7 @@ namespace ScummEditor.Gui
 
         private void LoadBinaryData()
         {
-            var x = new DynamicByteProvider(_notImplementedDataBlock.Contents);
+            var x = new DynamicByteProvider(_rawBlock.Contents ?? new byte[0]);
             hexBox1.ByteProvider = x;
         }
 

--- a/ScummEditor.Gui/Gui/NutFontControl.cs
+++ b/ScummEditor.Gui/Gui/NutFontControl.cs
@@ -14,10 +14,12 @@ namespace ScummEditor.Gui
     /// Viewer/editor for a SCUMM v7 external .NUT SMUSH font (The Dig, Full Throttle): the glyphs listed
     /// on the left, the decoded glyph on the right. Glyphs are decoded by NutImageDecoder (codec 1/3 BOMP,
     /// 21/44 skip-copy). A NUT carries no palette of its own (its pixels are runtime palette indices), so a
-    /// palette combobox shows the glyph either on a grayscale ramp or against one of the game's room
-    /// palettes - this is only a preview; editing is index-based. "Export/Import PNG" edits the selected
-    /// glyph; "Export/Import font" round-trips the whole font as one atlas. A NutFont is a standalone file,
-    /// not a BlockBase, so this is a plain UserControl driven by SetData (like CharsetV3Control).
+    /// palette combobox controls how the glyph is previewed: a high-contrast "Glyph shape" silhouette (the
+    /// default - font ink is often a near-white palette index that would be invisible on a light background),
+    /// a literal grayscale-by-index ramp, or one of the game's room palettes. This is only a preview;
+    /// editing is index-based (the exported PNG carries the raw indices). "Export/Import PNG" edits the
+    /// selected glyph; "Export/Import font" round-trips the whole font as one atlas. A NutFont is a
+    /// standalone file, not a BlockBase, so this is a plain UserControl driven by SetData.
     /// </summary>
     public class NutFontControl : UserControl
     {
@@ -33,13 +35,18 @@ namespace ScummEditor.Gui
         private readonly Button _importFontButton;
 
         private NutFontResource _resource;
+        private List<Color[]> _gamePalettes;
         private int _currentGlyph = -1;
         private bool _splitterApplied;
 
+        /// <summary>A combobox palette choice: the colours used to preview a glyph on screen, and the
+        /// colours written as the PLTE of an exported PNG (kept index-distinguishable so the file is
+        /// editable even when the preview is a flat silhouette).</summary>
         private class PaletteChoice
         {
             public string Name;
-            public Color[] Palette;
+            public Color[] Preview;
+            public Color[] Export;
             public override string ToString() { return Name; }
         }
 
@@ -93,10 +100,11 @@ namespace ScummEditor.Gui
         }
 
         /// <summary>Shows a NUT font. <paramref name="gamePalettes"/> are optional game room palettes offered
-        /// in the combobox (beside grayscale) so a glyph can be previewed in real colours.</summary>
+        /// in the combobox (beside the shape/grayscale views) so a glyph can be previewed in real colours.</summary>
         public void SetData(NutFontResource resource, List<Color[]> gamePalettes)
         {
             _resource = resource;
+            _gamePalettes = gamePalettes;
             _tree.Nodes.Clear();
             ClearImage();
             _currentGlyph = -1;
@@ -135,7 +143,12 @@ namespace ScummEditor.Gui
         private void BuildPaletteChoices(List<Color[]> gamePalettes)
         {
             _paletteBox.Items.Clear();
-            _paletteBox.Items.Add(new PaletteChoice { Name = "Grayscale (by index)", Palette = null });
+            Color[] gray = GrayscalePalette();
+
+            // Default: a flat dark silhouette - always clearly visible whatever palette index the font's ink
+            // uses (font ink is commonly a near-white index that vanishes on the light background in grayscale).
+            _paletteBox.Items.Add(new PaletteChoice { Name = "Glyph shape", Preview = SilhouettePalette(), Export = gray });
+            _paletteBox.Items.Add(new PaletteChoice { Name = "Grayscale (by index)", Preview = gray, Export = gray });
             if (gamePalettes != null)
             {
                 for (int i = 0; i < gamePalettes.Count; i++)
@@ -143,17 +156,17 @@ namespace ScummEditor.Gui
                     _paletteBox.Items.Add(new PaletteChoice
                     {
                         Name = gamePalettes.Count > 1 ? "Game palette " + i : "Game palette",
-                        Palette = gamePalettes[i],
+                        Preview = gamePalettes[i],
+                        Export = gamePalettes[i],
                     });
                 }
             }
             _paletteBox.SelectedIndex = 0;
         }
 
-        private Color[] SelectedPalette()
+        private PaletteChoice SelectedChoice()
         {
-            var choice = _paletteBox.SelectedItem as PaletteChoice;
-            return choice != null ? choice.Palette : null;
+            return _paletteBox.SelectedItem as PaletteChoice;
         }
 
         private void TreeAfterSelect(object sender, TreeViewEventArgs e)
@@ -183,16 +196,21 @@ namespace ScummEditor.Gui
 
             try
             {
-                Bitmap glyph = NutImageDecoder.DecodeGlyph(font, _currentGlyph, SelectedPalette());
-                if (glyph == null)
+                byte[,] indices = NutImageDecoder.DecodeGlyphIndices(font, _currentGlyph);
+                if (indices == null)
                 {
                     _info.Text = baseInfo + " - not decodable (unsupported codec)";
                     return;
                 }
-                _picture.Image = glyph;
+
+                int transparency = NutImageDecoder.TransparencyIndex(g.Codec);
+                PaletteChoice choice = SelectedChoice();
+                Color[] preview = choice != null ? choice.Preview : GrayscalePalette();
+                _picture.Image = IndexedImageHelper.FromIndexMatrix(indices, preview, transparency);
+
                 _exportGlyphButton.Enabled = true;
                 _importGlyphButton.Enabled = NutImageEncoder.CanEncode(g.Codec);
-                _info.Text = baseInfo;
+                _info.Text = baseInfo + (HasInk(indices, transparency) ? string.Empty : "  (blank - no ink, e.g. a space or placeholder)");
             }
             catch (Exception ex)
             {
@@ -212,7 +230,7 @@ namespace ScummEditor.Gui
                 if (dialog.ShowDialog() != DialogResult.OK) return;
                 try
                 {
-                    NutFontPngCodec.ExportGlyphPng(_resource.Font, _currentGlyph, dialog.FileName, SelectedPalette());
+                    NutFontPngCodec.ExportGlyphPng(_resource.Font, _currentGlyph, dialog.FileName, ExportPalette());
                 }
                 catch (Exception ex)
                 {
@@ -237,7 +255,7 @@ namespace ScummEditor.Gui
                     MessageBox.Show(ex.Message, "Import failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     return;
                 }
-                SetData(_resource, CurrentPalettes());
+                SetData(_resource, _gamePalettes);
                 if (reselect < _tree.Nodes.Count) _tree.SelectedNode = _tree.Nodes[reselect];
                 MessageBox.Show("Glyph imported. Use \"Save changes\" to write it back to the game files.",
                     "Import", MessageBoxButtons.OK, MessageBoxIcon.Information);
@@ -252,7 +270,7 @@ namespace ScummEditor.Gui
                 if (dialog.ShowDialog() != DialogResult.OK) return;
                 try
                 {
-                    NutFontPngCodec.ExportPng(_resource.Font, dialog.FileName, SelectedPalette());
+                    NutFontPngCodec.ExportPng(_resource.Font, dialog.FileName, ExportPalette());
                     MessageBox.Show("Font exported as one atlas (all glyphs in a grid). Edit it as an INDEXED PNG, " +
                         "then Import font.", "Export font", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
@@ -279,23 +297,39 @@ namespace ScummEditor.Gui
                     return;
                 }
                 int reselect = _currentGlyph;
-                SetData(_resource, CurrentPalettes());
+                SetData(_resource, _gamePalettes);
                 if (reselect >= 0 && reselect < _tree.Nodes.Count) _tree.SelectedNode = _tree.Nodes[reselect];
                 MessageBox.Show("Font imported. Use \"Save changes\" to write it back to the game files.",
                     "Import font", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
         }
 
-        /// <summary>The current palette list (rebuilt from the combobox) so a refresh keeps the same choices.</summary>
-        private List<Color[]> CurrentPalettes()
+        private Color[] ExportPalette()
         {
-            var list = new List<Color[]>();
-            foreach (var obj in _paletteBox.Items)
-            {
-                var choice = obj as PaletteChoice;
-                if (choice != null && choice.Palette != null) list.Add(choice.Palette);
-            }
-            return list;
+            PaletteChoice choice = SelectedChoice();
+            return choice != null ? choice.Export : GrayscalePalette();
+        }
+
+        private static bool HasInk(byte[,] indices, int transparency)
+        {
+            for (int x = 0; x < indices.GetLength(0); x++)
+                for (int y = 0; y < indices.GetLength(1); y++)
+                    if (indices[x, y] != transparency) return true;
+            return false;
+        }
+
+        private static Color[] GrayscalePalette()
+        {
+            var palette = new Color[256];
+            for (int i = 0; i < 256; i++) palette[i] = Color.FromArgb(i, i, i);
+            return palette;
+        }
+
+        private static Color[] SilhouettePalette()
+        {
+            var palette = new Color[256];
+            for (int i = 0; i < 256; i++) palette[i] = Color.FromArgb(32, 32, 32); // ink is drawn dark; the transparent index is made transparent
+            return palette;
         }
 
         private string FontName()

--- a/ScummEditor.Gui/Gui/NutFontControl.cs
+++ b/ScummEditor.Gui/Gui/NutFontControl.cs
@@ -270,9 +270,12 @@ namespace ScummEditor.Gui
                 if (dialog.ShowDialog() != DialogResult.OK) return;
                 try
                 {
-                    NutFontPngCodec.ExportPng(_resource.Font, dialog.FileName, ExportPalette());
-                    MessageBox.Show("Font exported as one atlas (all glyphs in a grid). Edit it as an INDEXED PNG, " +
-                        "then Import font.", "Export font", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    string guidePath = Path.Combine(Path.GetDirectoryName(dialog.FileName) ?? string.Empty,
+                        Path.GetFileNameWithoutExtension(dialog.FileName) + ".guide.png");
+                    NutFontPngCodec.ExportPng(_resource.Font, dialog.FileName, guidePath, ExportPalette());
+                    MessageBox.Show("Font exported as one atlas (all glyphs in a grid), plus a .guide.png with the " +
+                        "cell grid and glyph indices. Edit the atlas as an INDEXED PNG, then Import font.",
+                        "Export font", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
                 catch (Exception ex)
                 {

--- a/ScummEditor.Gui/Gui/NutFontControl.cs
+++ b/ScummEditor.Gui/Gui/NutFontControl.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Exceptions;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+
+namespace ScummEditor.Gui
+{
+    /// <summary>
+    /// Viewer/editor for a SCUMM v7 external .NUT SMUSH font (The Dig, Full Throttle): the glyphs listed
+    /// on the left, the decoded glyph on the right. Glyphs are decoded by NutImageDecoder (codec 1/3 BOMP,
+    /// 21/44 skip-copy). A NUT carries no palette of its own (its pixels are runtime palette indices), so a
+    /// palette combobox shows the glyph either on a grayscale ramp or against one of the game's room
+    /// palettes - this is only a preview; editing is index-based. "Export/Import PNG" edits the selected
+    /// glyph; "Export/Import font" round-trips the whole font as one atlas. A NutFont is a standalone file,
+    /// not a BlockBase, so this is a plain UserControl driven by SetData (like CharsetV3Control).
+    /// </summary>
+    public class NutFontControl : UserControl
+    {
+        private readonly SplitContainer _split;
+        private readonly TreeView _tree;
+        private readonly Panel _scroll;
+        private readonly PictureBox _picture;
+        private readonly Label _info;
+        private readonly ComboBox _paletteBox;
+        private readonly Button _exportGlyphButton;
+        private readonly Button _importGlyphButton;
+        private readonly Button _exportFontButton;
+        private readonly Button _importFontButton;
+
+        private NutFontResource _resource;
+        private int _currentGlyph = -1;
+        private bool _splitterApplied;
+
+        private class PaletteChoice
+        {
+            public string Name;
+            public Color[] Palette;
+            public override string ToString() { return Name; }
+        }
+
+        public NutFontControl()
+        {
+            _split = new SplitContainer { Dock = DockStyle.Fill, Orientation = Orientation.Vertical };
+
+            _tree = new TreeView { Dock = DockStyle.Fill, HideSelection = false };
+            _tree.AfterSelect += TreeAfterSelect;
+            _split.Panel1.Controls.Add(_tree);
+
+            _scroll = new Panel { Dock = DockStyle.Fill, AutoScroll = true, BackColor = Color.LightGray };
+            _picture = new PictureBox { SizeMode = PictureBoxSizeMode.AutoSize };
+            _scroll.Controls.Add(_picture);
+
+            var topBar = new Panel { Dock = DockStyle.Top, Height = 60 };
+            _exportGlyphButton = new Button { Text = "Export PNG", Width = 90, Left = 3, Top = 3, Enabled = false };
+            _exportGlyphButton.Click += ExportGlyphClick;
+            _importGlyphButton = new Button { Text = "Import PNG", Width = 90, Left = 99, Top = 3, Enabled = false };
+            _importGlyphButton.Click += ImportGlyphClick;
+            _exportFontButton = new Button { Text = "Export font", Width = 90, Left = 201, Top = 3, Enabled = false };
+            _exportFontButton.Click += ExportFontClick;
+            _importFontButton = new Button { Text = "Import font", Width = 90, Left = 297, Top = 3, Enabled = false };
+            _importFontButton.Click += ImportFontClick;
+            var paletteLabel = new Label { Text = "Palette:", AutoSize = true, Left = 3, Top = 38 };
+            _paletteBox = new ComboBox { Left = 54, Top = 34, Width = 237, DropDownStyle = ComboBoxStyle.DropDownList };
+            _paletteBox.SelectedIndexChanged += (s, e) => RenderCurrent();
+            _info = new Label { Left = 297, Top = 38, AutoSize = true, Text = string.Empty };
+            topBar.Controls.Add(_exportGlyphButton);
+            topBar.Controls.Add(_importGlyphButton);
+            topBar.Controls.Add(_exportFontButton);
+            topBar.Controls.Add(_importFontButton);
+            topBar.Controls.Add(paletteLabel);
+            topBar.Controls.Add(_paletteBox);
+            topBar.Controls.Add(_info);
+
+            _split.Panel2.Controls.Add(_scroll);
+            _split.Panel2.Controls.Add(topBar);
+
+            Controls.Add(_split);
+        }
+
+        protected override void OnSizeChanged(EventArgs e)
+        {
+            base.OnSizeChanged(e);
+            if (_split != null && !_splitterApplied && _split.Width > 200)
+            {
+                _split.SplitterDistance = 150;
+                _splitterApplied = true;
+            }
+        }
+
+        /// <summary>Shows a NUT font. <paramref name="gamePalettes"/> are optional game room palettes offered
+        /// in the combobox (beside grayscale) so a glyph can be previewed in real colours.</summary>
+        public void SetData(NutFontResource resource, List<Color[]> gamePalettes)
+        {
+            _resource = resource;
+            _tree.Nodes.Clear();
+            ClearImage();
+            _currentGlyph = -1;
+            _exportGlyphButton.Enabled = false;
+            _importGlyphButton.Enabled = false;
+            _exportFontButton.Enabled = false;
+            _importFontButton.Enabled = false;
+            _info.Text = string.Empty;
+            if (_resource == null || _resource.Font == null) return;
+
+            NutFont font = _resource.Font;
+            for (int i = 0; i < font.Glyphs.Count; i++)
+            {
+                NutGlyph g = font.Glyphs[i];
+                string text = g.HasPixels
+                    ? string.Format("Glyph {0} ({1}x{2})", i, g.Width, g.Height)
+                    : string.Format("Glyph {0} - empty", i);
+                var node = _tree.Nodes.Add(text);
+                node.Tag = i;
+            }
+
+            BuildPaletteChoices(gamePalettes);
+            _exportFontButton.Enabled = font.IsValid;
+            _importFontButton.Enabled = font.IsValid;
+
+            if (_tree.Nodes.Count > 0)
+            {
+                _tree.SelectedNode = _tree.Nodes[0];
+            }
+            else
+            {
+                _info.Text = font.IsValid ? "(no glyphs)" : "(not a parseable NUT font)";
+            }
+        }
+
+        private void BuildPaletteChoices(List<Color[]> gamePalettes)
+        {
+            _paletteBox.Items.Clear();
+            _paletteBox.Items.Add(new PaletteChoice { Name = "Grayscale (by index)", Palette = null });
+            if (gamePalettes != null)
+            {
+                for (int i = 0; i < gamePalettes.Count; i++)
+                {
+                    _paletteBox.Items.Add(new PaletteChoice
+                    {
+                        Name = gamePalettes.Count > 1 ? "Game palette " + i : "Game palette",
+                        Palette = gamePalettes[i],
+                    });
+                }
+            }
+            _paletteBox.SelectedIndex = 0;
+        }
+
+        private Color[] SelectedPalette()
+        {
+            var choice = _paletteBox.SelectedItem as PaletteChoice;
+            return choice != null ? choice.Palette : null;
+        }
+
+        private void TreeAfterSelect(object sender, TreeViewEventArgs e)
+        {
+            _currentGlyph = (e.Node != null && e.Node.Tag is int) ? (int)e.Node.Tag : -1;
+            RenderCurrent();
+        }
+
+        private void RenderCurrent()
+        {
+            ClearImage();
+            _exportGlyphButton.Enabled = false;
+            _importGlyphButton.Enabled = false;
+            if (_resource == null || _resource.Font == null || _currentGlyph < 0)
+            {
+                return;
+            }
+
+            NutFont font = _resource.Font;
+            NutGlyph g = font.Glyphs[_currentGlyph];
+            string baseInfo = string.Format("codec {0}  |  glyph {1}: {2}x{3}", g.Codec, _currentGlyph, g.Width, g.Height);
+            if (!g.HasPixels)
+            {
+                _info.Text = baseInfo + " - empty (no frame object)";
+                return;
+            }
+
+            try
+            {
+                Bitmap glyph = NutImageDecoder.DecodeGlyph(font, _currentGlyph, SelectedPalette());
+                if (glyph == null)
+                {
+                    _info.Text = baseInfo + " - not decodable (unsupported codec)";
+                    return;
+                }
+                _picture.Image = glyph;
+                _exportGlyphButton.Enabled = true;
+                _importGlyphButton.Enabled = NutImageEncoder.CanEncode(g.Codec);
+                _info.Text = baseInfo;
+            }
+            catch (Exception ex)
+            {
+                _info.Text = baseInfo + " - decode failed: " + ex.Message;
+            }
+        }
+
+        private void ExportGlyphClick(object sender, EventArgs e)
+        {
+            if (_resource == null || _currentGlyph < 0) return;
+            using (var dialog = new SaveFileDialog
+            {
+                Filter = "PNG Files|*.png",
+                FileName = string.Format("{0} glyph{1}.png", FontName(), _currentGlyph)
+            })
+            {
+                if (dialog.ShowDialog() != DialogResult.OK) return;
+                try
+                {
+                    NutFontPngCodec.ExportGlyphPng(_resource.Font, _currentGlyph, dialog.FileName, SelectedPalette());
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(ex.Message, "Export failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+            }
+        }
+
+        private void ImportGlyphClick(object sender, EventArgs e)
+        {
+            if (_resource == null || _currentGlyph < 0) return;
+            using (var dialog = new OpenFileDialog { Filter = "PNG Files|*.png" })
+            {
+                if (dialog.ShowDialog() != DialogResult.OK) return;
+                int reselect = _currentGlyph;
+                try
+                {
+                    NutFontPngCodec.ImportGlyphPng(_resource.Font, _currentGlyph, dialog.FileName);
+                }
+                catch (ImageEncodeException ex)
+                {
+                    MessageBox.Show(ex.Message, "Import failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+                SetData(_resource, CurrentPalettes());
+                if (reselect < _tree.Nodes.Count) _tree.SelectedNode = _tree.Nodes[reselect];
+                MessageBox.Show("Glyph imported. Use \"Save changes\" to write it back to the game files.",
+                    "Import", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+        }
+
+        private void ExportFontClick(object sender, EventArgs e)
+        {
+            if (_resource == null) return;
+            using (var dialog = new SaveFileDialog { Filter = "PNG Files|*.png", FileName = FontName() + ".png" })
+            {
+                if (dialog.ShowDialog() != DialogResult.OK) return;
+                try
+                {
+                    NutFontPngCodec.ExportPng(_resource.Font, dialog.FileName, SelectedPalette());
+                    MessageBox.Show("Font exported as one atlas (all glyphs in a grid). Edit it as an INDEXED PNG, " +
+                        "then Import font.", "Export font", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(ex.Message, "Export failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+            }
+        }
+
+        private void ImportFontClick(object sender, EventArgs e)
+        {
+            if (_resource == null) return;
+            using (var dialog = new OpenFileDialog { Filter = "PNG Files|*.png" })
+            {
+                if (dialog.ShowDialog() != DialogResult.OK) return;
+                try
+                {
+                    NutFontPngCodec.ImportPng(_resource.Font, dialog.FileName);
+                }
+                catch (ImageEncodeException ex)
+                {
+                    MessageBox.Show(ex.Message, "Import failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+                int reselect = _currentGlyph;
+                SetData(_resource, CurrentPalettes());
+                if (reselect >= 0 && reselect < _tree.Nodes.Count) _tree.SelectedNode = _tree.Nodes[reselect];
+                MessageBox.Show("Font imported. Use \"Save changes\" to write it back to the game files.",
+                    "Import font", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+        }
+
+        /// <summary>The current palette list (rebuilt from the combobox) so a refresh keeps the same choices.</summary>
+        private List<Color[]> CurrentPalettes()
+        {
+            var list = new List<Color[]>();
+            foreach (var obj in _paletteBox.Items)
+            {
+                var choice = obj as PaletteChoice;
+                if (choice != null && choice.Palette != null) list.Add(choice.Palette);
+            }
+            return list;
+        }
+
+        private string FontName()
+        {
+            return _resource != null && _resource.FilePath != null
+                ? Path.GetFileNameWithoutExtension(_resource.FilePath)
+                : "font";
+        }
+
+        private void ClearImage()
+        {
+            if (_picture.Image != null)
+            {
+                _picture.Image.Dispose();
+                _picture.Image = null;
+            }
+        }
+    }
+}

--- a/ScummEditor.Gui/Gui/NutFontControl.cs
+++ b/ScummEditor.Gui/Gui/NutFontControl.cs
@@ -119,9 +119,11 @@ namespace ScummEditor.Gui
             for (int i = 0; i < font.Glyphs.Count; i++)
             {
                 NutGlyph g = font.Glyphs[i];
+                // The glyph index is the character code the scripts reference, so label it in hex (0xNN),
+                // matching the charset viewers and the guide image.
                 string text = g.HasPixels
-                    ? string.Format("Glyph {0} ({1}x{2})", i, g.Width, g.Height)
-                    : string.Format("Glyph {0} - empty", i);
+                    ? string.Format("Glyph 0x{0:X2} ({1}x{2})", i, g.Width, g.Height)
+                    : string.Format("Glyph 0x{0:X2} - empty", i);
                 var node = _tree.Nodes.Add(text);
                 node.Tag = i;
             }
@@ -187,7 +189,7 @@ namespace ScummEditor.Gui
 
             NutFont font = _resource.Font;
             NutGlyph g = font.Glyphs[_currentGlyph];
-            string baseInfo = string.Format("codec {0}  |  glyph {1}: {2}x{3}", g.Codec, _currentGlyph, g.Width, g.Height);
+            string baseInfo = string.Format("codec {0}  |  glyph 0x{1:X2}: {2}x{3}", g.Codec, _currentGlyph, g.Width, g.Height);
             if (!g.HasPixels)
             {
                 _info.Text = baseInfo + " - empty (no frame object)";
@@ -224,7 +226,7 @@ namespace ScummEditor.Gui
             using (var dialog = new SaveFileDialog
             {
                 Filter = "PNG Files|*.png",
-                FileName = string.Format("{0} glyph{1}.png", FontName(), _currentGlyph)
+                FileName = string.Format("{0} glyph0x{1:X2}.png", FontName(), _currentGlyph)
             })
             {
                 if (dialog.ShowDialog() != DialogResult.OK) return;

--- a/ScummEditor.Gui/Gui/SoundBlockV7Control.cs
+++ b/ScummEditor.Gui/Gui/SoundBlockV7Control.cs
@@ -1,0 +1,199 @@
+using System;
+using System.IO;
+using System.Media;
+using System.Windows.Forms;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+
+namespace ScummEditor.Gui
+{
+    /// <summary>
+    /// Viewer/player for a SCUMM v7 SOUN block (The Dig, Full Throttle). The Dig stores an iMUS digital
+    /// resource (decoded by ImuseAudioDecoder: MAP/FRMT/DATA, 8/12-bit PCM -> WAV); Full Throttle stores a
+    /// Creative Voice File (decoded by the existing SoundConverter.VocToWav). The decoded PCM is played via
+    /// System.Media.SoundPlayer and can be exported as WAV; the raw resource can also be exported verbatim.
+    /// Sound import stays deferred, matching v4-v6.
+    /// </summary>
+    public class SoundBlockV7Control : BlockBaseControl
+    {
+        private readonly Label _info;
+        private readonly Button _playButton;
+        private readonly Button _stopButton;
+        private readonly Button _exportWavButton;
+        private readonly Button _exportRawButton;
+
+        private byte[] _wav;          // decoded PCM WAV, or null when the codec is not decodable
+        private byte[] _raw;          // the raw resource bytes (iMUS / VOC), for verbatim export
+        private string _kind = string.Empty;
+        private string _rawExtension = ".bin";
+        private SoundPlayer _player;
+
+        public SoundBlockV7Control()
+        {
+            var bar = new Panel { Dock = DockStyle.Top, Height = 64 };
+            _playButton = new Button { Text = "Play", Width = 80, Left = 3, Top = 3, Enabled = false };
+            _playButton.Click += (s, e) => PlayClick();
+            _stopButton = new Button { Text = "Stop", Width = 80, Left = 87, Top = 3, Enabled = false };
+            _stopButton.Click += (s, e) => StopPlayback();
+            _exportWavButton = new Button { Text = "Export WAV", Width = 100, Left = 171, Top = 3, Enabled = false };
+            _exportWavButton.Click += (s, e) => ExportWavClick();
+            _exportRawButton = new Button { Text = "Export raw", Width = 100, Left = 275, Top = 3, Enabled = false };
+            _exportRawButton.Click += (s, e) => ExportRawClick();
+            _info = new Label { Left = 3, Top = 36, AutoSize = true, Text = string.Empty };
+
+            bar.Controls.Add(_playButton);
+            bar.Controls.Add(_stopButton);
+            bar.Controls.Add(_exportWavButton);
+            bar.Controls.Add(_exportRawButton);
+            bar.Controls.Add(_info);
+            Controls.Add(bar);
+            bar.BringToFront();
+        }
+
+        public override void SetAndRefreshData(BlockBase blockBase)
+        {
+            base.SetAndRefreshData(blockBase);
+            StopPlayback();
+
+            _wav = null;
+            _raw = null;
+            _kind = string.Empty;
+            _rawExtension = ".bin";
+            _playButton.Enabled = false;
+            _stopButton.Enabled = false;
+            _exportWavButton.Enabled = false;
+            _exportRawButton.Enabled = false;
+            _info.Text = string.Empty;
+            if (blockBase == null) return;
+
+            byte[] body = Serialize(blockBase);
+
+            int voc = IndexOf(body, "Creative Voice File");
+            if (voc >= 0)
+            {
+                _kind = "Creative Voice File (VOC)";
+                _rawExtension = ".voc";
+                _raw = Slice(body, voc);
+                _wav = SafeVocToWav(_raw);
+            }
+            else if (ImuseAudioDecoder.IsImus(body))
+            {
+                int imus = IndexOf(body, "iMUS");
+                _raw = imus >= 0 ? Slice(body, imus) : body;
+                _rawExtension = ".imus";
+                ImuseAudioDecoder.ImuseInfo info = ImuseAudioDecoder.GetInfo(body);
+                _kind = info != null
+                    ? string.Format("iMUSE PCM ({0}-bit, {1} Hz, {2} ch)", info.WordSize, info.SampleRate, info.Channels)
+                    : "iMUSE";
+                _wav = ImuseAudioDecoder.ToWav(body);
+            }
+            else
+            {
+                _kind = "unrecognised sound";
+                _raw = body;
+            }
+
+            _exportRawButton.Enabled = _raw != null && _raw.Length > 0;
+            if (_wav != null)
+            {
+                _playButton.Enabled = true;
+                _exportWavButton.Enabled = true;
+                _info.Text = _kind + "  -  " + _raw.Length + " bytes";
+            }
+            else
+            {
+                _info.Text = _kind + "  -  " + (_raw != null ? _raw.Length : 0) + " bytes (not decodable to WAV; export raw)";
+            }
+        }
+
+        private void PlayClick()
+        {
+            if (_wav == null) return;
+            try
+            {
+                StopPlayback();
+                _player = new SoundPlayer(new MemoryStream(_wav));
+                _player.Play();
+                _stopButton.Enabled = true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Play failed", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+        }
+
+        private void StopPlayback()
+        {
+            if (_player != null)
+            {
+                try { _player.Stop(); } catch { /* nothing to stop */ }
+                _player.Dispose();
+                _player = null;
+            }
+            _stopButton.Enabled = false;
+        }
+
+        private void ExportWavClick()
+        {
+            if (_wav == null) return;
+            using (var dialog = new SaveFileDialog { Filter = "WAV audio|*.wav", FileName = "sound.wav" })
+            {
+                if (dialog.ShowDialog() != DialogResult.OK) return;
+                try { File.WriteAllBytes(dialog.FileName, _wav); }
+                catch (Exception ex) { MessageBox.Show(ex.Message, "Export failed", MessageBoxButtons.OK, MessageBoxIcon.Warning); }
+            }
+        }
+
+        private void ExportRawClick()
+        {
+            if (_raw == null) return;
+            using (var dialog = new SaveFileDialog
+            {
+                Filter = "Sound resource|*" + _rawExtension + "|All files|*.*",
+                FileName = "sound" + _rawExtension
+            })
+            {
+                if (dialog.ShowDialog() != DialogResult.OK) return;
+                try { File.WriteAllBytes(dialog.FileName, _raw); }
+                catch (Exception ex) { MessageBox.Show(ex.Message, "Export failed", MessageBoxButtons.OK, MessageBoxIcon.Warning); }
+            }
+        }
+
+        private static byte[] SafeVocToWav(byte[] voc)
+        {
+            try { return SoundConverter.VocToWav(voc); }
+            catch { return null; }
+        }
+
+        private static byte[] Serialize(BlockBase block)
+        {
+            using (var ms = new MemoryStream())
+            {
+                block.SaveToBinaryWriter(ms);
+                return ms.ToArray();
+            }
+        }
+
+        private static byte[] Slice(byte[] data, int start)
+        {
+            var result = new byte[data.Length - start];
+            Array.Copy(data, start, result, 0, result.Length);
+            return result;
+        }
+
+        private static int IndexOf(byte[] data, string text)
+        {
+            for (int i = 0; i + text.Length <= data.Length; i++)
+            {
+                bool match = true;
+                for (int j = 0; j < text.Length; j++)
+                {
+                    if (data[i + j] != text[j]) { match = false; break; }
+                }
+                if (match) return i;
+            }
+            return -1;
+        }
+    }
+}

--- a/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
@@ -262,17 +262,18 @@ namespace ScummEditor.Gui
             }
         }
 
-        /// <summary>Root nodes for the external .NUT SMUSH fonts (v7 The Dig / Full Throttle); the NutFont
-        /// viewer handles them. These are separate files next to the .LA0/.LA1 container.</summary>
+        /// <summary>A single "Fonts" root node grouping the external .NUT SMUSH fonts (v7 The Dig / Full
+        /// Throttle), one child per file; the NutFont viewer handles each. Purely a visual grouping - the
+        /// fonts are separate files next to the .LA0/.LA1 container and are dispatched by their tag.</summary>
         private void CreateNutFontNodes()
         {
-            if (GameData.NutFonts == null) return;
+            if (GameData.NutFonts == null || GameData.NutFonts.Count == 0) return;
 
+            TreeNode fontsRoot = _treeView.Nodes.Add("NutFonts", "Fonts");
             foreach (NutFontResource font in GameData.NutFonts)
             {
-                var node = _treeView.Nodes.Add("NutFont",
-                    "Font (" + System.IO.Path.GetFileName(font.FilePath) + ", NUT)");
-                node.Tag = font;
+                var node = new TreeNode(System.IO.Path.GetFileName(font.FilePath)) { Tag = font };
+                fontsRoot.Nodes.Add(node);
             }
         }
 

--- a/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
@@ -559,7 +559,9 @@ namespace ScummEditor.Gui
             var localizedText = e.Node.Tag as ILocalizedTextFile;
             if (localizedText != null)
             {
-                _localizedTextControl.SetData(localizedText);
+                // Show the text through the edition's DOS code page so its accents render correctly.
+                int codePage = ScummEditor.Engine.Encoders.DosCodePageText.CodePageFor(GameData.LoadedGameInfo.Language);
+                _localizedTextControl.SetData(localizedText, codePage);
                 _displayPanel.Controls.Add(_localizedTextControl);
                 _localizedTextControl.Dock = DockStyle.Fill;
                 return;

--- a/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
@@ -79,6 +79,7 @@ namespace ScummEditor.Gui
             _controlViewers.Add(typeof(ObjectCode).Name, new ObjectCodeControl());
 
             _controlViewers.Add(typeof(SoundBlock).Name, new SoundBlockControl());
+            _controlViewers.Add(typeof(SoundBlockV7).Name, new SoundBlockV7Control()); // v7 SOUN (iMUS/VOC)
 
             var scriptControl = new ScriptControl();
             _controlViewers.Add(typeof(ScriptBlock).Name, scriptControl);

--- a/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
@@ -29,6 +29,7 @@ namespace ScummEditor.Gui
         private readonly V2ExeFontControl _v2ExeFontControl = new V2ExeFontControl();
         private readonly NutFontControl _nutFontControl = new NutFontControl();
         private readonly ImuseBundleControl _imuseBundleControl = new ImuseBundleControl();
+        private readonly LocalizedTextControl _localizedTextControl = new LocalizedTextControl();
         private readonly TreeView _treeView;
         private readonly Panel _displayPanel;
 
@@ -179,6 +180,7 @@ namespace ScummEditor.Gui
             CreateV2ExeFontNode();
             CreateNutFontNodes();
             CreateBundleNodes(GameData.LoadedGameInfo);
+            CreateLocalizedTextNodes();
             CreateSouFileNodes(GameData.LoadedGameInfo);
         }
 
@@ -324,6 +326,20 @@ namespace ScummEditor.Gui
             foreach (BlockBase block in indexFile.Blocks)
             {
                 CreateNode(block, node);
+            }
+        }
+
+        /// <summary>A single "Texts (localized)" root node grouping the external localized-text files (v7
+        /// The Dig LANGUAGE.BND + the .TRS subtitle/UI files); the localized-text viewer handles each.</summary>
+        private void CreateLocalizedTextNodes()
+        {
+            if (GameData.LocalizedTextFiles == null || GameData.LocalizedTextFiles.Count == 0) return;
+
+            TreeNode root = _treeView.Nodes.Add("LocalizedText", "Texts (localized)");
+            foreach (ILocalizedTextFile text in GameData.LocalizedTextFiles)
+            {
+                var node = new TreeNode(System.IO.Path.GetFileName(text.FilePath)) { Tag = text };
+                root.Nodes.Add(node);
             }
         }
 
@@ -536,6 +552,16 @@ namespace ScummEditor.Gui
                 _imuseBundleControl.SetData(bundle);
                 _displayPanel.Controls.Add(_imuseBundleControl);
                 _imuseBundleControl.Dock = DockStyle.Fill;
+                return;
+            }
+
+            // v7 external localized text (The Dig LANGUAGE.BND + the .TRS files).
+            var localizedText = e.Node.Tag as ILocalizedTextFile;
+            if (localizedText != null)
+            {
+                _localizedTextControl.SetData(localizedText);
+                _displayPanel.Controls.Add(_localizedTextControl);
+                _localizedTextControl.Dock = DockStyle.Fill;
                 return;
             }
 

--- a/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
@@ -27,6 +27,7 @@ namespace ScummEditor.Gui
         private readonly OldBundleObjectControl _oldBundleObjectControl = new OldBundleObjectControl();
         private readonly OldBundleScriptControl _oldBundleScriptControl = new OldBundleScriptControl();
         private readonly V2ExeFontControl _v2ExeFontControl = new V2ExeFontControl();
+        private readonly NutFontControl _nutFontControl = new NutFontControl();
         private readonly TreeView _treeView;
         private readonly Panel _displayPanel;
 
@@ -174,6 +175,7 @@ namespace ScummEditor.Gui
             CreateFontFileNodes();
             CreateV3FontNodes();
             CreateV2ExeFontNode();
+            CreateNutFontNodes();
             CreateSouFileNodes(GameData.LoadedGameInfo);
         }
 
@@ -258,6 +260,57 @@ namespace ScummEditor.Gui
                     "Font (" + System.IO.Path.GetFileName(font.FilePath) + ")");
                 node.Tag = font.Charset;
             }
+        }
+
+        /// <summary>Root nodes for the external .NUT SMUSH fonts (v7 The Dig / Full Throttle); the NutFont
+        /// viewer handles them. These are separate files next to the .LA0/.LA1 container.</summary>
+        private void CreateNutFontNodes()
+        {
+            if (GameData.NutFonts == null) return;
+
+            foreach (NutFontResource font in GameData.NutFonts)
+            {
+                var node = _treeView.Nodes.Add("NutFont",
+                    "Font (" + System.IO.Path.GetFileName(font.FilePath) + ", NUT)");
+                node.Tag = font;
+            }
+        }
+
+        /// <summary>
+        /// A few distinct room palettes from the loaded game, offered as preview palettes for the .NUT font
+        /// viewer (a NUT carries no palette of its own; its pixels are runtime palette indices). Capped and
+        /// de-duplicated so the combobox stays short even for a game with many rooms.
+        /// </summary>
+        private List<Color[]> GameRoomPalettes()
+        {
+            var palettes = new List<Color[]>();
+            if (GameData == null || GameData.DataFile == null) return palettes;
+
+            var seen = new HashSet<string>();
+            foreach (BlockBase child in GameData.DataFile.Childrens)
+            {
+                if (palettes.Count >= 8) break;
+                var disk = child as DiskBlock;
+                if (disk == null) continue;
+
+                RoomBlock room = disk.GetROOM();
+                if (room == null) continue;
+
+                Color[] palette;
+                try { palette = room.GetPALS().GetWRAP().GetAPALs()[0].Colors; }
+                catch { continue; }
+                if (palette == null) continue;
+
+                if (seen.Add(PaletteKey(palette))) palettes.Add(palette);
+            }
+            return palettes;
+        }
+
+        private static string PaletteKey(Color[] palette)
+        {
+            var sb = new System.Text.StringBuilder(palette.Length * 4);
+            foreach (Color c in palette) sb.Append(c.ToArgb()).Append(',');
+            return sb.ToString();
         }
 
         /// <summary>Index tree for SCUMM v4: a flat list of the index blocks (RN, 0R, 0S, ...).</summary>
@@ -445,6 +498,16 @@ namespace ScummEditor.Gui
                 _v2ExeFontControl.SetData(v2ExeFont);
                 _displayPanel.Controls.Add(_v2ExeFontControl);
                 _v2ExeFontControl.Dock = DockStyle.Fill;
+                return;
+            }
+
+            // v7 external .NUT SMUSH fonts (The Dig / Full Throttle), standalone files next to the container.
+            var nutFont = e.Node.Tag as NutFontResource;
+            if (nutFont != null)
+            {
+                _nutFontControl.SetData(nutFont, GameRoomPalettes());
+                _displayPanel.Controls.Add(_nutFontControl);
+                _nutFontControl.Dock = DockStyle.Fill;
                 return;
             }
 

--- a/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
@@ -44,7 +44,13 @@ namespace ScummEditor.Gui
             _controlViewers.Add(typeof(RoomHeader).Name, new RoomHeaderControl());
             _controlViewers.Add(typeof(DiskBlock).Name, new DiskBlockControl());
             _controlViewers.Add(typeof(ScummV4RoomBlock).Name, new ScummV4RoomImageControl());
-            _controlViewers.Add(typeof(NotImplementedDataBlock).Name, new NotImplementedDataBlockControl());
+            // The byte-preserved blocks (v4-v6 NotImplementedDataBlock and the v7 generic blocks) all
+            // share the hex viewer so their raw content is shown instead of just the generic header.
+            var rawBlockControl = new NotImplementedDataBlockControl();
+            _controlViewers.Add(typeof(NotImplementedDataBlock).Name, rawBlockControl);
+            _controlViewers.Add(typeof(RawContainerBlock).Name, rawBlockControl);
+            _controlViewers.Add(typeof(RawDataBlock).Name, rawBlockControl);
+            _controlViewers.Add(typeof(RawIndexBlock).Name, rawBlockControl);
             _controlViewers.Add(typeof(RoomOffsetTable).Name, new RoomOffsetTableControl());
             _controlViewers.Add(typeof(ZPlane).Name, new ZPlaneControl());
             _controlViewers.Add(typeof(ObjectImageHeader).Name, new ObjectImageHeaderControl());
@@ -101,6 +107,22 @@ namespace ScummEditor.Gui
 
         public void LoadTree()
         {
+            // BeginUpdate/EndUpdate suppress per-node repaints while the tree is populated. This is
+            // essential for v7 (The Dig, Full Throttle): their data files are tens of megabytes and
+            // produce many thousands of block nodes.
+            _treeView.BeginUpdate();
+            try
+            {
+                BuildTree();
+            }
+            finally
+            {
+                _treeView.EndUpdate();
+            }
+        }
+
+        private void BuildTree()
+        {
             _treeView.Nodes.Clear();
 
             var v4Index = GameData.IndexFile as ScummV4IndexFile;
@@ -111,6 +133,10 @@ namespace ScummEditor.Gui
             else if (GameData.IndexFile is ScummV3OldBundleIndexFile)
             {
                 CreateOldBundleIndexTree((ScummV3OldBundleIndexFile)GameData.IndexFile);
+            }
+            else if (GameData.IndexFile is ScummV7IndexFile)
+            {
+                CreateScummV7IndexFileTree((ScummV7IndexFile)GameData.IndexFile);
             }
             else if (GameData.IndexFile != null)
             {
@@ -322,6 +348,27 @@ namespace ScummEditor.Gui
             }
         }
 
+        /// <summary>
+        /// Index tree for SCUMM v7 (The Dig, Full Throttle): the raw RNAM/MAXS blocks, the five typed
+        /// resource directories, then the raw DOBJ/AARY and the v7-only ANAM (audio names). The raw
+        /// blocks are kept verbatim, so they are shown with the generic block viewer.
+        /// </summary>
+        private void CreateScummV7IndexFileTree(ScummV7IndexFile index)
+        {
+            var node = _treeView.Nodes.Add("IndexFile", "Index File");
+
+            CreateNode(index.RawRNAM, node);
+            CreateNode(index.RawMAXS, node);
+            CreateNode(index.DROO, node);
+            CreateNode(index.DSCR, node);
+            CreateNode(index.DSOU, node);
+            CreateNode(index.DCOS, node);
+            CreateNode(index.DCHR, node);
+            CreateNode(index.RawDOBJ, node);
+            CreateNode(index.RawAARY, node);
+            CreateNode(index.RawANAM, node);
+        }
+
         private void CreateScummIndexFileTree(ScummV5V6IndexFile scummV6IndexFile)
         {
             var node = _treeView.Nodes.Add("IndexFile", "Index File");
@@ -411,7 +458,14 @@ namespace ScummEditor.Gui
 
             string name = item.GetType().Name;
 
-
+            // v7 (The Dig, Full Throttle) rooms are not yet decoded into typed image/costume blocks
+            // (RMIM/PALS/OBIM are kept as generic byte-preserved blocks for now), so the rich DiskBlock
+            // room preview would fail looking for them. Fall back to the generic block view; the rich
+            // preview arrives with the typed v7 image/costume support in a later phase.
+            if (name == typeof(DiskBlock).Name && item.GameInfo != null && item.GameInfo.ScummVersion == 7)
+            {
+                name = typeof(BlockBase).Name;
+            }
 
             if (_controlViewers.ContainsKey(name))
             {

--- a/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
@@ -28,6 +28,7 @@ namespace ScummEditor.Gui
         private readonly OldBundleScriptControl _oldBundleScriptControl = new OldBundleScriptControl();
         private readonly V2ExeFontControl _v2ExeFontControl = new V2ExeFontControl();
         private readonly NutFontControl _nutFontControl = new NutFontControl();
+        private readonly ImuseBundleControl _imuseBundleControl = new ImuseBundleControl();
         private readonly TreeView _treeView;
         private readonly Panel _displayPanel;
 
@@ -177,6 +178,7 @@ namespace ScummEditor.Gui
             CreateV3FontNodes();
             CreateV2ExeFontNode();
             CreateNutFontNodes();
+            CreateBundleNodes(GameData.LoadedGameInfo);
             CreateSouFileNodes(GameData.LoadedGameInfo);
         }
 
@@ -322,6 +324,20 @@ namespace ScummEditor.Gui
             foreach (BlockBase block in indexFile.Blocks)
             {
                 CreateNode(block, node);
+            }
+        }
+
+        /// <summary>Root nodes for the external iMUSE sound bundles (v7 The Dig DIGMUSIC.BUN / DIGVOICE.BUN);
+        /// the iMUSE bundle viewer handles each. These are separate files next to the .LA0/.LA1 container.</summary>
+        private void CreateBundleNodes(GameInfo gameInfo)
+        {
+            if (gameInfo == null || gameInfo.BundleFiles == null) return;
+
+            foreach (string path in gameInfo.BundleFiles)
+            {
+                var node = _treeView.Nodes.Add("SoundBundle",
+                    "Sound Bundle (" + System.IO.Path.GetFileName(path) + ")");
+                node.Tag = new ImuseBundleFile(path);
             }
         }
 
@@ -510,6 +526,16 @@ namespace ScummEditor.Gui
                 _nutFontControl.SetData(nutFont, GameRoomPalettes());
                 _displayPanel.Controls.Add(_nutFontControl);
                 _nutFontControl.Dock = DockStyle.Fill;
+                return;
+            }
+
+            // v7 external iMUSE sound bundles (The Dig DIGMUSIC.BUN / DIGVOICE.BUN).
+            var bundle = e.Node.Tag as ImuseBundleFile;
+            if (bundle != null)
+            {
+                _imuseBundleControl.SetData(bundle);
+                _displayPanel.Controls.Add(_imuseBundleControl);
+                _imuseBundleControl.Dock = DockStyle.Fill;
                 return;
             }
 

--- a/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
@@ -50,7 +50,9 @@ namespace ScummEditor.Gui
             _controlViewers.Add(typeof(NotImplementedDataBlock).Name, rawBlockControl);
             _controlViewers.Add(typeof(RawContainerBlock).Name, rawBlockControl);
             _controlViewers.Add(typeof(RawDataBlock).Name, rawBlockControl);
-            _controlViewers.Add(typeof(RawIndexBlock).Name, rawBlockControl);
+            // The v7 index meta blocks (RNAM/MAXS/DOBJ/AARY/ANAM) are RawIndexBlock; decode them for a
+            // friendly view instead of the raw hex dump.
+            _controlViewers.Add(typeof(RawIndexBlock).Name, new V7IndexBlockControl());
             _controlViewers.Add(typeof(RoomOffsetTable).Name, new RoomOffsetTableControl());
             _controlViewers.Add(typeof(ZPlane).Name, new ZPlaneControl());
             _controlViewers.Add(typeof(ObjectImageHeader).Name, new ObjectImageHeaderControl());

--- a/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
@@ -55,6 +55,7 @@ namespace ScummEditor.Gui
             _controlViewers.Add(typeof(ZPlane).Name, new ZPlaneControl());
             _controlViewers.Add(typeof(ObjectImageHeader).Name, new ObjectImageHeaderControl());
             _controlViewers.Add(typeof(Costume).Name, new CostumeControl());
+            _controlViewers.Add(typeof(CostumeAkos).Name, new AkosCostumeControl()); // v7 AKOS costumes
             _controlViewers.Add(typeof(ImageBomp).Name, new ImageBompControl());
 
             var structuredBlockControl = new StructuredBlockControl();

--- a/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
@@ -458,15 +458,6 @@ namespace ScummEditor.Gui
 
             string name = item.GetType().Name;
 
-            // v7 (The Dig, Full Throttle) rooms are not yet decoded into typed image/costume blocks
-            // (RMIM/PALS/OBIM are kept as generic byte-preserved blocks for now), so the rich DiskBlock
-            // room preview would fail looking for them. Fall back to the generic block view; the rich
-            // preview arrives with the typed v7 image/costume support in a later phase.
-            if (name == typeof(DiskBlock).Name && item.GameInfo != null && item.GameInfo.ScummVersion == 7)
-            {
-                name = typeof(BlockBase).Name;
-            }
-
             if (_controlViewers.ContainsKey(name))
             {
                 _controlViewers[name].SetAndRefreshData(item);

--- a/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
+++ b/ScummEditor.Gui/Gui/TreeNavigatorManager.cs
@@ -294,7 +294,7 @@ namespace ScummEditor.Gui
             }
         }
 
-        private void CreateScummDataFileTree(ScummV5V6DataFile dataFile, string label)
+        private void CreateScummDataFileTree(ScummDataFile dataFile, string label)
         {
             TreeNode dataNode = _treeView.Nodes.Add(label, label);
 
@@ -372,7 +372,7 @@ namespace ScummEditor.Gui
             CreateNode(index.RawANAM, node);
         }
 
-        private void CreateScummIndexFileTree(ScummV5V6IndexFile scummV6IndexFile)
+        private void CreateScummIndexFileTree(ScummIndexFile scummV6IndexFile)
         {
             var node = _treeView.Nodes.Add("IndexFile", "Index File");
 

--- a/ScummEditor.Gui/Gui/V7IndexBlockControl.cs
+++ b/ScummEditor.Gui/Gui/V7IndexBlockControl.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+
+namespace ScummEditor.Gui
+{
+    /// <summary>
+    /// Friendly viewer for the SCUMM v7 index meta blocks that are kept verbatim (RawIndexBlock): RNAM
+    /// (room names), MAXS (engine maximums + version strings), ANAM (audio resource names), DOBJ (global
+    /// object owner/class table) and AARY (arrays). It DECODES each for display (read-only) instead of
+    /// the raw hex view; the underlying block stays byte-for-byte (no engine change, round-trip intact).
+    /// Formats mirror ScummVM resource.cpp (ScummEngine_v7::readMAXS / readIndexBlock / readRNAM).
+    /// </summary>
+    public class V7IndexBlockControl : BlockBaseControl
+    {
+        private readonly TextBox _text;
+
+        public V7IndexBlockControl()
+        {
+            _text = new TextBox
+            {
+                Dock = DockStyle.Fill,
+                Multiline = true,
+                ReadOnly = true,
+                ScrollBars = ScrollBars.Both,
+                WordWrap = false,
+                Font = new Font("Consolas", 9F),
+                BackColor = Color.White,
+            };
+            Controls.Add(_text);
+        }
+
+        public override void SetAndRefreshData(BlockBase blockBase)
+        {
+            base.SetAndRefreshData(blockBase);
+
+            var raw = blockBase as IRawContentBlock;
+            byte[] body = raw != null ? raw.Contents : null;
+            _text.Text = Decode(blockBase.BlockType, body).Replace("\n", "\r\n");
+        }
+
+        private static string Decode(string tag, byte[] body)
+        {
+            if (body == null) return "(no data)";
+            switch (tag)
+            {
+                case "RNAM": return DecodeRoomNames(body);
+                case "MAXS": return DecodeMaxs(body);
+                case "ANAM": return DecodeAudioNames(body);
+                case "DOBJ": return DecodeObjects(body);
+                case "AARY": return DecodeArrays(body);
+                default: return HexAndStrings(tag, body);
+            }
+        }
+
+        /// <summary>RNAM: [room#:1][name:9 XOR 0xFF] entries, terminated by room#==0.</summary>
+        private static string DecodeRoomNames(byte[] b)
+        {
+            var sb = new StringBuilder("RNAM - room names\n\n");
+            int p = 0, count = 0;
+            while (p < b.Length)
+            {
+                int room = b[p++];
+                if (room == 0) break;
+                if (p + 9 > b.Length) break;
+                var name = new char[9];
+                int n = 0;
+                for (int i = 0; i < 9; i++)
+                {
+                    byte c = (byte)(b[p + i] ^ 0xFF);
+                    if (c == 0) break;
+                    name[n++] = (char)c;
+                }
+                p += 9;
+                sb.AppendLine(string.Format("Room {0,3}: {1}", room, new string(name, 0, n)));
+                count++;
+            }
+            sb.AppendLine();
+            sb.AppendLine(count + " named rooms.");
+            return sb.ToString();
+        }
+
+        /// <summary>MAXS (v7): two 50-byte version strings then 15 uint16 engine maximums.</summary>
+        private static string DecodeMaxs(byte[] b)
+        {
+            if (b.Length < 130) return HexAndStrings("MAXS", b);
+            var sb = new StringBuilder("MAXS - engine maximums\n\n");
+            sb.AppendLine("Engine version : " + AsciiZ(b, 0, 50));
+            sb.AppendLine("Data version   : " + AsciiZ(b, 50, 50));
+            sb.AppendLine();
+            string[] labels =
+            {
+                "Variables", "Bit variables", "(unused)", "Global objects", "Local objects",
+                "New names", "Verbs", "Floating objects", "Inventory", "Arrays",
+                "Rooms", "Scripts", "Sounds", "Character sets", "Costumes",
+            };
+            int o = 100;
+            for (int i = 0; i < labels.Length && o + 2 <= b.Length; i++, o += 2)
+            {
+                sb.AppendLine(string.Format("{0,-16}: {1}", labels[i], b[o] | (b[o + 1] << 8)));
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>ANAM: [count:u16] then count x 9-byte audio resource names.</summary>
+        private static string DecodeAudioNames(byte[] b)
+        {
+            if (b.Length < 2) return HexAndStrings("ANAM", b);
+            int count = b[0] | (b[1] << 8);
+            var sb = new StringBuilder("ANAM - audio resource names\n\n");
+            sb.AppendLine(count + " entries:\n");
+            int p = 2;
+            for (int i = 0; i < count && p + 9 <= b.Length; i++, p += 9)
+            {
+                string name = AsciiZ(b, p, 9);
+                if (name.Length > 0) sb.AppendLine(string.Format("{0,4}: {1}", i, name));
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// DOBJ (v7): [count:u16] then THREE sequential tables (not per-object records), matching ScummVM
+        /// ScummEngine_v7::readGlobalObjects: [state:count bytes][room:count bytes][class:count x uint32 LE].
+        /// (The owner table is not stored in v7 - the engine defaults it to 0xFF.)
+        /// </summary>
+        private static string DecodeObjects(byte[] b)
+        {
+            if (b.Length < 2) return HexAndStrings("DOBJ", b);
+            int count = b[0] | (b[1] << 8);
+            int statesOff = 2;
+            int roomsOff = statesOff + count;
+            int classOff = roomsOff + count;
+            if (classOff + count * 4 > b.Length) return HexAndStrings("DOBJ", b); // truncated - show raw
+
+            var sb = new StringBuilder("DOBJ - global object state/room/class table\n\n");
+            sb.AppendLine(count + " global objects.\n");
+            sb.AppendLine("  obj  state  room   class");
+            for (int i = 0; i < count; i++)
+            {
+                int co = classOff + i * 4;
+                long cls = (uint)(b[co] | (b[co + 1] << 8) | (b[co + 2] << 16) | (b[co + 3] << 24));
+                sb.AppendLine(string.Format("{0,5}  {1,5}  {2,4}   0x{3:X6}", i, b[statesOff + i], b[roomsOff + i], cls & 0xFFFFFF));
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// AARY (predefined arrays), matching ScummVM ScummEngine_v6::readArrayFromIndexFile: repeated
+        /// [array#:u16][dim2:u16][dim1:u16][type:u16], terminated by array#==0. The call is
+        /// defineArray(array#, type, dim2, dim1), so the third word is the type.
+        /// </summary>
+        private static string DecodeArrays(byte[] b)
+        {
+            var sb = new StringBuilder("AARY - predefined arrays\n\n");
+            int p = 0, count = 0;
+            while (p + 2 <= b.Length)
+            {
+                int num = b[p] | (b[p + 1] << 8);
+                if (num == 0) break;
+                if (p + 8 > b.Length) break;
+                int dim2 = b[p + 2] | (b[p + 3] << 8);
+                int dim1 = b[p + 4] | (b[p + 5] << 8);
+                int type = b[p + 6] | (b[p + 7] << 8);
+                sb.AppendLine(string.Format("Array {0,4}: dim2={1} dim1={2} type={3}", num, dim2, dim1, type));
+                p += 8;
+                count++;
+            }
+            sb.AppendLine();
+            sb.AppendLine(count + " arrays.");
+            return sb.ToString();
+        }
+
+        private static string AsciiZ(byte[] b, int offset, int max)
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < max && offset + i < b.Length; i++)
+            {
+                byte c = b[offset + i];
+                if (c == 0) break;
+                sb.Append(c >= 32 && c < 127 ? (char)c : '.');
+            }
+            return sb.ToString().Trim();
+        }
+
+        /// <summary>Fallback for any other raw index block: a hex dump plus the readable ASCII runs.</summary>
+        private static string HexAndStrings(string tag, byte[] b)
+        {
+            var sb = new StringBuilder(tag + " - " + b.Length + " bytes\n\n");
+            int rows = Math.Min(b.Length, 1024);
+            for (int i = 0; i < rows; i += 16)
+            {
+                sb.Append(i.ToString("X4")).Append("  ");
+                for (int j = 0; j < 16 && i + j < rows; j++) sb.Append(b[i + j].ToString("X2")).Append(' ');
+                sb.Append(' ');
+                for (int j = 0; j < 16 && i + j < rows; j++)
+                {
+                    byte c = b[i + j];
+                    sb.Append(c >= 32 && c < 127 ? (char)c : '.');
+                }
+                sb.Append('\n');
+            }
+            if (b.Length > rows) sb.AppendLine("... (" + (b.Length - rows) + " more bytes)");
+            return sb.ToString();
+        }
+    }
+}

--- a/ScummEditor.Gui/Gui/V7IndexBlockControl.cs
+++ b/ScummEditor.Gui/Gui/V7IndexBlockControl.cs
@@ -31,7 +31,9 @@ namespace ScummEditor.Gui
                 Font = new Font("Consolas", 9F),
                 BackColor = Color.White,
             };
-            Controls.Add(_text);
+            // Add to the base control's Contents panel (positioned BELOW the BlockType/Size/Offset header)
+            // so the decoded text sits under the header instead of overlapping it.
+            Contents.Controls.Add(_text);
         }
 
         public override void SetAndRefreshData(BlockBase blockBase)

--- a/ScummEditor.Gui/Properties/AssemblyInfo.cs
+++ b/ScummEditor.Gui/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.6.1")]
-[assembly: AssemblyFileVersion("3.6.1")]
+[assembly: AssemblyVersion("4.0.0")]
+[assembly: AssemblyFileVersion("4.0.0")]
 // Application.ProductVersion (shown in the About window) reads this on modern .NET.
-[assembly: AssemblyInformationalVersion("3.6.1")]
+[assembly: AssemblyInformationalVersion("4.0.0")]

--- a/ScummEditor.Gui/Resources/History.txt
+++ b/ScummEditor.Gui/Resources/History.txt
@@ -1,3 +1,27 @@
+4.0.0
+-----
+* SCUMM v7 support. The Dig and Full Throttle (1995) can now be opened, viewed and edited with the same feature set as the v3-v6 games plus the extras these two need - extending coverage from v1 all the way to v7. As with every other version they are recognized from the content of their data files alone, never the game EXE: v7 keeps the same tagged IFF container as v5/v6 (the engine is a direct extension of v5/v6), split across a separate index file (.LA0) and data file (.LA1), and the container round-trips byte-for-byte across all 24 editions of the two games (every language release tested).
+
+* v7 game text translation. Object and location names, verb scripts, the room entry/exit scripts and the global scripts all disassemble and export/import for translation, with the tables and jump offsets remapped automatically when a translation changes length - the same workflow as every other version. The v6 script disassembler was completed for the handful of v7-only opcodes (including the two-byte local-script id).
+
+* Localized text - the high-value translation feature for these two games. Unlike the earlier games, The Dig and Full Throttle keep most of their on-screen text OUTSIDE the game container, in separate files: The Dig's dialogue in LANGUAGE.BND (lightly obfuscated) and both games' subtitle and interface text in .TRS files (plain, or in the ETRS/obfuscated form some releases use). The editor now exposes all of it under a new "Texts (localized)" node, decodes the obfuscation transparently, and writes it back with a byte-identical round-trip - so a translation of the actual spoken/subtitle text can be edited in place. This is the text most translators care about and it was previously unreachable.
+
+* Accented characters in the localized text now display correctly. v7 stores text in the original MS-DOS code page (code page 850 for the Western releases, including Brazilian Portuguese), so the editor transcodes it for display and on save - an "ã", "ç" or "ü" shows as itself instead of a raw byte, matching what the real engine draws.
+
+* v7 room and object images. Backgrounds, object images and the walk-behind (z-plane) masks reuse the v5/v6 picture codecs (the SMAP strip format and BOMP), decoded against the room palette and exported as lossless indexed PNGs; an edited PNG imports back the same way it does for v5/v6.
+
+* v7 costumes (AKOS). The Dig and Full Throttle use the later AKOS costume format rather than the classic one; its cels are decoded (the three codecs these games use - run-length, BOMP and the bit-packed MAJMIN), shown in the costume viewer and exported as PNGs, both per-resource and in the batch graphics pass, and edited frames import back into the original codec.
+
+* v7 fonts. Both the fonts stored inside the game container (shown and edited exactly like the v3-v6 charsets) and the external .NUT SMUSH fonts (The Dig and Full Throttle each ship several) are decoded, exported as glyph atlases and imported back. A re-encoded .NUT is written in the exact layout the real engine's font loader expects, so an edited font stays loadable - verified by reproducing the engine's own two-pass frame walk and pixel decode over every glyph of every .NUT in both games.
+
+* v7 sound. The speech and music stored inside the container (the iMUSE iMUS PCM format and Creative VOC) play in the viewer and export to WAV, as does Full Throttle's MONSTER.SOU speech file (its per-line VOC, including the lip-sync wrapper) and The Dig's .BUN iMUSE bundles (DIGMUSIC.BUN / DIGVOICE.BUN, whose LZ/delta/12-bit-repack compression is fully decompressed). As with v4-v6, sound is play/export only - importing edited audio is not yet available.
+
+* v7 games appear in the resource browser as a full block tree with the same per-resource viewers as the v2-v6 games, and the language of a v7 release is detected automatically (from the localized text for The Dig, from the container scripts for Full Throttle).
+
+* Engine-wide validation: all 24 v7 editions of the two games were loaded and had every image, costume, font and sound decoded through every viewer with no failures; and a copy of each game was edited end-to-end at once - dialogue and names, fonts, backgrounds, objects and costumes - then booted in both ScummVM and the original DOS interpreter under DOSBox, confirming the edits render and the games run.
+
+* Known limitations. Importing edited sound is not yet available (the same as v4-v6). The SMUSH full-motion cutscenes (.SAN) and the original-DOS support binaries that ScummVM reimplements are listed but not edited. As with every other version, an edit that changes the size of the index file changes its checksum, so ScummVM's automatic detection may need the new checksum (a size-neutral edit keeps it identical).
+
 3.6.1
 -----
 * Fix (critical): importing an edited image back into a v1 game (Maniac Mansion / Zak McKracken in their original 1987/1988 form) produced a game the real engine could not run - it started to a black screen under both the original DOS interpreter and ScummVM. The room was being rebuilt by appending the re-encoded picture data and leaving the old data behind, which roughly doubled the room, and the v1 engine cannot load a room that grew like that. Rooms are now rebuilt compactly - the picture data is re-compressed in place and every internal offset re-pointed - so an edited room stays close to its original size and the game runs. Confirmed by running an edited Maniac Mansion in DOSBox.

--- a/ScummEditor.UnitTests/GameLibrary.cs
+++ b/ScummEditor.UnitTests/GameLibrary.cs
@@ -50,6 +50,8 @@ namespace ScummEditor.UnitTests
         // SCUMM v7 (GAME.LA0 index + GAME.LA1 data; not XOR-encrypted; AKOS costumes)
         public const string TheDig = "ScummV7/Dig, The (1995)/DOS v1.0";
         public const string TheDigPortuguese = "ScummV7/Dig, The (1995)/Other Languages/Portuguese/CD";
+        // The CJK editions keep LANGUAGE.BND under a VIDEO/ subfolder (detection must search recursively).
+        public const string TheDigChinese = "ScummV7/Dig, The (1995)/Other Languages/Chinese/CD";
         public const string FullThrottle = "ScummV7/Full Throttle (1995)/DOS CD";
         public const string FullThrottlePortuguese = "ScummV7/Full Throttle (1995)/Other Languages/Portuguese/DOS CD";
 

--- a/ScummEditor.UnitTests/GameLibrary.cs
+++ b/ScummEditor.UnitTests/GameLibrary.cs
@@ -47,6 +47,16 @@ namespace ScummEditor.UnitTests
         public const string SamAndMaxFloppy = "ScummV6/Sam and Max Hit the Road (1993)/Floppy v1.0";
         public const string SamAndMaxCd = "ScummV6/Sam and Max Hit the Road (1993)/DOS CD Talkie";
 
+        // SCUMM v7 (GAME.LA0 index + GAME.LA1 data; not XOR-encrypted; AKOS costumes)
+        public const string TheDig = "ScummV7/Dig, The (1995)/DOS v1.0";
+        public const string TheDigPortuguese = "ScummV7/Dig, The (1995)/Other Languages/Portuguese/CD";
+        public const string FullThrottle = "ScummV7/Full Throttle (1995)/DOS CD";
+        public const string FullThrottlePortuguese = "ScummV7/Full Throttle (1995)/Other Languages/Portuguese/DOS CD";
+
+        // SCUMM v8 (The Curse of Monkey Island) - NOT supported; used to verify the v7 detector rejects it
+        // (it shares the COMI.LA0/COMI.LA1 naming + RNAM/LECF magic with v7).
+        public const string CurseOfMonkeyIsland = "ScummV8/Curse of Monkey Island, The (1997)/CD";
+
         private static readonly string _root = FindRoot();
 
         /// <summary>True when the GameData library was found next to the repo.</summary>

--- a/ScummEditor.UnitTests/StandaloneFontLoadTests.cs
+++ b/ScummEditor.UnitTests/StandaloneFontLoadTests.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using ScummEditor.Engine.Structures;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// The standalone-font loaders (v3 9N.LFL charsets, v4 90x.LFL fonts) read each file with
+    /// File.ReadAllBytes, and the GUI load path is not wrapped in a try-catch. A font enumerated at
+    /// detection could be missing/locked by load time; that must not crash the whole game load - the
+    /// unreadable file is skipped and the rest of the game (and the other fonts) still load. Mirrors
+    /// V7NutFontTests.MissingNutFileIsSkippedDuringLoad for the external .NUT fonts.
+    /// </summary>
+    public class StandaloneFontLoadTests
+    {
+        [SkippableTheory]
+        [InlineData(GameLibrary.Indy3Vga)]
+        public void MissingV3CharsetIsSkippedDuringLoad(string relativePath)
+        {
+            GameInfo info = GameLibrary.Detect(relativePath);
+            Skip.If(info == null, "GameData folder not present: " + relativePath);
+            Skip.If(info.FontFiles == null || info.FontFiles.Count == 0, "game has no standalone charset files");
+
+            info.FontFiles.Add(Path.Combine(GameLibrary.Folder(relativePath), "DOES_NOT_EXIST.LFL"));
+
+            ScummGameData game = ScummGameData.LoadFromGameInfo(info); // must not throw
+            Assert.True(game.V3Charsets.Count > 0, "no v3 charsets loaded");
+            Assert.DoesNotContain(game.V3Charsets, c => c.FilePath != null && c.FilePath.EndsWith("DOES_NOT_EXIST.LFL"));
+        }
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.MonkeyIsland1FloppyVga)]
+        public void MissingV4FontIsSkippedDuringLoad(string relativePath)
+        {
+            GameInfo info = GameLibrary.Detect(relativePath);
+            Skip.If(info == null, "GameData folder not present: " + relativePath);
+            Skip.If(info.FontFiles == null || info.FontFiles.Count == 0, "game has no standalone font files");
+
+            info.FontFiles.Add(Path.Combine(GameLibrary.Folder(relativePath), "DOES_NOT_EXIST.LFL"));
+
+            ScummGameData game = ScummGameData.LoadFromGameInfo(info); // must not throw
+            Assert.True(game.Fonts.Count > 0, "no v4 fonts loaded");
+            Assert.DoesNotContain(game.Fonts, f => f.FilePath != null && f.FilePath.EndsWith("DOES_NOT_EXIST.LFL"));
+        }
+    }
+}

--- a/ScummEditor.UnitTests/TestParallelization.cs
+++ b/ScummEditor.UnitTests/TestParallelization.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+// The real-data tests load whole SCUMM games (the v5/v6/v7 data files are tens to hundreds of MB),
+// decode hundreds of bitmaps and copy game files to temp folders. Running those test classes in
+// parallel contends for GDI handles, memory and the on-disk game files, which made the heavy
+// graphics export/import tests flaky (non-deterministic IO locks / failures). Run the suite serially
+// for deterministic results - the integration tests dominate the runtime either way.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/ScummEditor.UnitTests/V7BundleTests.cs
+++ b/ScummEditor.UnitTests/V7BundleTests.cs
@@ -75,6 +75,49 @@ namespace ScummEditor.UnitTests
             Assert.True(decoded > 0, "no entries decoded from " + bundleName);
         }
 
+        [Fact]
+        public void MalformedInputDecodesGracefully()
+        {
+            // None of these may throw; clearly-bad input must return null (entry shown as undecodable).
+            Assert.Null(ImuseBundleDecoder.DecodeToImus(null));
+            Assert.Null(ImuseBundleDecoder.DecodeToImus(new byte[] { 1, 2, 3 }));               // too short
+            Assert.Null(ImuseBundleDecoder.DecodeToImus(System.Text.Encoding.ASCII.GetBytes("XXXXjunkjunkjunk"))); // unknown tag
+
+            // A COMP whose single block declares the unsupported VIMA codec 13 -> null, no throw.
+            Assert.Null(ImuseBundleDecoder.DecodeToImus(BuildComp(1, 0, 16, 4, 13)));
+            // A COMP whose block points past the buffer -> null.
+            Assert.Null(ImuseBundleDecoder.DecodeToImus(BuildComp(1, 0, 16, 100000, 1)));
+            // A COMP claiming more blocks than the table holds -> null.
+            Assert.Null(ImuseBundleDecoder.DecodeToImus(BuildComp(50, 0, 16, 4, 1)));
+
+            // A COMP with a tiny codec-4 block (degenerate repack): must not throw (may return non-iMUS bytes,
+            // which ToWav then rejects as null).
+            byte[] tiny = BuildComp(1, 0, 16, 4, 4);
+            byte[] imus = ImuseBundleDecoder.DecodeToImus(tiny); // no exception
+            Assert.Null(ImuseBundleDecoder.ToWav(tiny));          // garbage -> not a valid iMUS/WAV
+        }
+
+        /// <summary>Builds a minimal COMP chunk with one block record for the robustness tests.</summary>
+        private static byte[] BuildComp(int numBlocks, int lastBlockSize, int blockOffset, int blockSize, int codec)
+        {
+            var ms = new MemoryStream();
+            ms.Write(System.Text.Encoding.ASCII.GetBytes("COMP"), 0, 4);
+            WriteBE(ms, numBlocks);
+            WriteBE(ms, 0);              // padding
+            WriteBE(ms, lastBlockSize);
+            WriteBE(ms, blockOffset);    // one block record: offset / size / codec / pad
+            WriteBE(ms, blockSize);
+            WriteBE(ms, codec);
+            WriteBE(ms, 0);
+            ms.Write(new byte[8], 0, 8); // a little payload so a small in-bounds block has bytes to read
+            return ms.ToArray();
+        }
+
+        private static void WriteBE(Stream s, int v)
+        {
+            s.WriteByte((byte)(v >> 24)); s.WriteByte((byte)(v >> 16)); s.WriteByte((byte)(v >> 8)); s.WriteByte((byte)v);
+        }
+
         private static int Find(byte[] data, string tag)
         {
             for (int i = 0; i + 4 <= data.Length; i++)

--- a/ScummEditor.UnitTests/V7BundleTests.cs
+++ b/ScummEditor.UnitTests/V7BundleTests.cs
@@ -1,0 +1,90 @@
+using System.IO;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// SCUMM v7 external iMUSE sound bundles (The Dig's DIGMUSIC.BUN / DIGVOICE.BUN). The bundles are
+    /// "LB83" directories of COMP-compressed iMUS resources (codecs 0-12, no VIMA). ImuseBundleFile parses
+    /// the directory; ImuseBundleDecoder decompresses an entry (ImuseBundleCodecs) into its iMUS resource,
+    /// which ImuseAudioDecoder turns into WAV. These tests run on The Dig's real bundles.
+    /// </summary>
+    public class V7BundleTests
+    {
+        [SkippableFact]
+        public void TheDigDetectsTwoBundlesFullThrottleNone()
+        {
+            GameInfo dig = GameLibrary.Detect(GameLibrary.TheDig);
+            Skip.If(dig == null, "The Dig not present");
+            Assert.NotNull(dig.BundleFiles);
+            Assert.Equal(2, dig.BundleFiles.Count); // DIGMUSIC.BUN + DIGVOICE.BUN
+
+            GameInfo ft = GameLibrary.Detect(GameLibrary.FullThrottle);
+            if (ft != null)
+            {
+                Assert.True(ft.BundleFiles == null || ft.BundleFiles.Count == 0, "Full Throttle should have no .BUN");
+            }
+        }
+
+        [SkippableFact]
+        public void DigVoiceBundleDecodesToWav()
+        {
+            DecodeSample("DIGVOICE.BUN", 30); // codecs 0-3 (raw / LZ77 / delta)
+        }
+
+        [SkippableFact]
+        public void DigMusicBundleDecodesToWav()
+        {
+            DecodeSample("DIGMUSIC.BUN", 3); // codecs 4-12 (delta + 12-bit repack); entries are large, so a few
+        }
+
+        private static void DecodeSample(string bundleName, int count)
+        {
+            string folder = GameLibrary.Folder(GameLibrary.TheDig);
+            Skip.If(folder == null, "The Dig not present");
+            string path = Path.Combine(folder, bundleName);
+            Skip.If(!File.Exists(path), bundleName + " not present");
+
+            var bundle = new ImuseBundleFile(path);
+            bundle.EnsureParsed();
+            Assert.True(bundle.IsValid, "bundle did not parse");
+            Assert.True(bundle.Entries.Count > 0, "bundle has no entries");
+
+            int decoded = 0;
+            int n = System.Math.Min(count, bundle.Entries.Count);
+            for (int i = 0; i < n; i++)
+            {
+                byte[] raw = bundle.ReadEntryRaw(i);
+                Assert.NotNull(raw);
+
+                byte[] imus = ImuseBundleDecoder.DecodeToImus(raw);
+                Assert.NotNull(imus);
+                // the decompressed entry must be a well-formed iMUS resource
+                Assert.True(Find(imus, "iMUS") == 0, "entry " + i + " did not start with iMUS");
+                Assert.True(Find(imus, "FRMT") > 0, "entry " + i + " has no FRMT");
+                Assert.True(Find(imus, "DATA") > 0, "entry " + i + " has no DATA");
+
+                byte[] wav = ImuseBundleDecoder.ToWav(raw);
+                Assert.NotNull(wav);
+                Assert.True(wav.Length > 44 && wav[0] == 'R' && wav[1] == 'I' && wav[2] == 'F' && wav[3] == 'F',
+                    "entry " + i + " did not decode to a RIFF/WAVE");
+                decoded++;
+            }
+            Assert.True(decoded > 0, "no entries decoded from " + bundleName);
+        }
+
+        private static int Find(byte[] data, string tag)
+        {
+            for (int i = 0; i + 4 <= data.Length; i++)
+            {
+                if (data[i] == tag[0] && data[i + 1] == tag[1] && data[i + 2] == tag[2] && data[i + 3] == tag[3])
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+    }
+}

--- a/ScummEditor.UnitTests/V7CharsetTests.cs
+++ b/ScummEditor.UnitTests/V7CharsetTests.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// SCUMM v7 (The Dig, Full Throttle) in-resource CHAR fonts. v7 keeps its dialogue/verb charsets as
+    /// CHAR blocks inside the LFLF (same body layout as v5/v6), now typed as Charset so the font viewer
+    /// and the existing CharsetPngCodec export/import pipeline work on them. (The external .NUT SMUSH
+    /// fonts are a separate resource - see the NUT font tests.)
+    /// </summary>
+    public class V7CharsetTests
+    {
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void InResourceCharsetsAreTypedAndDecode(string relativePath)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "GameData folder not present: " + relativePath);
+
+            ScummGameData game = GameLibrary.Load(relativePath);
+            List<Charset> charsets = CharsetPngCodec.CollectCharsets(game.DataFile);
+
+            // The CHAR blocks must now be typed as Charset (not RawContainerBlock), so CollectCharsets
+            // finds them; both v7 games ship several in-resource charsets.
+            Assert.True(charsets.Count > 0, "no in-resource CHAR charset found (CHAR not typed as Charset?)");
+
+            foreach (Charset charset in charsets)
+            {
+                Assert.True(charset.NumChars > 0, "charset declares 0 characters");
+                Assert.True(charset.PresentGlyphCount() > 0, "charset decoded no present glyphs");
+                Assert.InRange(charset.BitsPerPixel, 1, 8);
+            }
+        }
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void CharsetPngRoundTripIsByteIdentical(string relativePath)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "GameData folder not present: " + relativePath);
+
+            ScummGameData game = GameLibrary.Load(relativePath);
+            Charset charset = CharsetPngCodec.CollectCharsets(game.DataFile).First();
+            byte[] before = (byte[])charset.RawContent.Clone();
+
+            string dir = Path.Combine(Path.GetTempPath(), "scumm_v7_char_" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string png = Path.Combine(dir, "charset.png");
+                string guide = Path.Combine(dir, "charset.guide.png");
+                CharsetPngCodec.ExportPng(charset, png, guide);
+
+                // Re-importing the unedited atlas must rebuild the exact same bytes (every glyph unchanged).
+                CharsetPngCodec.ImportPng(charset, png);
+
+                Assert.Equal(before.Length, charset.RawContent.Length);
+                Assert.True(before.SequenceEqual(charset.RawContent),
+                    "no-op CHAR export/import changed the charset bytes");
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+}

--- a/ScummEditor.UnitTests/V7CharsetTests.cs
+++ b/ScummEditor.UnitTests/V7CharsetTests.cs
@@ -57,6 +57,17 @@ namespace ScummEditor.UnitTests
                 string guide = Path.Combine(dir, "charset.guide.png");
                 CharsetPngCodec.ExportPng(charset, png, guide);
 
+                // The editable atlas must carry the gutter grid (index 255 in each cell's column 0), like the
+                // .NUT atlas, so the two font exports look the same - and it must stay re-importable.
+                using (var atlas = (System.Drawing.Bitmap)System.Drawing.Image.FromFile(png))
+                {
+                    Assert.True(IndexedImageHelper.IsIndexed(atlas), "CHAR atlas is not an indexed PNG");
+                    byte[,] px = IndexedImageHelper.GetIndexMatrix(atlas);
+                    bool hasGrid = false;
+                    for (int y = 0; y < px.GetLength(1) && !hasGrid; y++) if (px[0, y] == 255) hasGrid = true;
+                    Assert.True(hasGrid, "CHAR atlas has no grid line in the gutter");
+                }
+
                 // Re-importing the unedited atlas must rebuild the exact same bytes (every glyph unchanged).
                 CharsetPngCodec.ImportPng(charset, png);
 

--- a/ScummEditor.UnitTests/V7CostumeTests.cs
+++ b/ScummEditor.UnitTests/V7CostumeTests.cs
@@ -232,6 +232,30 @@ namespace ScummEditor.UnitTests
             }
         }
 
+        /// <summary>
+        /// ScriptPaletteScanner finds a literal setCurrentPalette(roomN) - pushByte/pushWord then roomOps
+        /// (0x9C) + sub-op 213 - and ignores non-literal (variable) pushes. Pure synthetic bytecode.
+        /// </summary>
+        [Fact]
+        public void ScriptPaletteScannerFindsLiteralSetCurrentPalette()
+        {
+            // pushByte 5; roomOps; SO_ROOM_NEW_PALETTE  -> room 5
+            Assert.Equal(new[] { 5 }, ScriptPaletteScanner.FindCurrentPaletteRooms(new byte[] { 0x00, 5, 0x9C, 213 }, 0).ToArray());
+
+            // pushWord 300; roomOps; SO_ROOM_NEW_PALETTE -> room 300 (0x012C)
+            Assert.Equal(new[] { 300 }, ScriptPaletteScanner.FindCurrentPaletteRooms(new byte[] { 0x01, 0x2C, 0x01, 0x9C, 213 }, 0).ToArray());
+
+            // pushByteVar 5 (0x02) is NOT a literal -> nothing recovered
+            Assert.Empty(ScriptPaletteScanner.FindCurrentPaletteRooms(new byte[] { 0x02, 5, 0x9C, 213 }, 0).ToArray());
+
+            // roomOps with a different sub-op (not 213) -> nothing
+            Assert.Empty(ScriptPaletteScanner.FindCurrentPaletteRooms(new byte[] { 0x00, 5, 0x9C, 175 }, 0).ToArray());
+
+            // honours startOffset (skip a leading id byte) and finds two references
+            int[] two = ScriptPaletteScanner.FindCurrentPaletteRooms(new byte[] { 0xFF, 0x00, 7, 0x9C, 213, 0x00, 9, 0x9C, 213 }, 1).ToArray();
+            Assert.Equal(new[] { 7, 9 }, two);
+        }
+
         private static bool MatricesEqual(byte[,] a, byte[,] b)
         {
             if (a.GetLength(0) != b.GetLength(0) || a.GetLength(1) != b.GetLength(1)) return false;

--- a/ScummEditor.UnitTests/V7CostumeTests.cs
+++ b/ScummEditor.UnitTests/V7CostumeTests.cs
@@ -257,6 +257,93 @@ namespace ScummEditor.UnitTests
             Assert.Equal(new[] { 7, 9 }, two);
         }
 
+        /// <summary>ImageInfo parses the AKOS batch filename "Room#i Akos#j Cel#k" to ImageType.AkosCostume.</summary>
+        [Fact]
+        public void ImageInfoParsesAkosCostumeFilename()
+        {
+            var akos = new ImageInfo("Room#5 Akos#3 Cel#7.png");
+            Assert.Equal(ImageType.AkosCostume, akos.ImageType);
+            Assert.Equal(5, akos.RoomIndex);
+            Assert.Equal(3, akos.AkosIndex);
+            Assert.Equal(7, akos.CelIndex);
+
+            // a v5/v6 COST costume name is still parsed as the (different) Costume type
+            var cost = new ImageInfo("Room#2 Costume#1 FrameIndex#4.png");
+            Assert.Equal(ImageType.Costume, cost.ImageType);
+        }
+
+        /// <summary>
+        /// Batch export/import round-trip for v7 AKOS costumes: export every cel to PNG (Costumes-only),
+        /// then import the whole folder back and confirm it re-encodes without errors and a sample cel
+        /// still decodes identically. Exercises the AKOS export loop, the "Room#i Akos#j Cel#k" filename
+        /// convention, the import dispatch and the cel splice end-to-end through ScummV5V6GraphicsBatch.
+        /// </summary>
+        [SkippableFact]
+        public void AkosBatchExportImportRoundTrips()
+        {
+            Skip.If(GameLibrary.Folder(GameLibrary.FullThrottle) == null, "not present: " + GameLibrary.FullThrottle);
+            ScummGameData game = GameLibrary.Load(GameLibrary.FullThrottle);
+
+            // A sample cel of EACH codec (1 BYLE-RLE, 5 BOMP, 16 MAJMIN) to pixel-verify across the
+            // round-trip - so the batch PNG serialization is checked for every codec, not just codec 1.
+            var sampleAkos = new Dictionary<int, BlockBase>();
+            var sampleCel = new Dictionary<int, int>();
+            var sampleBefore = new Dictionary<int, byte[,]>();
+            foreach (DiskBlock disk in game.DataFile.GetLFLFs())
+            {
+                foreach (BlockBase child in disk.Childrens)
+                {
+                    if (child.BlockType != "AKOS") continue;
+                    int codec = AkosImageDecoder.GetCodec(child);
+                    if ((codec != 1 && codec != 5 && codec != 16) || sampleBefore.ContainsKey(codec)) continue;
+
+                    int cels = AkosImageDecoder.GetCelCount(child);
+                    for (int c = 0; c < cels; c++)
+                    {
+                        byte[,] idx = AkosImageDecoder.DecodeCelIndices(child, c);
+                        if (idx != null && idx.GetLength(0) * idx.GetLength(1) > 100)
+                        {
+                            sampleAkos[codec] = child; sampleCel[codec] = c; sampleBefore[codec] = idx;
+                            break;
+                        }
+                    }
+                }
+                if (sampleBefore.Count == 3) break;
+            }
+            Assert.True(sampleBefore.ContainsKey(1) && sampleBefore.ContainsKey(5) && sampleBefore.ContainsKey(16),
+                "did not find a sample cel for each codec 1/5/16");
+
+            string dir = Path.Combine(Path.GetTempPath(), "v7akosbatch_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                var options = new ScummV5V6GraphicsBatch.ExportOptions
+                {
+                    Backgrounds = false, Objects = false, BackgroundZPlanes = false, ObjectZPlanes = false, Costumes = true,
+                };
+                int exported = ScummV5V6GraphicsBatch.Export(game.DataFile, dir, options, null);
+                Assert.True(exported > 500, "too few AKOS cels exported: " + exported);
+
+                string[] pngs = Directory.GetFiles(dir, "*.png");
+                Assert.All(pngs, p => Assert.Contains("Akos#", Path.GetFileName(p)));
+
+                ScummV5V6GraphicsBatch.ImportReport report = ScummV5V6GraphicsBatch.Import(game.DataFile, dir, null);
+                Assert.True(report.Errors.Count == 0, "import errors: " + string.Join(" | ", report.Errors.Take(5)));
+                Assert.Equal(report.Found, report.Imported);
+
+                foreach (int codec in new[] { 1, 5, 16 })
+                {
+                    byte[,] after = AkosImageDecoder.DecodeCelIndices(sampleAkos[codec], sampleCel[codec]);
+                    Assert.True(after != null && MatricesEqual(sampleBefore[codec], after),
+                        "codec " + codec + " sample cel changed after batch round-trip");
+                }
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
         private static bool MatricesEqual(byte[,] a, byte[,] b)
         {
             if (a.GetLength(0) != b.GetLength(0) || a.GetLength(1) != b.GetLength(1)) return false;

--- a/ScummEditor.UnitTests/V7CostumeTests.cs
+++ b/ScummEditor.UnitTests/V7CostumeTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// SCUMM v7 (The Dig, Full Throttle) AKOS costumes: each costume's cels are decoded from its AKOS
+    /// sub-blocks (AKHD/AKOF/AKCI/AKCD/AKPL/RGBS). The Dig and Full Throttle use cel codec 1 (BYLE RLE,
+    /// the v5/v6 column-RLE scheme). This proves the AKOS cels decode to bitmaps without errors.
+    /// </summary>
+    public class V7CostumeTests
+    {
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void AkosCostumeCelsDecode(string path)
+        {
+            Skip.If(GameLibrary.Folder(path) == null, "not present: " + path);
+            ScummGameData game = GameLibrary.Load(path);
+
+            int akosCount = 0, totalCels = 0, decoded = 0, codec1 = 0;
+            var errors = new List<string>();
+
+            foreach (DiskBlock disk in game.DataFile.GetLFLFs())
+            {
+                foreach (BlockBase child in disk.Childrens)
+                {
+                    if (child.BlockType != "AKOS") continue;
+                    akosCount++;
+                    if (AkosImageDecoder.GetCodec(child) == 1) codec1++;
+
+                    int cels = AkosImageDecoder.GetCelCount(child);
+                    for (int i = 0; i < cels; i++)
+                    {
+                        totalCels++;
+                        try
+                        {
+                            using (Bitmap bmp = AkosImageDecoder.DecodeCel(child, i))
+                            {
+                                if (bmp != null) decoded++;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            if (errors.Count < 10) errors.Add("akos#" + akosCount + " cel#" + i + ": " + ex.GetType().Name + " " + ex.Message);
+                        }
+                    }
+                }
+            }
+
+            Assert.True(akosCount > 5, "too few AKOS costumes found: " + akosCount);
+            Assert.True(codec1 > 0, "no codec-1 AKOS costumes found");
+            Assert.True(totalCels > 50, "too few cels: " + totalCels);
+            Assert.True(errors.Count == 0, "cel decode errors:\n" + string.Join("\n", errors));
+            Assert.True(decoded > 50, string.Format("only {0}/{1} cels decoded", decoded, totalCels));
+        }
+    }
+}

--- a/ScummEditor.UnitTests/V7CostumeTests.cs
+++ b/ScummEditor.UnitTests/V7CostumeTests.cs
@@ -108,12 +108,12 @@ namespace ScummEditor.UnitTests
         }
 
         /// <summary>
-        /// AKOS cel ENCODER round-trip for codec 1 (BYLE RLE) and codec 5 (BOMP): decoding a cel to its
-        /// index matrix, re-encoding it with AkosImageEncoder.ReplaceCel (a no-op edit) and decoding again
-        /// must reproduce the exact same indices. This exercises both encoders AND the AKCD/AKOF splice (the
-        /// re-encoded run-length usually has a different byte length, so the offset table must be fixed up
+        /// AKOS cel ENCODER round-trip for codec 1 (BYLE RLE), codec 5 (BOMP) and codec 16 (MAJMIN): decoding
+        /// a cel to its index matrix, re-encoding it with AkosImageEncoder.ReplaceCel (a no-op edit) and
+        /// decoding again must reproduce the exact same indices. This exercises all three encoders AND the
+        /// AKCD/AKOF splice (the re-encoded length usually differs, so the offset table must be fixed up
         /// correctly). Edits are applied sequentially per costume, so a wrong offset fix corrupts later cels
-        /// and fails here. (Codec 16 / MAJMIN is not encodable yet, so it is skipped.)
+        /// and fails here.
         /// </summary>
         [SkippableTheory]
         [InlineData(GameLibrary.TheDig)]
@@ -133,7 +133,7 @@ namespace ScummEditor.UnitTests
                 {
                     if (child.BlockType != "AKOS") continue;
                     int codec = AkosImageDecoder.GetCodec(child);
-                    if (codec != 1 && codec != 5) continue;
+                    if (codec != 1 && codec != 5 && codec != 16) continue;
                     if (testedByCodec.GetValueOrDefault(codec) >= 150) continue; // enough of this codec
 
                     int cels = AkosImageDecoder.GetCelCount(child);
@@ -158,6 +158,7 @@ namespace ScummEditor.UnitTests
             Assert.True(mismatches.Count == 0, "encode round-trip changed pixels for: " + string.Join(", ", mismatches));
             Assert.True(testedByCodec.GetValueOrDefault(1) > 20, "too few codec-1 cels exercised: " + testedByCodec.GetValueOrDefault(1));
             Assert.True(testedByCodec.GetValueOrDefault(5) > 20, "too few codec-5 cels exercised: " + testedByCodec.GetValueOrDefault(5));
+            Assert.True(testedByCodec.GetValueOrDefault(16) > 20, "too few codec-16 cels exercised: " + testedByCodec.GetValueOrDefault(16));
         }
 
         /// <summary>

--- a/ScummEditor.UnitTests/V7CostumeTests.cs
+++ b/ScummEditor.UnitTests/V7CostumeTests.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
+using System.Linq;
+using ScummEditor.Engine;
 using ScummEditor.Engine.Encoders;
 using ScummEditor.Engine.Structures;
 using ScummEditor.Engine.Structures.DataFile;
@@ -102,6 +105,140 @@ namespace ScummEditor.UnitTests
             }
             Assert.True(richestCodec1 > 32,
                 "codec-1 64-colour cels never exceed 32 distinct colours - the 64 -> 6/2 bit split is wrong (only 32 palette indices reachable)");
+        }
+
+        /// <summary>
+        /// AKOS cel ENCODER round-trip for codec 1 (BYLE RLE) and codec 5 (BOMP): decoding a cel to its
+        /// index matrix, re-encoding it with AkosImageEncoder.ReplaceCel (a no-op edit) and decoding again
+        /// must reproduce the exact same indices. This exercises both encoders AND the AKCD/AKOF splice (the
+        /// re-encoded run-length usually has a different byte length, so the offset table must be fixed up
+        /// correctly). Edits are applied sequentially per costume, so a wrong offset fix corrupts later cels
+        /// and fails here. (Codec 16 / MAJMIN is not encodable yet, so it is skipped.)
+        /// </summary>
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void AkosCelEncodeRoundTrips(string path)
+        {
+            Skip.If(GameLibrary.Folder(path) == null, "not present: " + path);
+            ScummGameData game = GameLibrary.Load(path);
+
+            var testedByCodec = new Dictionary<int, int>();
+            var mismatches = new List<string>();
+            int total = 0;
+
+            foreach (DiskBlock disk in game.DataFile.GetLFLFs())
+            {
+                foreach (BlockBase child in disk.Childrens)
+                {
+                    if (child.BlockType != "AKOS") continue;
+                    int codec = AkosImageDecoder.GetCodec(child);
+                    if (codec != 1 && codec != 5) continue;
+                    if (testedByCodec.GetValueOrDefault(codec) >= 150) continue; // enough of this codec
+
+                    int cels = AkosImageDecoder.GetCelCount(child);
+                    for (int i = 0; i < cels; i++)
+                    {
+                        byte[,] before = AkosImageDecoder.DecodeCelIndices(child, i);
+                        if (before == null) continue; // empty/placeholder cel
+
+                        AkosImageEncoder.ReplaceCel(child, i, before);
+                        byte[,] after = AkosImageDecoder.DecodeCelIndices(child, i);
+
+                        testedByCodec[codec] = testedByCodec.GetValueOrDefault(codec) + 1;
+                        total++;
+                        if (after == null || !MatricesEqual(before, after))
+                        {
+                            if (mismatches.Count < 10) mismatches.Add("codec " + codec + " cel #" + i + " (" + before.GetLength(0) + "x" + before.GetLength(1) + ")");
+                        }
+                    }
+                }
+            }
+
+            Assert.True(mismatches.Count == 0, "encode round-trip changed pixels for: " + string.Join(", ", mismatches));
+            Assert.True(testedByCodec.GetValueOrDefault(1) > 20, "too few codec-1 cels exercised: " + testedByCodec.GetValueOrDefault(1));
+            Assert.True(testedByCodec.GetValueOrDefault(5) > 20, "too few codec-5 cels exercised: " + testedByCodec.GetValueOrDefault(5));
+        }
+
+        /// <summary>
+        /// End-to-end write-back: import (no-op re-encode) a codec-1 cel, SaveDataToDisk to a temp copy,
+        /// reload from disk and decode the same cel - it must match. This proves the edited AKOS serializes
+        /// into a valid game file (AKOS/sub-block sizes, LFLF/LECF positions and the index DCOS offset all
+        /// recomputed), not just that the in-memory splice is right.
+        /// </summary>
+        [SkippableFact]
+        public void AkosImportSurvivesSaveAndReload()
+        {
+            string src = GameLibrary.Folder(GameLibrary.FullThrottle);
+            Skip.If(src == null, "not present: " + GameLibrary.FullThrottle);
+
+            string dir = Path.Combine(Path.GetTempPath(), "v7akossave_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                // Only the index + data containers (.LA0/.LA1) are needed to detect, load and save back.
+                foreach (string f in Directory.GetFiles(src, "*.LA?"))
+                {
+                    File.Copy(f, Path.Combine(dir, Path.GetFileName(f)));
+                }
+
+                GameInfo info = Functions.FindScummGameInFolder(dir);
+                Assert.NotNull(info);
+                Assert.Equal(7, info.ScummVersion);
+                ScummGameData game = ScummGameData.LoadFromGameInfo(info);
+
+                // Locate the first codec-1 AKOS cel with real content.
+                int lflfIndex = -1, akosPos = -1, celIndex = -1;
+                byte[,] expected = null;
+                var lflfs = game.DataFile.GetLFLFs();
+                for (int li = 0; li < lflfs.Count && expected == null; li++)
+                {
+                    int pos = -1;
+                    foreach (BlockBase child in lflfs[li].Childrens)
+                    {
+                        if (child.BlockType != "AKOS") continue;
+                        pos++;
+                        if (AkosImageDecoder.GetCodec(child) != 1) continue;
+                        int cels = AkosImageDecoder.GetCelCount(child);
+                        for (int c = 0; c < cels; c++)
+                        {
+                            byte[,] idx = AkosImageDecoder.DecodeCelIndices(child, c);
+                            if (idx != null && idx.GetLength(0) * idx.GetLength(1) > 100)
+                            {
+                                lflfIndex = li; akosPos = pos; celIndex = c; expected = idx;
+                                AkosImageEncoder.ReplaceCel(child, c, idx); // no-op re-encode
+                                break;
+                            }
+                        }
+                        if (expected != null) break;
+                    }
+                }
+                Assert.True(expected != null, "no codec-1 cel found to edit");
+
+                game.SaveDataToDisk();
+
+                // Reload from the saved temp copy and decode the same cel.
+                ScummGameData reloaded = ScummGameData.LoadFromGameInfo(Functions.FindScummGameInFolder(dir));
+                DiskBlock disk = reloaded.DataFile.GetLFLFs()[lflfIndex];
+                BlockBase akos2 = disk.Childrens.Where(c => c.BlockType == "AKOS").ElementAt(akosPos);
+                byte[,] actual = AkosImageDecoder.DecodeCelIndices(akos2, celIndex);
+
+                Assert.True(actual != null && MatricesEqual(expected, actual),
+                    "edited cel did not survive save+reload");
+            }
+            finally
+            {
+                try { Directory.Delete(dir, true); } catch { }
+            }
+        }
+
+        private static bool MatricesEqual(byte[,] a, byte[,] b)
+        {
+            if (a.GetLength(0) != b.GetLength(0) || a.GetLength(1) != b.GetLength(1)) return false;
+            for (int x = 0; x < a.GetLength(0); x++)
+                for (int y = 0; y < a.GetLength(1); y++)
+                    if (a[x, y] != b[x, y]) return false;
+            return true;
         }
 
         /// <summary>Counts distinct ARGB colours in the bitmap, stopping once <paramref name="cap"/> is reached.</summary>

--- a/ScummEditor.UnitTests/V7CostumeTests.cs
+++ b/ScummEditor.UnitTests/V7CostumeTests.cs
@@ -23,7 +23,9 @@ namespace ScummEditor.UnitTests
             Skip.If(GameLibrary.Folder(path) == null, "not present: " + path);
             ScummGameData game = GameLibrary.Load(path);
 
-            int akosCount = 0, totalCels = 0, decoded = 0, codec1 = 0;
+            int akosCount = 0, totalCels = 0, decoded = 0;
+            var celsByCodec = new Dictionary<int, int>();
+            var decodedByCodec = new Dictionary<int, int>();
             var errors = new List<string>();
 
             foreach (DiskBlock disk in game.DataFile.GetLFLFs())
@@ -32,32 +34,89 @@ namespace ScummEditor.UnitTests
                 {
                     if (child.BlockType != "AKOS") continue;
                     akosCount++;
-                    if (AkosImageDecoder.GetCodec(child) == 1) codec1++;
+                    int codec = AkosImageDecoder.GetCodec(child);
 
                     int cels = AkosImageDecoder.GetCelCount(child);
                     for (int i = 0; i < cels; i++)
                     {
                         totalCels++;
+                        celsByCodec[codec] = celsByCodec.GetValueOrDefault(codec) + 1;
                         try
                         {
                             using (Bitmap bmp = AkosImageDecoder.DecodeCel(child, i))
                             {
-                                if (bmp != null) decoded++;
+                                if (bmp != null)
+                                {
+                                    decoded++;
+                                    decodedByCodec[codec] = decodedByCodec.GetValueOrDefault(codec) + 1;
+                                }
                             }
                         }
                         catch (Exception ex)
                         {
-                            if (errors.Count < 10) errors.Add("akos#" + akosCount + " cel#" + i + ": " + ex.GetType().Name + " " + ex.Message);
+                            if (errors.Count < 10) errors.Add("akos#" + akosCount + " cel#" + i + " codec" + codec + ": " + ex.GetType().Name + " " + ex.Message);
                         }
                     }
                 }
             }
 
             Assert.True(akosCount > 5, "too few AKOS costumes found: " + akosCount);
-            Assert.True(codec1 > 0, "no codec-1 AKOS costumes found");
             Assert.True(totalCels > 50, "too few cels: " + totalCels);
             Assert.True(errors.Count == 0, "cel decode errors:\n" + string.Join("\n", errors));
-            Assert.True(decoded > 50, string.Format("only {0}/{1} cels decoded", decoded, totalCels));
+
+            // The Dig and Full Throttle use three cel codecs (1 = BYLE RLE, 5 = BOMP, 16 = MAJMIN); each
+            // must be present and decode every cel. This guards the regression where only codec 1 was
+            // handled, so codec 5/16 costumes (e.g. Full Throttle LFLF 10 and 19) showed blank.
+            foreach (int codec in new[] { 1, 5, 16 })
+            {
+                int cels = celsByCodec.GetValueOrDefault(codec);
+                int ok = decodedByCodec.GetValueOrDefault(codec);
+                Assert.True(cels > 0, "no codec-" + codec + " cels found");
+                Assert.True(ok == cels, string.Format("codec {0}: only {1}/{2} cels decoded", codec, ok, cels));
+            }
+            Assert.True(decoded == totalCels, string.Format("only {0}/{1} cels decoded overall", decoded, totalCels));
+
+            // Pixel-correctness guard for the codec-1 BYLE-RLE bit split. A 64-colour AKPL costume uses 6
+            // colour bits, so its cels can reach palette indices > 31 (=> > 32 distinct colours). The old
+            // binary 5/3 split could only reach indices 0-31, capping distinct colours at 32, so this fails
+            // unless the 64 -> 6/2 split is correct. (Decode-returns-non-null alone never caught this.)
+            int richestCodec1 = 0;
+            foreach (DiskBlock disk in game.DataFile.GetLFLFs())
+            {
+                foreach (BlockBase child in disk.Childrens)
+                {
+                    if (child.BlockType != "AKOS") continue;
+                    if (AkosImageDecoder.GetCodec(child) != 1 || AkosImageDecoder.GetColorCount(child) != 64) continue;
+
+                    int n = AkosImageDecoder.GetCelCount(child);
+                    for (int i = 0; i < n && richestCodec1 <= 32; i++)
+                    {
+                        using (Bitmap bmp = AkosImageDecoder.DecodeCel(child, i))
+                        {
+                            if (bmp != null) richestCodec1 = Math.Max(richestCodec1, DistinctColors(bmp, 40));
+                        }
+                    }
+                    if (richestCodec1 > 32) break;
+                }
+                if (richestCodec1 > 32) break;
+            }
+            Assert.True(richestCodec1 > 32,
+                "codec-1 64-colour cels never exceed 32 distinct colours - the 64 -> 6/2 bit split is wrong (only 32 palette indices reachable)");
+        }
+
+        /// <summary>Counts distinct ARGB colours in the bitmap, stopping once <paramref name="cap"/> is reached.</summary>
+        private static int DistinctColors(Bitmap bmp, int cap)
+        {
+            var seen = new HashSet<int>();
+            for (int y = 0; y < bmp.Height; y++)
+            {
+                for (int x = 0; x < bmp.Width; x++)
+                {
+                    seen.Add(bmp.GetPixel(x, y).ToArgb());
+                    if (seen.Count >= cap) return seen.Count;
+                }
+            }
+            return seen.Count;
         }
     }
 }

--- a/ScummEditor.UnitTests/V7FoundationTests.cs
+++ b/ScummEditor.UnitTests/V7FoundationTests.cs
@@ -1,0 +1,178 @@
+using System.IO;
+using System.Linq;
+using ScummEditor.Engine;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.IndexFile;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// SCUMM v7 (The Dig, Full Throttle) foundation: detection, container read, and a byte-identical
+    /// load -> recompute -> save round-trip of both the GAME.LA0 index and the GAME.LA1 data file. The
+    /// round-trip exercises the whole offset machinery (CalculateBlockSize / CalculateOffsets /
+    /// FixUpIndexOffsets) and proves the v7 reader/writer is faithful before any block gets typed
+    /// support. A separate check confirms the index directories link to their data blocks (so edits
+    /// that move blocks will relocate the right entries), including the AKOS-as-costume mapping.
+    /// </summary>
+    public class V7FoundationTests
+    {
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig, 7, ScummGame.TheDig, "The Dig")]
+        [InlineData(GameLibrary.TheDigPortuguese, 7, ScummGame.TheDig, "The Dig")]
+        [InlineData(GameLibrary.FullThrottle, 7, ScummGame.FullThrottle, "Full Throttle")]
+        [InlineData(GameLibrary.FullThrottlePortuguese, 7, ScummGame.FullThrottle, "Full Throttle")]
+        public void DetectsV7Games(string relativePath, int version, ScummGame expectedGame, string expectedName)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "GameData folder not present: " + relativePath);
+
+            GameInfo info = GameLibrary.Detect(relativePath);
+            Assert.NotNull(info);
+            Assert.Equal(version, info.ScummVersion);
+            Assert.Equal(expectedGame, info.LoadedGame);
+            Assert.Equal(expectedName, ScummGameNames.DisplayName(info.LoadedGame));
+            Assert.False(info.Xored);
+            Assert.Equal(0, info.XorKey);
+            Assert.Equal(0, info.IndexXorKey);
+            Assert.False(info.UsesSmallHeader);
+        }
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void LoadsContainerTree(string relativePath)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "GameData folder not present: " + relativePath);
+
+            ScummGameData game = GameLibrary.Load(relativePath);
+            Assert.NotNull(game);
+            Assert.Equal("LECF", game.DataFile.BlockType);
+
+            // Every room is an LFLF disk block; there must be a LOFF table and at least one room.
+            Assert.NotNull(game.DataFile.GetLOFF());
+            Assert.True(game.DataFile.GetLFLFs().Count > 0, "no LFLF room blocks parsed");
+
+            // The index is the v7 layout (raw RNAM/MAXS/DOBJ/AARY/ANAM + typed directories).
+            var index = game.IndexFile as ScummV7IndexFile;
+            Assert.NotNull(index);
+            Assert.NotNull(index.RawANAM); // v7-only audio-names block
+            Assert.NotNull(index.DROO);
+            Assert.True(index.DROO.Rooms.Count > 0, "DROO is empty");
+        }
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void RoundTripIsByteIdentical(string relativePath)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "GameData folder not present: " + relativePath);
+
+            GameInfo info = GameLibrary.Detect(relativePath);
+            Assert.NotNull(info);
+            ScummGameData game = ScummGameData.LoadFromGameInfo(info);
+
+            byte[] originalIndex = File.ReadAllBytes(info.IndexFile);
+            byte[] originalData = File.ReadAllBytes(info.DataFile);
+
+            // Recompute sizes/offsets exactly as the on-disk save would (no edits applied).
+            game.PostProcessChanges();
+
+            byte[] savedIndex = SaveToBytes(s => game.IndexFile.SaveToBinaryWriter(s));
+            byte[] savedData = SaveToBytes(s => game.DataFile.SaveToBinaryWriter(s));
+
+            AssertBytesIdentical(originalIndex, savedIndex, "index (.LA0)");
+            AssertBytesIdentical(originalData, savedData, "data (.LA1)");
+        }
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void IndexDirectoriesLinkToDataBlocks(string relativePath)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "GameData folder not present: " + relativePath);
+
+            ScummGameData game = GameLibrary.Load(relativePath);
+            var index = (ScummV7IndexFile)game.IndexFile;
+
+            // Linking sets ItemId on every directory entry that found its data block. If the v7 offset
+            // convention (relative to ROOM) or the AKOS-as-costume mapping were wrong, nothing would link
+            // and edits could not relocate the right entries. Every game ships scripts and costumes.
+            Assert.True(LinkedCount(index.DSCR) > 0, "no script (DSCR) entry linked to a SCRP block");
+            Assert.True(LinkedCount(index.DCOS) > 0, "no costume (DCOS) entry linked to an AKOS block");
+        }
+
+        [SkippableFact]
+        public void RejectsV8CurseOfMonkeyIsland()
+        {
+            Skip.If(GameLibrary.Folder(GameLibrary.CurseOfMonkeyIsland) == null, "COMI (v8) not present");
+
+            // The Curse of Monkey Island is SCUMM v8 (unsupported) but ships the same COMI.LA0/COMI.LA1
+            // naming and the same plain RNAM/LECF magic as v7, so the content checks pass. The v7 detector
+            // must NOT claim it: it used to be mislabelled "The Dig" (v7) and then crashed on load (the v8
+            // index has a DRSC block and a larger MAXS the v7 reader cannot parse).
+            GameInfo info = Functions.FindScummGameInFolder(GameLibrary.Folder(GameLibrary.CurseOfMonkeyIsland));
+            Assert.NotEqual(7, info.ScummVersion);
+            Assert.NotEqual(ScummGame.TheDig, info.LoadedGame);
+            Assert.NotEqual(ScummGame.FullThrottle, info.LoadedGame);
+        }
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void DirectoryLinkingIsRoomScoped(string relativePath)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "GameData folder not present: " + relativePath);
+
+            var index = (ScummV7IndexFile)GameLibrary.Load(relativePath).IndexFile;
+
+            // Every directory ItemId must belong to entries of a SINGLE room. Before the room-scoped
+            // linking fix, resources at the same relative offset in different rooms cross-linked (the last
+            // room processed overwrote the rest), so a size-changing edit relocated the wrong entry. The
+            // Dig's DCOS and Full Throttle's DSOU contain such colliding offsets, so this catches it.
+            AssertNoCrossRoomLink(index.DSCR, "DSCR");
+            AssertNoCrossRoomLink(index.DSOU, "DSOU");
+            AssertNoCrossRoomLink(index.DCOS, "DCOS");
+            AssertNoCrossRoomLink(index.DCHR, "DCHR");
+        }
+
+        private static void AssertNoCrossRoomLink(DirectoryOfItems directory, string name)
+        {
+            foreach (var group in directory.Rooms.Where(r => !string.IsNullOrEmpty(r.ItemId)).GroupBy(r => r.ItemId))
+            {
+                int distinctRooms = group.Select(r => r.Number).Distinct().Count();
+                Assert.True(distinctRooms == 1,
+                    string.Format("{0}: one ItemId links entries from {1} different rooms (cross-room linking)", name, distinctRooms));
+            }
+        }
+
+        private static int LinkedCount(DirectoryOfItems directory)
+        {
+            return directory.Rooms.Count(r => !string.IsNullOrEmpty(r.ItemId));
+        }
+
+        private static byte[] SaveToBytes(System.Action<Stream> save)
+        {
+            using (var stream = new MemoryStream())
+            {
+                save(stream);
+                return stream.ToArray();
+            }
+        }
+
+        private static void AssertBytesIdentical(byte[] expected, byte[] actual, string label)
+        {
+            if (expected.Length != actual.Length)
+            {
+                Assert.Fail(string.Format("{0}: length differs - original {1}, rebuilt {2}", label, expected.Length, actual.Length));
+            }
+            for (int i = 0; i < expected.Length; i++)
+            {
+                if (expected[i] != actual[i])
+                {
+                    Assert.Fail(string.Format("{0}: first byte differs at offset {1} - original 0x{2:X2}, rebuilt 0x{3:X2}",
+                        label, i, expected[i], actual[i]));
+                }
+            }
+        }
+    }
+}

--- a/ScummEditor.UnitTests/V7ImageTests.cs
+++ b/ScummEditor.UnitTests/V7ImageTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// SCUMM v7 (The Dig, Full Throttle) images: the RMIM/OBIM/PALS blocks are typed (Phase C), and the
+    /// SMAP strip codec, z-planes and APAL palette are the same as v5/v6 - only the headers (RMHD, IMHD)
+    /// carry the v7 layout. These tests confirm room backgrounds and object images decode, and that the
+    /// codec round-trips an image's pixels (decode -> encode -> decode is identical), so editing works.
+    /// </summary>
+    public class V7ImageTests
+    {
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void RoomBackgroundsAndObjectsDecode(string path)
+        {
+            Skip.If(GameLibrary.Folder(path) == null, "not present: " + path);
+            ScummGameData game = GameLibrary.Load(path);
+
+            int backgrounds = 0, objects = 0, zplanes = 0;
+            var errors = new List<string>();
+
+            List<DiskBlock> disks = game.DataFile.GetLFLFs();
+            for (int i = 0; i < disks.Count; i++)
+            {
+                RoomBlock room = disks[i].GetROOM();
+                try
+                {
+                    Bitmap bg = ImageResourceCodec.Decode(room, null, ImageType.Background, 0, 0, 0, 0, false);
+                    if (bg != null) { backgrounds++; bg.Dispose(); }
+
+                    List<ZPlane> bgz = room.GetRMIM().GetIM00().GetZPlanes();
+                    for (int z = 0; z < bgz.Count; z++)
+                    {
+                        Bitmap zp = ImageResourceCodec.Decode(room, null, ImageType.ZPlane, 0, 0, z, 0, false);
+                        if (zp != null) { zplanes++; zp.Dispose(); }
+                    }
+
+                    List<ObjectImage> obims = room.GetOBIMs();
+                    for (int j = 0; j < obims.Count; j++)
+                    {
+                        List<ImageData> imgs = obims[j].GetIMxx();
+                        for (int k = 0; k < imgs.Count; k++)
+                        {
+                            Bitmap img = ImageResourceCodec.Decode(room, null, ImageType.Object, j, k, 0, 0, false);
+                            if (img != null) { objects++; img.Dispose(); }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errors.Add("room " + i + ": " + ex.GetType().Name + " " + ex.Message);
+                }
+            }
+
+            Assert.True(errors.Count == 0, "decode errors:\n" + string.Join("\n", errors));
+            Assert.True(backgrounds >= 50, "too few room backgrounds decoded: " + backgrounds);
+            Assert.True(objects >= 20, "too few object images decoded: " + objects);
+        }
+
+        [SkippableFact]
+        public void BackgroundCodecRoundTripsPixels()
+        {
+            Skip.If(GameLibrary.Folder(GameLibrary.TheDig) == null, "The Dig not present");
+            ScummGameData game = GameLibrary.Load(GameLibrary.TheDig);
+
+            foreach (DiskBlock disk in game.DataFile.GetLFLFs())
+            {
+                RoomBlock room = disk.GetROOM();
+                Bitmap first = ImageResourceCodec.Decode(room, null, ImageType.Background, 0, 0, 0, 0, false);
+                if (first == null) continue;
+
+                byte[,] before = IndexedImageHelper.GetIndexMatrix(first);
+
+                // Re-encode the decoded image and decode again: a lossless codec yields identical indices.
+                ImageResourceCodec.Encode(room, null, ImageType.Background, 0, 0, 0, first, ImageEncoder.EncodeTypeSettings.AutoDetect);
+                first.Dispose();
+
+                Bitmap second = ImageResourceCodec.Decode(room, null, ImageType.Background, 0, 0, 0, 0, false);
+                Assert.NotNull(second);
+                byte[,] after;
+                using (second) after = IndexedImageHelper.GetIndexMatrix(second);
+
+                Assert.Equal(before.GetLength(0), after.GetLength(0));
+                Assert.Equal(before.GetLength(1), after.GetLength(1));
+                for (int x = 0; x < before.GetLength(0); x++)
+                    for (int y = 0; y < before.GetLength(1); y++)
+                        if (before[x, y] != after[x, y])
+                            Assert.Fail(string.Format("pixel ({0},{1}) differs after re-encode: {2} != {3}", x, y, before[x, y], after[x, y]));
+
+                return; // one decodable room is enough to prove the codec round-trips pixels
+            }
+
+            Assert.Fail("no decodable background found");
+        }
+
+        [SkippableFact]
+        public void GraphicsBatchExportImportRoundTrips()
+        {
+            Skip.If(GameLibrary.Folder(GameLibrary.TheDig) == null, "The Dig not present");
+            ScummGameData game = GameLibrary.Load(GameLibrary.TheDig);
+
+            string dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "v7_gfx_batch");
+            if (System.IO.Directory.Exists(dir)) System.IO.Directory.Delete(dir, true);
+            System.IO.Directory.CreateDirectory(dir);
+
+            var opt = new ScummV5V6GraphicsBatch.ExportOptions
+            { Backgrounds = true, Objects = true, Costumes = true, BackgroundZPlanes = true, ObjectZPlanes = true };
+
+            int exported = ScummV5V6GraphicsBatch.Export(game.DataFile, dir, opt, null, null);
+            Assert.True(exported >= 50, "too few images exported: " + exported);
+
+            // Re-import the editor's own export: backgrounds/objects/z-planes re-encode cleanly. v7 has no
+            // COST costumes (AKOS, Phase D), so none were exported and none are imported - no errors.
+            ScummV5V6GraphicsBatch.ImportReport report = ScummV5V6GraphicsBatch.Import(game.DataFile, dir, null);
+            Assert.True(report.Errors.Count == 0, "import errors:\n" + string.Join("\n", report.Errors));
+            Assert.True(report.Imported >= 50, "too few images imported: " + report.Imported);
+
+            // The edited game must recompute offsets and save without throwing.
+            Assert.Null(Record.Exception(() => game.PostProcessChanges()));
+
+            try { System.IO.Directory.Delete(dir, true); } catch { }
+        }
+    }
+}

--- a/ScummEditor.UnitTests/V7LanguageTests.cs
+++ b/ScummEditor.UnitTests/V7LanguageTests.cs
@@ -1,0 +1,104 @@
+using System.IO;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// SCUMM v7 language detection. v7 has no language field and its MD5 is not in the v2-v6 table, so the
+    /// detector reads the real translated text: The Dig's dialogue is in the external LANGUAGE.BND (whose
+    /// double-byte editions carry a CJK marker j/h/c), while Full Throttle keeps it in the container scripts.
+    /// These run on the real editions and assert the detected GameInfo.Language (set by RefineFromContent,
+    /// the same call the GUI makes after load).
+    /// </summary>
+    public class V7LanguageTests
+    {
+        [SkippableTheory]
+        // The Dig - dialogue in LANGUAGE.BND (Western word-heuristic) or its CJK marker; English ships no bundle.
+        [InlineData("ScummV7/Dig, The (1995)/DOS v1.0", ScummLanguage.English)]
+        [InlineData("ScummV7/Dig, The (1995)/Other Languages/Portuguese/CD", ScummLanguage.Portuguese)]
+        [InlineData("ScummV7/Dig, The (1995)/Other Languages/French/DOS CD", ScummLanguage.French)]
+        [InlineData("ScummV7/Dig, The (1995)/Other Languages/German/CD", ScummLanguage.German)]
+        [InlineData("ScummV7/Dig, The (1995)/Other Languages/Italian/DOS CD", ScummLanguage.Italian)]
+        [InlineData("ScummV7/Dig, The (1995)/Other Languages/Spanish/CD", ScummLanguage.Spanish)]
+        [InlineData("ScummV7/Dig, The (1995)/Other Languages/Chinese/CD", ScummLanguage.Chinese)]
+        [InlineData("ScummV7/Dig, The (1995)/Other Languages/Japanese/Windows", ScummLanguage.Japanese)]
+        [InlineData("ScummV7/Dig, The (1995)/Other Languages/Korean/Windows", ScummLanguage.Korean)]
+        // Full Throttle - dialogue in the container scripts (no bundle), incl. Spanish the .TRS could not call.
+        [InlineData("ScummV7/Full Throttle (1995)/DOS CD", ScummLanguage.English)]
+        [InlineData("ScummV7/Full Throttle (1995)/Other Languages/Portuguese/DOS CD", ScummLanguage.Portuguese)]
+        [InlineData("ScummV7/Full Throttle (1995)/Other Languages/French/DOS CD", ScummLanguage.French)]
+        [InlineData("ScummV7/Full Throttle (1995)/Other Languages/German/DOS CD", ScummLanguage.German)]
+        [InlineData("ScummV7/Full Throttle (1995)/Other Languages/Italian/DOS CD", ScummLanguage.Italian)]
+        [InlineData("ScummV7/Full Throttle (1995)/Other Languages/Spanish/DOS CD", ScummLanguage.Spanish)]
+        public void V7EditionLanguageIsDetected(string relativePath, ScummLanguage expected)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "not present: " + relativePath);
+
+            ScummGameData game = GameLibrary.Load(relativePath);
+            ScummLanguageDetector.RefineFromContent(game); // the GUI runs this right after load
+
+            Assert.Equal(expected, game.LoadedGameInfo.Language);
+        }
+
+        // ---- accent display via the DOS code page ----
+
+        [Theory]
+        [InlineData(850)]
+        [InlineData(860)]
+        public void DosCodePageRoundTripsEveryByte(int codePage)
+        {
+            // Display -> edit-encode must return every byte 0x00-0xFF unchanged, so an unedited localized
+            // string stays byte-identical when shown through the code page.
+            var chars = new char[256];
+            for (int i = 0; i < 256; i++) chars[i] = (char)i;
+            string latin1 = new string(chars);
+
+            string display = DosCodePageText.ToDisplay(latin1, codePage);
+            Assert.Equal(latin1, DosCodePageText.FromDisplay(display, codePage));
+        }
+
+        [Fact]
+        public void CodePageForMapsLanguagesToTheRightDosCodePage()
+        {
+            // SCUMM v7 uses CP850 for every Western edition, including Portuguese (verified vs the real PT data).
+            Assert.Equal(850, DosCodePageText.CodePageFor(ScummLanguage.Portuguese));
+            Assert.Equal(850, DosCodePageText.CodePageFor(ScummLanguage.English));
+            Assert.Equal(850, DosCodePageText.CodePageFor(ScummLanguage.French));
+            Assert.Equal(850, DosCodePageText.CodePageFor(ScummLanguage.Spanish));
+            Assert.Equal(0, DosCodePageText.CodePageFor(ScummLanguage.Chinese));   // CJK stays raw
+            Assert.Equal(0, DosCodePageText.CodePageFor(ScummLanguage.Unknown));
+        }
+
+        [Fact]
+        public void CodePageZeroLeavesTextRaw()
+        {
+            string s = "abcãÿ";
+            Assert.Equal(s, DosCodePageText.ToDisplay(s, 0));
+            Assert.Equal(s, DosCodePageText.FromDisplay(s, 0));
+        }
+
+        [SkippableFact]
+        public void PortugueseDigBundleRendersAccentsViaCp850()
+        {
+            string folder = GameLibrary.Folder(GameLibrary.TheDigPortuguese);
+            Skip.If(folder == null, "PT The Dig not present");
+
+            var bnd = new LanguageBundleFile(Path.Combine(folder, "LANGUAGE.BND"));
+            bnd.Load(File.ReadAllBytes(bnd.FilePath));
+
+            bool correctAccent = false;
+            foreach (LocalizedTextEntry e in bnd.Entries)
+            {
+                string display = DosCodePageText.ToDisplay(e.Text, 850);
+                // unedited text must round-trip byte-identically through the code page
+                Assert.Equal(e.Text, DosCodePageText.FromDisplay(display, 850));
+                // CP850 must yield the CORRECT Portuguese spelling (with the right "ã"), which CP860 mangles.
+                if (display.Contains("não alcanço") || display.Contains("compressão") || display.Contains("botão"))
+                    correctAccent = true;
+            }
+            Assert.True(correctAccent, "CP850 did not render the expected accented Portuguese (ã) from the PT bundle");
+        }
+    }
+}

--- a/ScummEditor.UnitTests/V7LocalizedSweepTests.cs
+++ b/ScummEditor.UnitTests/V7LocalizedSweepTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ScummEditor.Engine.Structures;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// Library-wide adversarial sweep: runs the real LanguageBundleFile / TrsFile code against EVERY
+    /// LANGUAGE.BND and .TRS in the whole v7 game library (all 24 editions, incl. the CJK bundles under
+    /// VIDEO/ and the Full Throttle per-scene files), not just the two Portuguese files the focused suite
+    /// covers. For each file it asserts: (1) a no-op BuildContent is byte-identical to the original; (2) an
+    /// export -> re-import-unchanged -> BuildContent is byte-identical; (3) a structural edit (prepend a
+    /// marker to the first entry) survives a rebuild+reload with the entry count and the neighbour entry
+    /// intact. Collects ALL failures before asserting so the report is exhaustive. Skips when the
+    /// (git-ignored) game library is absent.
+    /// </summary>
+    public class V7LocalizedSweepTests
+    {
+        private readonly ITestOutputHelper _out;
+        public V7LocalizedSweepTests(ITestOutputHelper output) { _out = output; }
+
+        private const string Marker = "ZZ9_EDIT_";
+
+        [SkippableFact]
+        public void SweepEveryLanguageBundle()
+        {
+            string root = GameLibrary.Folder("ScummV7");
+            Skip.If(root == null, "ScummV7 game library not present");
+
+            string[] files = Directory.GetFiles(root, "LANGUAGE.BND", SearchOption.AllDirectories);
+            Skip.If(files.Length == 0, "no LANGUAGE.BND found");
+
+            var failures = new List<string>();
+            int encoded = 0, plain = 0, totalEntries = 0;
+
+            foreach (string path in files.OrderBy(p => p))
+            {
+                string rel = path.Substring(root.Length + 1);
+                try
+                {
+                    var bnd = new LanguageBundleFile(path);
+                    bnd.Load(File.ReadAllBytes(path));
+                    if (bnd.Encoded) encoded++; else plain++;
+                    totalEntries += bnd.Entries.Count;
+
+                    if (!bnd.BuildContent().SequenceEqual(bnd.OriginalContent))
+                        failures.Add("[BND no-op build differs] " + rel);
+
+                    string dump = bnd.ExportToText();
+                    bnd.ImportFromText(dump);
+                    if (!bnd.BuildContent().SequenceEqual(bnd.OriginalContent))
+                        failures.Add("[BND export/import no-op differs] " + rel);
+
+                    EditCheck(rel, "BND", bnd.Entries, bnd.BuildContent, failures, b =>
+                    {
+                        var r = new LanguageBundleFile(path); r.Load(b); return r.Entries;
+                    });
+                }
+                catch (Exception ex)
+                {
+                    failures.Add("[BND THREW] " + rel + " : " + ex.GetType().Name + " " + ex.Message);
+                }
+            }
+
+            _out.WriteLine($"LANGUAGE.BND swept: {files.Length} files, {encoded} encoded / {plain} plain, {totalEntries} entries total");
+            Assert.True(failures.Count == 0, "Failures:\n" + string.Join("\n", failures));
+        }
+
+        [SkippableFact]
+        public void SweepEveryTrs()
+        {
+            string root = GameLibrary.Folder("ScummV7");
+            Skip.If(root == null, "ScummV7 game library not present");
+
+            string[] files = Directory.GetFiles(root, "*.TRS", SearchOption.AllDirectories);
+            Skip.If(files.Length == 0, "no .TRS found");
+
+            var failures = new List<string>();
+            int etrs = 0, plain = 0, noEntries = 0, totalEntries = 0;
+
+            foreach (string path in files.OrderBy(p => p))
+            {
+                string rel = path.Substring(root.Length + 1);
+                try
+                {
+                    var trs = new TrsFile(path);
+                    trs.Load(File.ReadAllBytes(path));
+                    if (trs.Encoded) etrs++; else plain++;
+                    if (trs.Entries.Count == 0) noEntries++;
+                    totalEntries += trs.Entries.Count;
+
+                    if (!trs.BuildContent().SequenceEqual(trs.OriginalContent))
+                        failures.Add("[TRS no-op build differs] " + rel);
+
+                    string dump = trs.ExportToText();
+                    trs.ImportFromText(dump);
+                    if (!trs.BuildContent().SequenceEqual(trs.OriginalContent))
+                        failures.Add("[TRS export/import no-op differs] " + rel);
+
+                    EditCheck(rel, "TRS", trs.Entries, trs.BuildContent, failures, b =>
+                    {
+                        var r = new TrsFile(path); r.Load(b); return r.Entries;
+                    });
+                }
+                catch (Exception ex)
+                {
+                    failures.Add("[TRS THREW] " + rel + " : " + ex.GetType().Name + " " + ex.Message);
+                }
+            }
+
+            _out.WriteLine($".TRS swept: {files.Length} files, {etrs} ETRS / {plain} plain, {noEntries} with no #define entries, {totalEntries} entries total");
+            Assert.True(failures.Count == 0, "Failures:\n" + string.Join("\n", failures));
+        }
+
+        /// <summary>Prepends a marker to the first entry, rebuilds, reloads, and checks the edit survived,
+        /// the entry count is unchanged, and the second entry is byte-for-byte the same as before.</summary>
+        private static void EditCheck(string rel, string kind, IReadOnlyList<LocalizedTextEntry> entries,
+            Func<byte[]> build, List<string> failures, Func<byte[], IReadOnlyList<LocalizedTextEntry>> reload)
+        {
+            if (entries.Count < 2) return; // need a neighbour to check
+            string before0 = entries[0].Text;
+            string before1Key = entries[1].Key, before1Text = entries[1].Text;
+
+            entries[0].Text = Marker + before0;       // prepend = safe (never touches the next-entry boundary)
+            IReadOnlyList<LocalizedTextEntry> after = reload(build());
+            entries[0].Text = before0;                // restore the in-memory state
+
+            if (after.Count != entries.Count)
+            { failures.Add($"[{kind} edit changed entry count {entries.Count}->{after.Count}] {rel}"); return; }
+            if (after[0].Text != Marker + before0)
+                failures.Add($"[{kind} edit did not survive] {rel} got=\"{Truncate(after[0].Text)}\"");
+            if (after[1].Key != before1Key || after[1].Text != before1Text)
+                failures.Add($"[{kind} edit disturbed neighbour] {rel}");
+        }
+
+        private static string Truncate(string s)
+        {
+            s = (s ?? "").Replace("\r", "\\r").Replace("\n", "\\n");
+            return s.Length > 40 ? s.Substring(0, 40) + "..." : s;
+        }
+    }
+}

--- a/ScummEditor.UnitTests/V7LocalizedTextTests.cs
+++ b/ScummEditor.UnitTests/V7LocalizedTextTests.cs
@@ -1,0 +1,84 @@
+using System.IO;
+using System.Linq;
+using ScummEditor.Engine.Structures;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// SCUMM v7 external localized text: The Dig's LANGUAGE.BND (XOR 0x13) and the .TRS subtitle/UI files.
+    /// These hold the translated strings for the non-English editions and were not editable before. Tests
+    /// run on the real Portuguese The Dig data.
+    /// </summary>
+    public class V7LocalizedTextTests
+    {
+        private const string PtDig = GameLibrary.TheDigPortuguese; // ScummV7/Dig, The (1995)/Other Languages/Portuguese/CD
+
+        private static LanguageBundleFile LoadBnd()
+        {
+            string folder = GameLibrary.Folder(PtDig);
+            if (folder == null) return null;
+            string path = Path.Combine(folder, "LANGUAGE.BND");
+            if (!File.Exists(path)) return null;
+            var bnd = new LanguageBundleFile(path);
+            bnd.Load(File.ReadAllBytes(path));
+            return bnd;
+        }
+
+        [SkippableFact]
+        public void LanguageBundleDecodesRealPortuguese()
+        {
+            LanguageBundleFile bnd = LoadBnd();
+            Skip.If(bnd == null, "Portuguese The Dig LANGUAGE.BND not present");
+
+            Assert.True(bnd.IsValid);
+            Assert.True(bnd.Encoded, "the PT bundle should be XOR-0x13 encoded");
+            Assert.True(bnd.Entries.Count > 100, "too few strings parsed");
+            // Keys are ROOM.index; the first AIRLOCK strings are known plain-ASCII lines.
+            Assert.Contains(bnd.Entries, e => e.Key.StartsWith("AIRLOCK.") && e.Text == "Maggie.");
+            Assert.Contains(bnd.Entries, e => e.Text == "Venha para este lado da porta.");
+        }
+
+        [SkippableFact]
+        public void LanguageBundleRoundTripIsByteIdentical()
+        {
+            LanguageBundleFile bnd = LoadBnd();
+            Skip.If(bnd == null, "PT The Dig LANGUAGE.BND not present");
+
+            byte[] rebuilt = bnd.BuildContent();
+            Assert.Equal(bnd.OriginalContent.Length, rebuilt.Length);
+            Assert.True(rebuilt.SequenceEqual(bnd.OriginalContent), "no-op rebuild changed the bundle bytes");
+        }
+
+        [SkippableFact]
+        public void LanguageBundleEditRoundTrips()
+        {
+            LanguageBundleFile bnd = LoadBnd();
+            Skip.If(bnd == null, "PT The Dig LANGUAGE.BND not present");
+
+            // Edit one entry; the change must survive a rebuild+reload and not disturb its neighbours.
+            LocalizedTextEntry target = bnd.Entries.First(e => e.Text == "Maggie.");
+            string otherKey = bnd.Entries.First(e => e.Key != target.Key).Key;
+            string otherText = bnd.Entries.First(e => e.Key != target.Key).Text;
+            target.Text = "Teste 123";
+
+            var reloaded = new LanguageBundleFile(bnd.FilePath);
+            reloaded.Load(bnd.BuildContent());
+
+            Assert.Equal("Teste 123", reloaded.Entries.First(e => e.Key == target.Key).Text);
+            Assert.Equal(otherText, reloaded.Entries.First(e => e.Key == otherKey).Text);
+        }
+
+        [SkippableFact]
+        public void LanguageBundleExportImportNoOpIsByteIdentical()
+        {
+            LanguageBundleFile bnd = LoadBnd();
+            Skip.If(bnd == null, "PT The Dig LANGUAGE.BND not present");
+
+            string dump = bnd.ExportToText();
+            string report = bnd.ImportFromText(dump); // re-import the unchanged dump
+            Assert.Contains("0 of", report);          // nothing changed
+            Assert.True(bnd.BuildContent().SequenceEqual(bnd.OriginalContent), "export/import no-op changed bytes");
+        }
+    }
+}

--- a/ScummEditor.UnitTests/V7LocalizedTextTests.cs
+++ b/ScummEditor.UnitTests/V7LocalizedTextTests.cs
@@ -80,5 +80,83 @@ namespace ScummEditor.UnitTests
             Assert.Contains("0 of", report);          // nothing changed
             Assert.True(bnd.BuildContent().SequenceEqual(bnd.OriginalContent), "export/import no-op changed bytes");
         }
+
+        // ---- .TRS ----
+
+        private static TrsFile LoadTrs(string relativePath)
+        {
+            string full = GameLibrary.Folder(relativePath.Substring(0, relativePath.IndexOf('|')));
+            if (full == null) return null;
+            string path = Path.Combine(full, relativePath.Substring(relativePath.IndexOf('|') + 1).Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(path)) return null;
+            var trs = new TrsFile(path);
+            trs.Load(File.ReadAllBytes(path));
+            return trs;
+        }
+
+        [SkippableTheory]
+        [InlineData(PtDig + "|DIG.TRS")]
+        [InlineData(PtDig + "|VIDEO/DIGTXT.TRS")]
+        public void TrsFileRoundTripsByteIdentical(string spec)
+        {
+            TrsFile trs = LoadTrs(spec);
+            Skip.If(trs == null, ".TRS not present: " + spec);
+
+            Assert.True(trs.IsValid, "no #define entries parsed");
+            Assert.True(trs.Entries.Count > 0);
+            Assert.True(trs.BuildContent().SequenceEqual(trs.OriginalContent), "no-op rebuild changed the .TRS bytes");
+        }
+
+        [SkippableFact]
+        public void DigtxtTrsHasReadableStrings()
+        {
+            TrsFile trs = LoadTrs(PtDig + "|VIDEO/DIGTXT.TRS");
+            Skip.If(trs == null, "DIGTXT.TRS not present");
+            // The credits block and a subtitle line are present in the decoded text.
+            Assert.Contains(trs.Entries, e => e.Text.Contains("Charlie Ramos"));
+        }
+
+        [SkippableFact]
+        public void TrsFileEditRoundTrips()
+        {
+            TrsFile trs = LoadTrs(PtDig + "|VIDEO/DIGTXT.TRS");
+            Skip.If(trs == null, "DIGTXT.TRS not present");
+
+            LocalizedTextEntry target = trs.Entries[1]; // a subtitle block
+            string otherKey = trs.Entries[0].Key;
+            string otherText = trs.Entries[0].Text;
+            target.Text = "^f00Texto de teste.\r\n\r\n";
+
+            var reloaded = new TrsFile(trs.FilePath);
+            reloaded.Load(trs.BuildContent());
+            Assert.Equal("^f00Texto de teste.\r\n\r\n", reloaded.Entries.First(e => e.Key == target.Key).Text);
+            Assert.Equal(otherText, reloaded.Entries.First(e => e.Key == otherKey).Text);
+        }
+
+        [Fact]
+        public void EtrsEncodedTrsRoundTripsAndDecodes()
+        {
+            // Build a synthetic ETRS .TRS (16-byte header + XOR-0xCC body) to cover the encoded path.
+            byte[] body = System.Text.Encoding.Latin1.GetBytes("#define A 1\r\nHello\r\n\r\n#define B 2\r\nWorld\r\n");
+            var file = new byte[16 + body.Length];
+            file[0] = (byte)'E'; file[1] = (byte)'T'; file[2] = (byte)'R'; file[3] = (byte)'S';
+            for (int i = 0; i < body.Length; i++) file[16 + i] = (byte)(body[i] ^ 0xCC);
+
+            var trs = new TrsFile("synthetic.trs");
+            trs.Load(file);
+
+            Assert.True(trs.Encoded);
+            Assert.Equal(2, trs.Entries.Count);
+            Assert.Contains(trs.Entries, e => e.Text.Contains("Hello"));
+            Assert.True(trs.BuildContent().SequenceEqual(file), "ETRS no-op rebuild changed bytes");
+
+            // edit + rebuild + reload survives, still ETRS-encoded
+            trs.Entries[0].Text = "Bonjour\r\n\r\n";
+            var reloaded = new TrsFile("synthetic.trs");
+            reloaded.Load(trs.BuildContent());
+            Assert.True(reloaded.Encoded);
+            Assert.Contains(reloaded.Entries, e => e.Text.Contains("Bonjour"));
+            Assert.Contains(reloaded.Entries, e => e.Text.Contains("World"));
+        }
     }
 }

--- a/ScummEditor.UnitTests/V7LocalizedTextTests.cs
+++ b/ScummEditor.UnitTests/V7LocalizedTextTests.cs
@@ -107,6 +107,45 @@ namespace ScummEditor.UnitTests
             Assert.True(trs.BuildContent().SequenceEqual(trs.OriginalContent), "no-op rebuild changed the .TRS bytes");
         }
 
+        [SkippableTheory]
+        [InlineData(PtDig + "|DIG.TRS")]
+        [InlineData(PtDig + "|VIDEO/DIGTXT.TRS")]
+        public void TrsFileExportImportNoOpIsByteIdentical(string spec)
+        {
+            TrsFile trs = LoadTrs(spec);
+            Skip.If(trs == null, ".TRS not present: " + spec);
+
+            string dump = trs.ExportToText();
+            string report = trs.ImportFromText(dump); // re-import the unchanged dump
+            Assert.Contains("0 of", report);          // nothing changed
+            Assert.True(trs.BuildContent().SequenceEqual(trs.OriginalContent), "export/import no-op changed the .TRS bytes");
+        }
+
+        [Fact]
+        public void TrsExportImportPreservesLfLineEndings()
+        {
+            // A plain .TRS with Unix (LF) line endings - the Steam Mac The Dig ships LF-LF .TRS files.
+            // Export+import of an unchanged dump must stay byte-identical (the file's own line ending is
+            // restored on import, not forced to CRLF), and an edited entry must keep the LF convention.
+            byte[] file = System.Text.Encoding.Latin1.GetBytes("#define A 1\nHello\nthere\n\n#define B 2\nWorld\n");
+            var trs = new TrsFile("unix.trs");
+            trs.Load(file);
+
+            Assert.False(trs.Encoded);
+            Assert.Equal(2, trs.Entries.Count);
+
+            string report = trs.ImportFromText(trs.ExportToText());
+            Assert.Contains("0 of", report);
+            Assert.True(trs.BuildContent().SequenceEqual(file), "LF .TRS export/import no-op changed bytes");
+
+            // editing one entry through the import path keeps LF, never introduces CR
+            string editedDump = trs.ExportToText().Replace("World", "Mundo");
+            trs.ImportFromText(editedDump);
+            byte[] rebuilt = trs.BuildContent();
+            Assert.DoesNotContain((byte)'\r', rebuilt);
+            Assert.Contains("Mundo", System.Text.Encoding.Latin1.GetString(rebuilt));
+        }
+
         [SkippableFact]
         public void DigtxtTrsHasReadableStrings()
         {
@@ -145,6 +184,75 @@ namespace ScummEditor.UnitTests
             Assert.Contains(game.LocalizedTextFiles, f => f is LanguageBundleFile && f.IsValid);
             Assert.Contains(game.LocalizedTextFiles, f => f is TrsFile && f.FileName.Equals("DIG.TRS", System.StringComparison.OrdinalIgnoreCase));
             Assert.True(game.LocalizedTextFiles.Count >= 3, "expected LANGUAGE.BND + at least DIG.TRS + DIGTXT.TRS");
+        }
+
+        // ---- adversarial-validation fixes ----
+
+        [SkippableFact]
+        public void DetectionFindsLanguageBundleInVideoSubfolder()
+        {
+            // The Chinese/Japanese/Korean editions keep LANGUAGE.BND under VIDEO/, not the root. Detection
+            // must find it (it used to look only at the root, so the CJK editions' text was unreachable).
+            GameInfo info = GameLibrary.Detect(GameLibrary.TheDigChinese);
+            Skip.If(info == null, "Chinese The Dig not present");
+
+            Assert.False(string.IsNullOrEmpty(info.LanguageBundlePath), "LANGUAGE.BND not detected for the CJK edition");
+            Assert.Contains("VIDEO", info.LanguageBundlePath, System.StringComparison.OrdinalIgnoreCase);
+
+            ScummGameData game = ScummGameData.LoadFromGameInfo(info);
+            Assert.Contains(game.LocalizedTextFiles, f => f is LanguageBundleFile && f.IsValid);
+        }
+
+        [Fact]
+        public void NormalizeEditedTextCollapsesNewlinesForBundle()
+        {
+            // A LANGUAGE.BND message is one line; a newline typed in the GUI must collapse to a space so the
+            // saved file keeps its line-based structure (ScummVM reads a message only up to the first CR/LF).
+            var bnd = new LanguageBundleFile("x.bnd");
+            Assert.Equal("a b c", bnd.NormalizeEditedText("a\r\nb\nc"));
+        }
+
+        [Fact]
+        public void NormalizeEditedTextKeepsTrsNativeLineEnding()
+        {
+            // A .TRS edited in the GUI (Windows Forms forces CRLF) must be re-expressed in the file's own
+            // line ending, so editing a Mac LF-LF file does not silently rewrite every line to CRLF.
+            byte[] lf = System.Text.Encoding.Latin1.GetBytes("#define A 1\nHello\n\n");
+            var trs = new TrsFile("unix.trs");
+            trs.Load(lf);
+
+            Assert.Equal("Linha1\nLinha2\n", trs.NormalizeEditedText("Linha1\r\nLinha2\r\n"));
+        }
+
+        [Fact]
+        public void TrsImportRejectsEmbeddedDefineLine()
+        {
+            // A translated value whose own text begins a line with "#define" would be re-parsed as a new
+            // entry on reload, corrupting the file - the import must skip it and keep the structure intact.
+            byte[] file = System.Text.Encoding.Latin1.GetBytes("#define A 1\r\nHello\r\n\r\n#define B 2\r\nWorld\r\n");
+            var trs = new TrsFile("g.trs");
+            trs.Load(file);
+            int before = trs.Entries.Count;
+
+            string dump = "A 1\t#define EVIL 99\\nInjected\r\n"; // escaped \n -> a real newline starting "#define"
+            string report = trs.ImportFromText(dump);
+
+            Assert.Contains("skipped", report);
+            Assert.Equal(before, trs.Entries.Count);                       // no phantom entry
+            Assert.True(trs.BuildContent().SequenceEqual(file), "rejected edit must leave the file unchanged");
+        }
+
+        [Fact]
+        public void ImportWarnsAboutCharactersOutsideCodePage()
+        {
+            // A smart quote (U+2019) pasted from a word processor cannot be stored in the DOS code page;
+            // Latin-1 would write it as '?', so the import must warn instead of silently corrupting.
+            byte[] file = System.Text.Encoding.Latin1.GetBytes("#define A 1\r\nHello\r\n\r\n#define B 2\r\nWorld\r\n");
+            var trs = new TrsFile("g.trs");
+            trs.Load(file);
+
+            string report = trs.ImportFromText("A 1\tIt’s here\r\n");
+            Assert.Contains("outside the game's 8-bit code page", report);
         }
 
         [Fact]

--- a/ScummEditor.UnitTests/V7LocalizedTextTests.cs
+++ b/ScummEditor.UnitTests/V7LocalizedTextTests.cs
@@ -133,6 +133,20 @@ namespace ScummEditor.UnitTests
             Assert.Equal(otherText, reloaded.Entries.First(e => e.Key == otherKey).Text);
         }
 
+        // ---- load/save wiring ----
+
+        [SkippableFact]
+        public void GameLoadsLocalizedTextFiles()
+        {
+            ScummGameData game = GameLibrary.Load(PtDig);
+            Skip.If(game == null, "PT The Dig not present");
+
+            // The loader exposes LANGUAGE.BND (as a LanguageBundleFile) plus the .TRS files.
+            Assert.Contains(game.LocalizedTextFiles, f => f is LanguageBundleFile && f.IsValid);
+            Assert.Contains(game.LocalizedTextFiles, f => f is TrsFile && f.FileName.Equals("DIG.TRS", System.StringComparison.OrdinalIgnoreCase));
+            Assert.True(game.LocalizedTextFiles.Count >= 3, "expected LANGUAGE.BND + at least DIG.TRS + DIGTXT.TRS");
+        }
+
         [Fact]
         public void EtrsEncodedTrsRoundTripsAndDecodes()
         {

--- a/ScummEditor.UnitTests/V7NutEngineCompatTests.cs
+++ b/ScummEditor.UnitTests/V7NutEngineCompatTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.IO;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures.DataFile;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// SCUMM v7 .NUT font re-encode ENGINE compatibility. A re-encoded glyph must stay loadable by the real
+    /// engine, not merely decodable by our own decoder (the gap that let a broken re-encode ship and crash
+    /// Full Throttle, which draws .NUT text at boot). After re-encoding every glyph these assert, mirroring
+    /// ScummVM's NutRenderer::loadFont:
+    ///   (1) the two frame-walk loops stay consistent - the decodedLength COUNT loop (advances by the FOBJ
+    ///       size + its even pad) and the DECODE loop (advances by the FRME size + its even pad) must agree
+    ///       on every char, or ScummVM overflows its glyph buffer. This requires the canonical layout: the
+    ///       FOBJ chunk even-padded INSIDE the FRME so the FRME size is always even;
+    ///   (2) decoding our re-encoded payload with ScummVM's exact codec1 (bompDecodeLine, setZero=false) /
+    ///       codec21 yields pixels identical to decoding the original.
+    /// </summary>
+    public class V7NutEngineCompatTests
+    {
+        [SkippableTheory]
+        [InlineData(GameLibrary.FullThrottle)]
+        [InlineData(GameLibrary.TheDig)]
+        public void ReencodedNutStaysEngineLoadable(string relativePath)
+        {
+            string folder = GameLibrary.Folder(relativePath);
+            Skip.If(folder == null, "not present: " + relativePath);
+
+            string[] nuts = Directory.GetFiles(folder, "*.NUT", SearchOption.AllDirectories);
+            Skip.If(nuts.Length == 0, "no .NUT fonts");
+
+            int fontsChecked = 0, glyphsChecked = 0;
+            foreach (string path in nuts)
+            {
+                byte[] orig = File.ReadAllBytes(path);
+                var f1 = new NutFont { FilePath = path };
+                f1.LoadFromFileBytes(orig);
+                if (!f1.IsValid) continue;
+
+                var f2 = new NutFont { FilePath = path };
+                f2.LoadFromFileBytes((byte[])orig.Clone());
+
+                for (int i = 0; i < f1.Glyphs.Count; i++)
+                {
+                    NutGlyph g = f1.Glyphs[i];
+                    if (!g.HasPixels || !NutImageEncoder.CanEncode(g.Codec)) continue;
+                    int w = g.Width, h = g.Height;
+                    if (w <= 0 || h <= 0) continue;
+
+                    byte[] origPayload = Slice(f1.RawContent, g.FobjOffset + 22, g.FobjSize - 14);
+                    byte[,] m = NutImageDecoder.DecodeGlyphIndices(f2, i);
+                    NutImageEncoder.ReplaceGlyph(f2, i, m); // no-op re-encode: must reproduce engine-valid output
+                    NutGlyph g2 = f2.Glyphs[i];
+                    byte[] newPayload = Slice(f2.RawContent, g2.FobjOffset + 22, g2.FobjSize - 14);
+
+                    byte[] a = ScummVmDecode(origPayload, w, h, g.Codec);
+                    byte[] b = ScummVmDecode(newPayload, w, h, g.Codec);
+                    Assert.True(SeqEqual(a, b),
+                        string.Format("{0} glyph#{1} codec={2}: ScummVM decode of the re-encode differs from the original",
+                            Path.GetFileName(path), i, g.Codec));
+                    glyphsChecked++;
+                }
+
+                // The whole font must still walk consistently under ScummVM's two loadFont loops.
+                AssertWalkConsistent(orig, "original " + Path.GetFileName(path));
+                AssertWalkConsistent(f2.RawContent, "re-encoded " + Path.GetFileName(path));
+                fontsChecked++;
+            }
+
+            Assert.True(fontsChecked > 0, "no NUT fonts checked");
+            Assert.True(glyphsChecked > 0, "no NUT glyphs checked");
+        }
+
+        private static void AssertWalkConsistent(byte[] file, string label)
+        {
+            int baseOff = 8, length = file.Length - baseOff;
+            int numChars = U16(file, baseOff + 10);
+
+            int offset = 0, c1 = 0;
+            for (int l = 0; l < numChars; l++)
+            {
+                if (offset + 8 > length) break;
+                int cs = (int)U32BE(file, baseOff + offset + 4);
+                long next = (long)offset + cs + 16 + (cs & 1);
+                if (next + 18 > length) break;
+                offset = (int)next; c1++;
+            }
+
+            offset = 0; int c2 = 0; bool ok = true;
+            for (int l = 0; l < c1; l++)
+            {
+                if (offset + 8 > length) { ok = false; break; }
+                int cs = (int)U32BE(file, baseOff + offset + 4);
+                long next = (long)offset + cs + 8 + (cs & 1);
+                if (next + 8 > length) { ok = false; break; }
+                offset = (int)next;
+                if (U32BE(file, baseOff + offset) != Tag("FRME")) { ok = false; break; }
+                offset += 8;
+                if (offset + 22 > length || U32BE(file, baseOff + offset) != Tag("FOBJ")) { ok = false; break; }
+                c2++;
+            }
+            Assert.True(c1 == numChars && c2 == numChars && ok,
+                string.Format("{0}: ScummVM frame walk inconsistent (numChars={1} count={2} decode={3} ok={4})", label, numChars, c1, c2, ok));
+        }
+
+        // ScummVM NutRenderer decode: codec1 = smushDecodeRLE(bompDecodeLine, setZero=false); codec21/44 = codec21.
+        private static byte[] ScummVmDecode(byte[] p, int w, int h, int codec)
+        {
+            var dst = new byte[w * h];
+            int sp = 0;
+            try
+            {
+                if (codec == 1 || codec == 3)
+                {
+                    for (int y = 0; y < h; y++)
+                    {
+                        int lineLen = U16(p, sp);
+                        BompLine(dst, y * w, p, sp + 2, w);
+                        sp += lineLen + 2;
+                    }
+                }
+                else
+                {
+                    for (int y = 0; y < h; y++)
+                    {
+                        int lineLen = U16(p, sp);
+                        int next = sp + 2 + lineLen;
+                        sp += 2;
+                        int len = w, d = y * w;
+                        do
+                        {
+                            int offs = U16(p, sp); sp += 2;
+                            d += offs; len -= offs;
+                            if (len <= 0) break;
+                            int rw = U16(p, sp) + 1; sp += 2;
+                            len -= rw;
+                            if (len < 0) rw += len;
+                            for (int k = 0; k < rw; k++) dst[d + k] = p[sp + k];
+                            d += rw; sp += rw;
+                        } while (len > 0);
+                        sp = next;
+                    }
+                }
+            }
+            catch { return null; } // an out-of-bounds decode is itself a failure (would crash the engine)
+            return dst;
+        }
+
+        private static void BompLine(byte[] dst, int dstOff, byte[] src, int sp, int len)
+        {
+            while (len > 0)
+            {
+                byte code = src[sp++];
+                int num = (code >> 1) + 1;
+                if (num > len) num = len;
+                len -= num;
+                if ((code & 1) != 0) { byte color = src[sp++]; if (color != 0) for (int k = 0; k < num; k++) dst[dstOff + k] = color; dstOff += num; }
+                else { for (int k = 0; k < num; k++) { byte color = src[sp++]; if (color != 0) dst[dstOff] = color; dstOff++; } }
+            }
+        }
+
+        private static int U16(byte[] a, int p) => a[p] | (a[p + 1] << 8);
+        private static uint U32BE(byte[] a, int p) => (uint)((a[p] << 24) | (a[p + 1] << 16) | (a[p + 2] << 8) | a[p + 3]);
+        private static uint Tag(string t) => (uint)((t[0] << 24) | (t[1] << 16) | (t[2] << 8) | t[3]);
+        private static byte[] Slice(byte[] a, int o, int l) { if (o < 0 || l < 0 || o + l > a.Length) l = Math.Max(0, Math.Min(l, a.Length - o)); var r = new byte[l]; Array.Copy(a, o, r, 0, l); return r; }
+        private static bool SeqEqual(byte[] a, byte[] b) { if (a == null || b == null) return false; if (a.Length != b.Length) return false; for (int i = 0; i < a.Length; i++) if (a[i] != b[i]) return false; return true; }
+    }
+}

--- a/ScummEditor.UnitTests/V7NutFontTests.cs
+++ b/ScummEditor.UnitTests/V7NutFontTests.cs
@@ -176,8 +176,10 @@ namespace ScummEditor.UnitTests
             try
             {
                 string png = Path.Combine(dir, "font.png");
-                NutFontPngCodec.ExportPng(font, png, null);
-                NutFontPngCodec.ImportPng(font, png); // no-op re-import
+                string guide = Path.Combine(dir, "font.guide.png");
+                NutFontPngCodec.ExportPng(font, png, guide, null);
+                Assert.True(File.Exists(guide), "atlas export did not write the guide image");
+                NutFontPngCodec.ImportPng(font, png); // no-op re-import (the guide is reference-only)
 
                 byte[][,] after = DecodeAll(font);
                 Assert.Equal(before.Length, after.Length);

--- a/ScummEditor.UnitTests/V7NutFontTests.cs
+++ b/ScummEditor.UnitTests/V7NutFontTests.cs
@@ -179,7 +179,19 @@ namespace ScummEditor.UnitTests
                 string guide = Path.Combine(dir, "font.guide.png");
                 NutFontPngCodec.ExportPng(font, png, guide, null);
                 Assert.True(File.Exists(guide), "atlas export did not write the guide image");
-                NutFontPngCodec.ImportPng(font, png); // no-op re-import (the guide is reference-only)
+
+                // The editable atlas itself must carry the cell grid (index 255 in each cell's gutter), so the
+                // translation team sees the cell boundaries while editing - and it must stay re-importable.
+                using (var atlas = (System.Drawing.Bitmap)System.Drawing.Image.FromFile(png))
+                {
+                    Assert.True(IndexedImageHelper.IsIndexed(atlas), "exported atlas is not an indexed PNG");
+                    byte[,] pixels = IndexedImageHelper.GetIndexMatrix(atlas);
+                    bool hasGrid = false;
+                    for (int y = 0; y < pixels.GetLength(1) && !hasGrid; y++) if (pixels[0, y] == 255) hasGrid = true;
+                    Assert.True(hasGrid, "exported atlas has no grid line in the gutter");
+                }
+
+                NutFontPngCodec.ImportPng(font, png); // no-op re-import (grid gutter + guide are ignored)
 
                 byte[][,] after = DecodeAll(font);
                 Assert.Equal(before.Length, after.Length);

--- a/ScummEditor.UnitTests/V7NutFontTests.cs
+++ b/ScummEditor.UnitTests/V7NutFontTests.cs
@@ -269,6 +269,22 @@ namespace ScummEditor.UnitTests
             }
         }
 
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        public void MissingNutFileIsSkippedDuringLoad(string relativePath)
+        {
+            GameInfo info = GameLibrary.Detect(relativePath);
+            Skip.If(info == null, "GameData folder not present: " + relativePath);
+
+            // A .NUT enumerated at detection could be gone/locked by load time; that must not crash the
+            // whole game load - the file is skipped and the rest of the game (and the other fonts) load.
+            info.NutFontFiles.Add(Path.Combine(GameLibrary.Folder(relativePath), "DOES_NOT_EXIST.NUT"));
+
+            ScummGameData game = ScummGameData.LoadFromGameInfo(info); // must not throw
+            Assert.True(game.NutFonts.Count > 0, "no NUT fonts loaded");
+            Assert.DoesNotContain(game.NutFonts, r => r.FilePath != null && r.FilePath.EndsWith("DOES_NOT_EXIST.NUT"));
+        }
+
         private static bool BytesEqual(byte[] a, byte[] b)
         {
             if (a.Length != b.Length) return false;

--- a/ScummEditor.UnitTests/V7NutFontTests.cs
+++ b/ScummEditor.UnitTests/V7NutFontTests.cs
@@ -1,0 +1,334 @@
+using System.Collections.Generic;
+using System.IO;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// SCUMM v7 external .NUT SMUSH fonts (The Dig, Full Throttle): the parser (ANIM/AHDR/FRME/FOBJ) and
+    /// the glyph decoder for all four codecs the games use (1/3 = BOMP, 21/44 = skip-copy). These run on
+    /// the real font files in the game library, decoding every glyph of every NUT to prove the format
+    /// reading and the codecs are faithful, and that a loaded NUT is preserved byte-for-byte.
+    /// </summary>
+    public class V7NutFontTests
+    {
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void EveryNutGlyphDecodes(string relativePath)
+        {
+            string folder = GameLibrary.Folder(relativePath);
+            Skip.If(folder == null, "GameData folder not present: " + relativePath);
+
+            List<string> nutFiles = FindNutFiles(folder);
+            Assert.True(nutFiles.Count > 0, "no .NUT files found under " + folder);
+
+            var codecs = new SortedSet<int>();
+            int decoded = 0;
+            foreach (string path in nutFiles)
+            {
+                var font = new NutFont { FilePath = path };
+                font.LoadFromFileBytes(File.ReadAllBytes(path));
+
+                Assert.True(font.IsValid, "NUT failed to parse: " + Path.GetFileName(path));
+                Assert.Equal(font.NumChars, font.Glyphs.Count); // fully walked, no truncation
+
+                for (int i = 0; i < font.Glyphs.Count; i++)
+                {
+                    NutGlyph g = font.Glyphs[i];
+                    if (!g.HasPixels) continue;
+
+                    codecs.Add(g.Codec);
+                    Assert.True(NutImageDecoder.IsSupportedCodec(g.Codec),
+                        "unsupported codec " + g.Codec + " in " + Path.GetFileName(path));
+
+                    byte[,] m = NutImageDecoder.DecodeGlyphIndices(font, i);
+                    Assert.NotNull(m);
+                    Assert.Equal(g.Width, m.GetLength(0));
+                    Assert.Equal(g.Height, m.GetLength(1));
+                    decoded++;
+                }
+            }
+
+            Assert.True(decoded > 0, "no glyphs decoded");
+            // Both games together cover all four codecs; each game covers at least these.
+            Assert.Contains(1, codecs);  // BOMP (BIGFONT / sprite sheets)
+            Assert.True(codecs.Contains(44) || codecs.Contains(21),
+                "expected a skip-copy font codec (21 or 44)");
+        }
+
+        [SkippableFact]
+        public void DigAndFullThrottleCoverAllFourCodecs()
+        {
+            string dig = GameLibrary.Folder(GameLibrary.TheDig);
+            string ft = GameLibrary.Folder(GameLibrary.FullThrottle);
+            Skip.If(dig == null || ft == null, "GameData folders not present");
+
+            var codecs = new SortedSet<int>();
+            foreach (string folder in new[] { dig, ft })
+                foreach (string path in FindNutFiles(folder))
+                {
+                    var font = new NutFont { FilePath = path };
+                    font.LoadFromFileBytes(File.ReadAllBytes(path));
+                    foreach (NutGlyph g in font.Glyphs)
+                        if (g.HasPixels) codecs.Add(g.Codec);
+                }
+
+            // The two games together exercise every codec this engine decodes: The Dig uses codec 1
+            // (BIGFONT) and codec 44 (FONT0-3 / SMLFONT video subtitles); Full Throttle adds codec 3
+            // (BRUSH.NUT) and codec 21 (SCUMMFNT / TECHFNT / TITLFNT).
+            Assert.Contains(1, codecs);
+            Assert.Contains(3, codecs);
+            Assert.Contains(21, codecs);
+            Assert.Contains(44, codecs);
+        }
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void LoadedNutIsByteIdentical(string relativePath)
+        {
+            string folder = GameLibrary.Folder(relativePath);
+            Skip.If(folder == null, "GameData folder not present: " + relativePath);
+
+            foreach (string path in FindNutFiles(folder))
+            {
+                byte[] original = File.ReadAllBytes(path);
+                var font = new NutFont();
+                font.LoadFromFileBytes(original);
+                Assert.True(font.RawContent.Length == original.Length,
+                    "NUT RawContent length changed: " + Path.GetFileName(path));
+            }
+        }
+
+        // ---- encoder / PNG round-trips ----
+
+        [SkippableTheory]
+        [InlineData(1)]
+        [InlineData(3)]
+        [InlineData(21)]
+        [InlineData(44)]
+        public void GlyphReEncodeIsSelfConsistent(int codec)
+        {
+            NutFont font; int gi;
+            Skip.IfNot(FindSampleGlyph(codec, out font, out gi), "no codec-" + codec + " glyph in the library");
+
+            // Re-encoding a glyph's own decoded indices must decode back to the same pixels, and the rest
+            // of the font must stay intact (frame count unchanged, every other glyph identical).
+            byte[,] before = NutImageDecoder.DecodeGlyphIndices(font, gi);
+            byte[][,] others = DecodeAll(font);
+            int numChars = font.NumChars;
+
+            NutImageEncoder.ReplaceGlyph(font, gi, before);
+
+            Assert.True(font.IsValid);
+            Assert.Equal(numChars, font.NumChars);
+            byte[,] after = NutImageDecoder.DecodeGlyphIndices(font, gi);
+            Assert.True(MatricesEqual(before, after), "codec " + codec + " glyph changed after a no-op re-encode");
+
+            byte[][,] othersAfter = DecodeAll(font);
+            for (int i = 0; i < othersAfter.Length; i++)
+            {
+                Assert.True(MatricesEqual(others[i], othersAfter[i]), "another glyph changed after editing glyph " + gi);
+            }
+        }
+
+        [SkippableTheory]
+        [InlineData(1)]
+        [InlineData(3)]
+        [InlineData(21)]
+        [InlineData(44)]
+        public void EditedGlyphSurvivesReEncode(int codec)
+        {
+            NutFont font; int gi;
+            Skip.IfNot(FindSampleGlyph(codec, out font, out gi), "no codec-" + codec + " glyph in the library");
+
+            byte[,] m = NutImageDecoder.DecodeGlyphIndices(font, gi);
+            int w = m.GetLength(0), h = m.GetLength(1);
+            // Paint a small distinctive non-transparent block (index 7 is never the transparent index here).
+            int bw = System.Math.Min(3, w), bh = System.Math.Min(3, h);
+            for (int x = 0; x < bw; x++)
+                for (int y = 0; y < bh; y++)
+                    m[x, y] = 7;
+
+            NutImageEncoder.ReplaceGlyph(font, gi, m);
+
+            byte[,] after = NutImageDecoder.DecodeGlyphIndices(font, gi);
+            Assert.True(MatricesEqual(m, after), "edited codec-" + codec + " glyph did not round-trip");
+        }
+
+        [SkippableTheory]
+        [InlineData(1)]
+        [InlineData(21)]
+        [InlineData(44)]
+        public void AtlasPngRoundTripPreservesAllGlyphs(int codec)
+        {
+            NutFont font; int gi;
+            Skip.IfNot(FindSampleGlyph(codec, out font, out gi), "no codec-" + codec + " font in the library");
+
+            byte[][,] before = DecodeAll(font);
+
+            string dir = Path.Combine(Path.GetTempPath(), "scumm_nut_" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string png = Path.Combine(dir, "font.png");
+                NutFontPngCodec.ExportPng(font, png, null);
+                NutFontPngCodec.ImportPng(font, png); // no-op re-import
+
+                byte[][,] after = DecodeAll(font);
+                Assert.Equal(before.Length, after.Length);
+                for (int i = 0; i < before.Length; i++)
+                {
+                    Assert.True(MatricesEqual(before[i], after[i]), "glyph " + i + " changed across an atlas PNG round-trip");
+                }
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        // ---- load / save wiring ----
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void NutFontsLoadWithGame(string relativePath)
+        {
+            string folder = GameLibrary.Folder(relativePath);
+            Skip.If(folder == null, "GameData folder not present: " + relativePath);
+
+            ScummGameData game = GameLibrary.Load(relativePath);
+            Assert.Equal(FindNutFiles(folder).Count, game.NutFonts.Count); // every .NUT loaded
+            Assert.True(game.NutFonts.Count > 0, "no NUT fonts loaded");
+            foreach (NutFontResource r in game.NutFonts)
+            {
+                Assert.NotNull(r.Font);
+                Assert.True(r.Font.IsValid, "NUT font failed to parse: " + Path.GetFileName(r.FilePath));
+            }
+        }
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void UneditedNutWriteBackIsByteIdentical(string relativePath)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "GameData folder not present: " + relativePath);
+
+            ScummGameData game = GameLibrary.Load(relativePath);
+            foreach (NutFontResource r in game.NutFonts)
+            {
+                byte[] onDisk = File.ReadAllBytes(r.FilePath);
+                // SaveDataToDisk writes r.Font.RawContent back to the file verbatim; an unedited font's
+                // RawContent must equal the bytes on disk, so the file round-trips byte-identically.
+                Assert.True(r.Font.RawContent.Length == onDisk.Length && BytesEqual(r.Font.RawContent, onDisk),
+                    "unedited NUT changed: " + Path.GetFileName(r.FilePath));
+            }
+        }
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void NutBatchExportImportRoundTrips(string relativePath)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "GameData folder not present: " + relativePath);
+
+            ScummGameData game = GameLibrary.Load(relativePath);
+            List<NutFontResource> fonts = game.NutFonts;
+
+            // All glyphs of every font, before the round-trip.
+            var before = new Dictionary<string, byte[][,]>();
+            foreach (NutFontResource r in fonts) before[r.FilePath] = DecodeAll(r.Font);
+
+            string dir = Path.Combine(Path.GetTempPath(), "scumm_nutbatch_" + System.Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            try
+            {
+                NutFontPngCodec.ExportAll(fonts, dir);
+                NutFontPngCodec.ImportAll(fonts, dir);
+
+                foreach (NutFontResource r in fonts)
+                {
+                    byte[][,] after = DecodeAll(r.Font);
+                    byte[][,] orig = before[r.FilePath];
+                    Assert.Equal(orig.Length, after.Length);
+                    for (int i = 0; i < orig.Length; i++)
+                    {
+                        Assert.True(MatricesEqual(orig[i], after[i]),
+                            "glyph " + i + " of " + Path.GetFileName(r.FilePath) + " changed across the batch round-trip");
+                    }
+                }
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
+        private static bool BytesEqual(byte[] a, byte[] b)
+        {
+            if (a.Length != b.Length) return false;
+            for (int i = 0; i < a.Length; i++) if (a[i] != b[i]) return false;
+            return true;
+        }
+
+        private static byte[][,] DecodeAll(NutFont font)
+        {
+            var all = new byte[font.Glyphs.Count][,];
+            for (int i = 0; i < font.Glyphs.Count; i++)
+            {
+                all[i] = NutImageDecoder.DecodeGlyphIndices(font, i);
+            }
+            return all;
+        }
+
+        /// <summary>Finds the first font in the library whose first decodable glyph uses the given codec.</summary>
+        private static bool FindSampleGlyph(int codec, out NutFont font, out int glyphIndex)
+        {
+            font = null; glyphIndex = -1;
+            foreach (string rel in new[] { GameLibrary.TheDig, GameLibrary.FullThrottle })
+            {
+                string folder = GameLibrary.Folder(rel);
+                if (folder == null) continue;
+                foreach (string path in FindNutFiles(folder))
+                {
+                    var f = new NutFont { FilePath = path };
+                    f.LoadFromFileBytes(File.ReadAllBytes(path));
+                    for (int i = 0; i < f.Glyphs.Count; i++)
+                    {
+                        NutGlyph g = f.Glyphs[i];
+                        if (g.HasPixels && g.Codec == codec && g.Width * g.Height > 16)
+                        {
+                            font = f; glyphIndex = i; return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        private static bool MatricesEqual(byte[,] a, byte[,] b)
+        {
+            if (a == null || b == null) return a == b;
+            if (a.GetLength(0) != b.GetLength(0) || a.GetLength(1) != b.GetLength(1)) return false;
+            for (int x = 0; x < a.GetLength(0); x++)
+                for (int y = 0; y < a.GetLength(1); y++)
+                    if (a[x, y] != b[x, y]) return false;
+            return true;
+        }
+
+        private static List<string> FindNutFiles(string folder)
+        {
+            var list = new List<string>();
+            foreach (string path in Directory.GetFiles(folder, "*.NUT", SearchOption.AllDirectories))
+            {
+                list.Add(path);
+            }
+            return list;
+        }
+    }
+}

--- a/ScummEditor.UnitTests/V7SoundTests.cs
+++ b/ScummEditor.UnitTests/V7SoundTests.cs
@@ -97,6 +97,33 @@ namespace ScummEditor.UnitTests
             Assert.True(File.Exists(info.SpeechFilePath), "MONSTER.SOU not found");
         }
 
+        [SkippableTheory]
+        [InlineData(GameLibrary.FullThrottle)]        // v7: each entry is VCTL + VTLK-wrapped VOC
+        [InlineData(GameLibrary.DayOfTheTentacleCd)]  // v6: VCTL + bare VOC (no VTLK wrapper)
+        [InlineData(GameLibrary.SamAndMaxCd)]         // v6: VCTL + bare VOC
+        public void MonsterSouParsesEverySpeechEntry(string relativePath)
+        {
+            string folder = GameLibrary.Folder(relativePath);
+            Skip.If(folder == null, "GameData folder not present: " + relativePath);
+            string sou = Path.Combine(folder, "MONSTER.SOU");
+            Skip.If(!File.Exists(sou), "MONSTER.SOU not present: " + relativePath);
+
+            var speech = new SpeechSouFile(sou);
+            speech.EnsureParsed();
+
+            // The walk must reach the end of the file (Full Throttle wraps the VOC in a VTLK block that the
+            // parser must skip; the older talkie editions do not) and expose every speech entry.
+            Assert.Null(speech.ParseError);
+            Assert.True(speech.Entries.Count > 100, "too few speech entries parsed: " + speech.Entries.Count);
+
+            // Spot-check the first entry: it points at a real Creative VOC and yielded a sample rate.
+            SpeechSouEntry first = speech.Entries[0];
+            byte[] voc = speech.ReadVocBytes(first);
+            Assert.True(voc.Length > 26, "VOC too short");
+            Assert.Equal("Creative Voice File", System.Text.Encoding.ASCII.GetString(voc, 0, 19));
+            Assert.True(first.SampleRate > 0, "no sample rate decoded");
+        }
+
         [SkippableFact]
         public void TheDigHasNoMonsterSou()
         {

--- a/ScummEditor.UnitTests/V7SoundTests.cs
+++ b/ScummEditor.UnitTests/V7SoundTests.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.IO;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// SCUMM v7 in-container sound (SOUN). v7 SOUN blocks are typed as SoundBlockV7 (a byte-exact
+    /// RawContainerBlock marker) so the GUI can decode them: The Dig wraps an iMUS digital-audio resource
+    /// (MAP/FRMT/DATA, 8/12-bit PCM) decoded by ImuseAudioDecoder; Full Throttle stores a Creative Voice
+    /// File (VOC) decoded by the existing SoundConverter.VocToWav. These tests run on the real games.
+    /// </summary>
+    public class V7SoundTests
+    {
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void SounBlocksAreTypedAsSoundBlockV7(string relativePath)
+        {
+            Skip.If(GameLibrary.Folder(relativePath) == null, "GameData folder not present: " + relativePath);
+
+            ScummGameData game = GameLibrary.Load(relativePath);
+            List<SoundBlockV7> sounds = CollectSounds(game);
+            Assert.True(sounds.Count > 0, "no SOUN blocks found (SOUN not typed as SoundBlockV7?)");
+        }
+
+        [SkippableFact]
+        public void TheDigImusSoundsDecodeToWav()
+        {
+            Skip.If(GameLibrary.Folder(GameLibrary.TheDig) == null, "The Dig not present");
+
+            ScummGameData game = GameLibrary.Load(GameLibrary.TheDig);
+            int decoded = 0, checkedCount = 0;
+            foreach (SoundBlockV7 s in CollectSounds(game))
+            {
+                byte[] body = Serialize(s);
+                if (!ImuseAudioDecoder.IsImus(body)) continue;
+
+                ImuseAudioDecoder.ImuseInfo info = ImuseAudioDecoder.GetInfo(body);
+                Assert.NotNull(info);
+                Assert.Contains(info.WordSize, new[] { 8, 12, 16 });
+                Assert.InRange(info.Channels, 1, 2);
+                Assert.True(info.SampleRate == 11025 || info.SampleRate == 22050, "unexpected rate " + info.SampleRate);
+
+                byte[] wav = ImuseAudioDecoder.ToWav(body);
+                Assert.NotNull(wav);
+                AssertValidWav(wav, info.Channels, info.SampleRate, info.WordSize == 8 ? 8 : 16);
+                decoded++;
+
+                if (++checkedCount >= 40) break; // a representative sample keeps the test fast
+            }
+            Assert.True(decoded > 0, "no iMUS sounds decoded");
+        }
+
+        [SkippableFact]
+        public void FullThrottleVocSoundsDecodeToWav()
+        {
+            Skip.If(GameLibrary.Folder(GameLibrary.FullThrottle) == null, "Full Throttle not present");
+
+            ScummGameData game = GameLibrary.Load(GameLibrary.FullThrottle);
+            int decoded = 0, checkedCount = 0;
+            foreach (SoundBlockV7 s in CollectSounds(game))
+            {
+                byte[] body = Serialize(s);
+                int voc = IndexOf(body, "Creative Voice File");
+                if (voc < 0) continue;
+
+                byte[] slice = new byte[body.Length - voc];
+                System.Array.Copy(body, voc, slice, 0, slice.Length);
+                byte[] wav = SoundConverter.VocToWav(slice);
+                // VocToWav returns null only for an unsupported codec (e.g. ADPCM); FT speech is PCM.
+                if (wav != null)
+                {
+                    Assert.True(wav.Length > 44 && wav[0] == 'R' && wav[1] == 'I' && wav[2] == 'F' && wav[3] == 'F',
+                        "VOC did not decode to a RIFF/WAVE");
+                    decoded++;
+                }
+
+                if (++checkedCount >= 40) break;
+            }
+            Assert.True(decoded > 0, "no VOC sounds decoded");
+        }
+
+        private static List<SoundBlockV7> CollectSounds(ScummGameData game)
+        {
+            var list = new List<SoundBlockV7>();
+            Walk((BlockBase)game.DataFile, list);
+            return list;
+        }
+
+        private static void Walk(BlockBase node, List<SoundBlockV7> outList)
+        {
+            if (node is SoundBlockV7 s) outList.Add(s);
+            foreach (BlockBase c in node.Childrens) Walk(c, outList);
+        }
+
+        private static byte[] Serialize(BlockBase block)
+        {
+            using (var ms = new MemoryStream())
+            {
+                block.SaveToBinaryWriter(ms);
+                return ms.ToArray();
+            }
+        }
+
+        private static void AssertValidWav(byte[] wav, int channels, int sampleRate, int bits)
+        {
+            Assert.True(wav.Length > 44, "WAV too short");
+            Assert.True(wav[0] == 'R' && wav[1] == 'I' && wav[2] == 'F' && wav[3] == 'F', "no RIFF");
+            Assert.True(wav[8] == 'W' && wav[9] == 'A' && wav[10] == 'V' && wav[11] == 'E', "no WAVE");
+            Assert.Equal(channels, wav[22] | (wav[23] << 8));            // fmt channels
+            Assert.Equal(sampleRate, wav[24] | (wav[25] << 8) | (wav[26] << 16) | (wav[27] << 24));
+            Assert.Equal(bits, wav[34] | (wav[35] << 8));                // bits per sample
+        }
+
+        private static int IndexOf(byte[] data, string text)
+        {
+            for (int i = 0; i + text.Length <= data.Length; i++)
+            {
+                bool match = true;
+                for (int j = 0; j < text.Length; j++)
+                {
+                    if (data[i + j] != text[j]) { match = false; break; }
+                }
+                if (match) return i;
+            }
+            return -1;
+        }
+    }
+}

--- a/ScummEditor.UnitTests/V7SoundTests.cs
+++ b/ScummEditor.UnitTests/V7SoundTests.cs
@@ -84,6 +84,29 @@ namespace ScummEditor.UnitTests
             Assert.True(decoded > 0, "no VOC sounds decoded");
         }
 
+        [SkippableFact]
+        public void FullThrottleExposesMonsterSouSpeech()
+        {
+            GameInfo info = GameLibrary.Detect(GameLibrary.FullThrottle);
+            Skip.If(info == null, "Full Throttle not present");
+
+            // FT's recorded speech is an external MONSTER.SOU (Creative VOC); the existing speech viewer
+            // shows/plays/exports it once detection points SpeechFilePath at it.
+            Assert.NotNull(info.SpeechFilePath);
+            Assert.EndsWith("MONSTER.SOU", info.SpeechFilePath, System.StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(info.SpeechFilePath), "MONSTER.SOU not found");
+        }
+
+        [SkippableFact]
+        public void TheDigHasNoMonsterSou()
+        {
+            GameInfo info = GameLibrary.Detect(GameLibrary.TheDig);
+            Skip.If(info == null, "The Dig not present");
+
+            // The Dig keeps its voice in DIGVOICE.BUN, not a MONSTER.SOU, so no speech file is exposed.
+            Assert.Null(info.SpeechFilePath);
+        }
+
         private static List<SoundBlockV7> CollectSounds(ScummGameData game)
         {
             var list = new List<SoundBlockV7>();

--- a/ScummEditor.UnitTests/V7TextTests.cs
+++ b/ScummEditor.UnitTests/V7TextTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ScummEditor.Engine;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+using Xunit;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// SCUMM v7 (The Dig, Full Throttle) text pipeline: the scripts/objects are typed (ScriptBlock /
+    /// ObjectCode) so GameTextManager can extract and re-import their strings using the v6-compatible
+    /// disassembler (extended for the v7 opcodes/wait sub-ops and the 2-byte LSCR id). These tests prove
+    /// every script and verb decodes to the end (a prerequisite for safe import), that a no-op text
+    /// round-trip is byte-identical, and that a real edit applies and re-verifies.
+    /// </summary>
+    public class V7TextTests
+    {
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void AllScriptsAndVerbsDecodeToEnd(string path)
+        {
+            Skip.If(GameLibrary.Folder(path) == null, "not present: " + path);
+            ScummGameData game = GameLibrary.Load(path);
+
+            int scripts = 0, scriptsOk = 0, verbs = 0, verbsOk = 0;
+            foreach (DiskBlock disk in game.DataFile.GetLFLFs())
+            {
+                var blocks = new List<BlockBase>(disk.Childrens);
+                RoomBlock room = disk.GetROOM();
+                if (room != null) blocks.AddRange(room.Childrens);
+
+                foreach (BlockBase b in blocks)
+                {
+                    var s = b as ScriptBlock;
+                    if (s != null)
+                    {
+                        scripts++;
+                        if (s.Disassemble().DecodedToEnd) scriptsOk++;
+                    }
+
+                    var obcd = b as ObjectCode;
+                    if (obcd != null && obcd.VerbCodeOffset >= 0 && obcd.VerbCodeLength > 0)
+                    {
+                        verbs++;
+                        var slice = new byte[obcd.VerbCodeLength];
+                        Array.Copy(obcd.RawContent, obcd.VerbCodeOffset, slice, 0, obcd.VerbCodeLength);
+                        if (ScummV6Disassembler.Disassemble(slice, 0).DecodedToEnd) verbsOk++;
+                    }
+                }
+            }
+
+            Assert.True(scripts > 100, "too few scripts found: " + scripts);
+            Assert.True(scriptsOk == scripts, string.Format("only {0}/{1} scripts decoded to the end", scriptsOk, scripts));
+            Assert.True(verbsOk == verbs, string.Format("only {0}/{1} verb-code blocks decoded to the end", verbsOk, verbs));
+        }
+
+        [SkippableTheory]
+        [InlineData(GameLibrary.TheDig)]
+        [InlineData(GameLibrary.FullThrottle)]
+        public void TextNoOpRoundTripIsByteIdentical(string path)
+        {
+            Skip.If(GameLibrary.Folder(path) == null, "not present: " + path);
+            GameInfo info = GameLibrary.Detect(path);
+            ScummGameData game = ScummGameData.LoadFromGameInfo(info);
+            byte[] originalData = File.ReadAllBytes(info.DataFile);
+
+            string file = Path.Combine(Path.GetTempPath(), "v7_text_noop.txt");
+            int count = GameTextManager.ExportToFile(game.DataFile, file, GameTextCodec.Default(), "test");
+            Assert.True(count > 1000, "too few text entries exported: " + count);
+
+            // Re-importing the exact export must change nothing and round-trip the data byte-for-byte.
+            GameTextImportReport report = GameTextManager.ImportFromFile(game.DataFile, file);
+            Assert.Empty(report.Errors);
+            Assert.Equal(0, report.StringsChanged);
+
+            game.PostProcessChanges();
+            byte[] saved = SaveToBytes(s => game.DataFile.SaveToBinaryWriter(s));
+            Assert.True(BytesEqual(originalData, saved), "data file differs after a no-op text round-trip");
+
+            try { File.Delete(file); } catch { }
+        }
+
+        [SkippableFact]
+        public void SingleTextEditAppliesAndReverifies()
+        {
+            Skip.If(GameLibrary.Folder(GameLibrary.TheDig) == null, "The Dig not present");
+            ScummGameData game = GameLibrary.Load(GameLibrary.TheDig);
+
+            string file = Path.Combine(Path.GetTempPath(), "v7_text_edit.txt");
+            GameTextManager.ExportToFile(game.DataFile, file, GameTextCodec.Default(), "test");
+
+            // Lengthen the first plain-ASCII translatable line (exercises the jump remapping in
+            // RebuildCode), keeping its id, then re-import.
+            string[] lines = File.ReadAllLines(file);
+            string editedId = null, newText = null;
+            for (int i = 0; i < lines.Length; i++)
+            {
+                if (lines[i].Length == 0 || lines[i][0] == ';') continue;
+                int eq = lines[i].IndexOf('=');
+                if (eq <= 0) continue;
+                string id = lines[i].Substring(0, eq).Trim();
+                string text = lines[i].Substring(eq + 1).TrimStart();
+                if (text.Length >= 4 && IsPlainAscii(text))
+                {
+                    editedId = id;
+                    newText = text + " EDITADO";
+                    lines[i] = id + " = " + newText;
+                    break;
+                }
+            }
+            Assert.NotNull(editedId);
+            File.WriteAllLines(file, lines);
+
+            GameTextImportReport report = GameTextManager.ImportFromFile(game.DataFile, file);
+            Assert.Empty(report.Errors);
+            Assert.True(report.StringsChanged >= 1, "no string was changed");
+
+            // The edited text must now be what the pipeline extracts, and the rebuilt block must still
+            // round-trip through save (offsets recomputed).
+            List<GameTextEntry> after = GameTextManager.Extract(game.DataFile, GameTextCodec.Default());
+            Assert.Contains(after, e => e.Id == editedId && e.Text == newText);
+            Assert.Null(Record.Exception(() => game.PostProcessChanges()));
+
+            try { File.Delete(file); } catch { }
+        }
+
+        private static bool IsPlainAscii(string s)
+        {
+            foreach (char c in s)
+            {
+                bool letter = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+                if (!letter && c != ' ') return false;
+            }
+            return true;
+        }
+
+        private static byte[] SaveToBytes(Action<Stream> save)
+        {
+            using (var ms = new MemoryStream()) { save(ms); return ms.ToArray(); }
+        }
+
+        private static bool BytesEqual(byte[] a, byte[] b)
+        {
+            if (a.Length != b.Length) return false;
+            for (int i = 0; i < a.Length; i++) if (a[i] != b[i]) return false;
+            return true;
+        }
+    }
+}

--- a/ScummEditor.UnitTests/V7ViewerSweepTests.cs
+++ b/ScummEditor.UnitTests/V7ViewerSweepTests.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using ScummEditor.Engine;
+using ScummEditor.Engine.Encoders;
+using ScummEditor.Engine.Structures;
+using ScummEditor.Engine.Structures.DataFile;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ScummEditor.UnitTests
+{
+    /// <summary>
+    /// Cross-edition viewer sweep: loads EVERY v7 edition in the game library (all The Dig + Full Throttle
+    /// editions, incl. the localized / Windows / CJK ones) and actually DECODES a real sample through every
+    /// viewer's decode path - room/object/z-plane images, AKOS costume cels, in-resource charsets, .NUT
+    /// fonts, in-container iMUS/VOC sound, scripts + object verb bytecode, localized text, the MONSTER.SOU
+    /// speech file and the .BUN iMUSE bundles. The focused per-resource tests exercise The Dig + Full
+    /// Throttle exhaustively; this guards the gap that let the Full Throttle MONSTER.SOU "0 entries" bug ship
+    /// - a per-edition format quirk that a detection-only test never exercises. Every failure is collected so
+    /// the report is exhaustive; skips when the (git-ignored) library is absent.
+    /// </summary>
+    public class V7ViewerSweepTests
+    {
+        private readonly ITestOutputHelper _out;
+        public V7ViewerSweepTests(ITestOutputHelper output) { _out = output; }
+
+        [SkippableFact]
+        public void EveryV7EditionDecodesThroughEveryViewer()
+        {
+            List<string> editions = DiscoverV7Editions();
+            Skip.If(editions.Count == 0, "no v7 editions present in the game library");
+
+            var failures = new List<string>();
+            int sweptEditions = 0;
+
+            foreach (string folder in editions)
+            {
+                GameInfo info;
+                try { info = Functions.FindScummGameInFolder(folder); }
+                catch (Exception ex) { failures.Add(Rel(folder) + " | detect threw: " + ex.Message); continue; }
+                if (info == null || info.ScummVersion != 7) continue;
+
+                string rel = Rel(folder);
+                ScummGameData game;
+                try { game = ScummGameData.LoadFromGameInfo(info); }
+                catch (Exception ex) { failures.Add(rel + " | load threw: " + ex.GetType().Name + " " + ex.Message); continue; }
+
+                sweptEditions++;
+                SweepEdition(rel, info, game, failures);
+            }
+
+            _out.WriteLine($"Swept {sweptEditions} v7 editions; {failures.Count} failure(s).");
+            Assert.True(failures.Count == 0, "viewer decode failures:\n" + string.Join("\n", failures));
+            Assert.True(sweptEditions >= 2, "expected at least The Dig + Full Throttle; swept " + sweptEditions);
+        }
+
+        // Per-edition sample caps. Images/cels/scripts are essentially identical across the editions of one
+        // game (localization changes text/fonts/sound, not the artwork or opcode structure), and The Dig +
+        // Full Throttle are already decoded exhaustively by the focused tests - so here a sample per edition
+        // is enough to prove that viewer decodes for THAT edition, without 50k redundant identical decodes.
+        private const int ImageCap = 150;
+        private const int CelCap = 150;
+        private const int ScriptCap = 300;
+        private const int SoundCap = 40;
+
+        private void SweepEdition(string rel, GameInfo info, ScummGameData game, List<string> failures)
+        {
+            int images = 0, cels = 0, glyphs = 0, sounds = 0, scripts = 0, verbs = 0, charsets = 0;
+
+            // --- in-container resources walked from the LFLF/ROOM tree ---
+            foreach (DiskBlock disk in game.DataFile.GetLFLFs())
+            {
+                RoomBlock room = disk.GetROOM();
+                if (room != null)
+                {
+                    // background + its z-planes
+                    Try(failures, rel, "background", () =>
+                    {
+                        using (Bitmap bg = ImageResourceCodec.Decode(room, null, ImageType.Background, 0, 0, 0, 0, false))
+                            if (bg != null) images++;
+                    });
+                    List<ZPlane> zps = SafeZPlanes(room);
+                    for (int z = 0; z < zps.Count; z++)
+                    {
+                        int zi = z;
+                        Try(failures, rel, "z-plane " + zi, () =>
+                        {
+                            using (Bitmap zp = ImageResourceCodec.Decode(room, null, ImageType.ZPlane, 0, 0, zi, 0, false))
+                                if (zp != null) images++;
+                        });
+                    }
+                    // object images (capped per edition - the format is uniform, we only need to exercise it)
+                    List<ObjectImage> obims = room.GetOBIMs();
+                    for (int j = 0; j < obims.Count && images < ImageCap; j++)
+                    {
+                        int jj = j;
+                        List<ImageData> imgs = obims[j].GetIMxx();
+                        for (int k = 0; k < imgs.Count; k++)
+                        {
+                            int kk = k;
+                            Try(failures, rel, "object " + jj + "/" + kk, () =>
+                            {
+                                using (Bitmap im = ImageResourceCodec.Decode(room, null, ImageType.Object, jj, kk, 0, 0, false))
+                                    if (im != null) images++;
+                            });
+                        }
+                    }
+                }
+
+                foreach (BlockBase child in Children(disk, room))
+                {
+                    if (child.BlockType == "AKOS" && cels < CelCap)
+                    {
+                        int count = AkosImageDecoder.GetCelCount(child);
+                        for (int i = 0; i < count; i++)
+                        {
+                            int ci = i;
+                            Try(failures, rel, "AKOS cel " + ci, () =>
+                            {
+                                using (Bitmap bmp = AkosImageDecoder.DecodeCel(child, ci))
+                                    if (bmp != null) cels++;
+                            });
+                        }
+                    }
+
+                    if (child is ScriptBlock s && scripts < ScriptCap)
+                    {
+                        scripts++;
+                        Try(failures, rel, "script", () =>
+                        {
+                            if (!s.Disassemble().DecodedToEnd) failures.Add(rel + " | script did not decode to end");
+                        });
+                    }
+
+                    if (child is ObjectCode oc && oc.VerbCodeOffset >= 0 && oc.VerbCodeLength > 0 && verbs < ScriptCap)
+                    {
+                        verbs++;
+                        Try(failures, rel, "verb code", () =>
+                        {
+                            var slice = new byte[oc.VerbCodeLength];
+                            Array.Copy(oc.RawContent, oc.VerbCodeOffset, slice, 0, oc.VerbCodeLength);
+                            if (!ScummV6Disassembler.Disassemble(slice, 0).DecodedToEnd)
+                                failures.Add(rel + " | verb code did not decode to end");
+                        });
+                    }
+                }
+            }
+
+            // --- in-container sound (sampled: the per-format decode is what we are exercising) ---
+            foreach (SoundBlockV7 sound in CollectSounds(game))
+            {
+                if (sounds >= SoundCap) break;
+                Try(failures, rel, "sound", () =>
+                {
+                    byte[] body = Serialize(sound);
+                    if (ImuseAudioDecoder.IsImus(body))
+                    {
+                        if (ImuseAudioDecoder.ToWav(body) != null) sounds++;
+                    }
+                    else
+                    {
+                        int voc = IndexOf(body, "Creative Voice File");
+                        if (voc >= 0)
+                        {
+                            var slice = new byte[body.Length - voc];
+                            Array.Copy(body, voc, slice, 0, slice.Length);
+                            if (SoundConverter.VocToWav(slice) != null) sounds++;
+                        }
+                    }
+                });
+            }
+
+            // --- in-resource charsets: ExportPng renders every glyph (real decode) ---
+            string tmp = Path.Combine(Path.GetTempPath(), "v7sweep_" + Guid.NewGuid().ToString("N"));
+            try
+            {
+                Directory.CreateDirectory(tmp);
+                foreach (Charset cs in CharsetPngCodec.CollectCharsets(game.DataFile))
+                {
+                    int idx = charsets;
+                    Try(failures, rel, "charset " + idx, () =>
+                    {
+                        CharsetPngCodec.ExportPng(cs, Path.Combine(tmp, "c" + idx + ".png"), Path.Combine(tmp, "c" + idx + ".guide.png"));
+                        charsets++;
+                    });
+                }
+            }
+            finally { try { Directory.Delete(tmp, true); } catch { } }
+
+            // --- external .NUT SMUSH fonts ---
+            if (game.NutFonts != null)
+            {
+                foreach (NutFontResource res in game.NutFonts)
+                {
+                    NutFont font = res.Font;
+                    if (font == null || !font.IsValid) continue;
+                    for (int i = 0; i < font.Glyphs.Count; i++)
+                    {
+                        if (!font.Glyphs[i].HasPixels) continue;
+                        int gi = i;
+                        Try(failures, rel, "NUT glyph " + gi, () =>
+                        {
+                            if (NutImageDecoder.DecodeGlyphIndices(font, gi) != null) glyphs++;
+                        });
+                    }
+                }
+            }
+
+            // --- localized text (LANGUAGE.BND / .TRS) - exhaustively swept elsewhere, touched here too ---
+            if (game.LocalizedTextFiles != null)
+            {
+                foreach (ILocalizedTextFile text in game.LocalizedTextFiles)
+                {
+                    int n = 0;
+                    foreach (LocalizedTextEntry e in text.Entries) { n++; if (n > 0) break; }
+                }
+            }
+
+            // --- external speech MONSTER.SOU (Full Throttle) ---
+            if (!string.IsNullOrEmpty(info.SpeechFilePath) && File.Exists(info.SpeechFilePath))
+            {
+                Try(failures, rel, "MONSTER.SOU", () =>
+                {
+                    var speech = new SpeechSouFile(info.SpeechFilePath);
+                    speech.EnsureParsed();
+                    if (speech.ParseError != null) failures.Add(rel + " | MONSTER.SOU parse stopped: " + speech.ParseError);
+                    if (speech.Entries.Count == 0) failures.Add(rel + " | MONSTER.SOU yielded 0 entries");
+                    // decode a small sample of the speech VOCs
+                    int take = Math.Min(10, speech.Entries.Count);
+                    for (int i = 0; i < take; i++)
+                    {
+                        if (SoundConverter.VocToWav(speech.ReadVocBytes(speech.Entries[i])) == null)
+                            failures.Add(rel + " | MONSTER.SOU entry " + i + " did not decode to WAV");
+                    }
+                });
+            }
+
+            // --- external iMUSE bundles .BUN (The Dig) ---
+            if (info.BundleFiles != null)
+            {
+                foreach (string path in info.BundleFiles)
+                {
+                    if (!File.Exists(path)) continue;
+                    string name = Path.GetFileName(path);
+                    Try(failures, rel, name, () =>
+                    {
+                        var bundle = new ImuseBundleFile(path);
+                        bundle.EnsureParsed();
+                        if (!bundle.IsValid || bundle.Entries.Count == 0) { failures.Add(rel + " | " + name + " parsed no entries"); return; }
+                        int take = Math.Min(6, bundle.Entries.Count);
+                        for (int i = 0; i < take; i++)
+                        {
+                            if (ImuseBundleDecoder.ToWav(bundle.ReadEntryRaw(i)) == null)
+                                failures.Add(rel + " | " + name + " entry " + i + " did not decode to WAV");
+                        }
+                    });
+                }
+            }
+
+            _out.WriteLine($"  {rel}: img={images} cels={cels} glyphs={glyphs} sounds={sounds} scripts={scripts} verbs={verbs} charsets={charsets}");
+        }
+
+        // ---- helpers ----
+
+        private static void Try(List<string> failures, string rel, string label, Action action)
+        {
+            try { action(); }
+            catch (Exception ex)
+            {
+                if (failures.Count < 80) failures.Add(rel + " | " + label + ": " + ex.GetType().Name + " " + ex.Message);
+            }
+        }
+
+        private static List<ZPlane> SafeZPlanes(RoomBlock room)
+        {
+            try
+            {
+                var rmim = room.GetRMIM();
+                var im00 = rmim != null ? rmim.GetIM00() : null;
+                return im00 != null ? im00.GetZPlanes() : new List<ZPlane>();
+            }
+            catch { return new List<ZPlane>(); }
+        }
+
+        private static IEnumerable<BlockBase> Children(DiskBlock disk, RoomBlock room)
+        {
+            foreach (BlockBase c in disk.Childrens) yield return c;
+            if (room != null)
+                foreach (BlockBase c in room.Childrens) yield return c;
+        }
+
+        private static List<SoundBlockV7> CollectSounds(ScummGameData game)
+        {
+            var list = new List<SoundBlockV7>();
+            WalkSounds((BlockBase)game.DataFile, list);
+            return list;
+        }
+
+        private static void WalkSounds(BlockBase node, List<SoundBlockV7> outList)
+        {
+            if (node is SoundBlockV7 s) outList.Add(s);
+            foreach (BlockBase c in node.Childrens) WalkSounds(c, outList);
+        }
+
+        private static byte[] Serialize(BlockBase block)
+        {
+            using (var ms = new MemoryStream())
+            {
+                block.SaveToBinaryWriter(ms);
+                return ms.ToArray();
+            }
+        }
+
+        private static int IndexOf(byte[] data, string text)
+        {
+            for (int i = 0; i + text.Length <= data.Length; i++)
+            {
+                bool match = true;
+                for (int j = 0; j < text.Length; j++)
+                {
+                    if (data[i + j] != text[j]) { match = false; break; }
+                }
+                if (match) return i;
+            }
+            return -1;
+        }
+
+        /// <summary>Every distinct v7 edition folder in the library (a folder holding a *.LA0 index).</summary>
+        private static List<string> DiscoverV7Editions()
+        {
+            var result = new List<string>();
+            string root = GameLibrary.Folder("ScummV7");
+            if (root == null) return result;
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string la0 in Directory.GetFiles(root, "*.LA0", SearchOption.AllDirectories))
+            {
+                string dir = Path.GetDirectoryName(la0);
+                if (dir != null && seen.Add(dir)) result.Add(dir);
+            }
+            result.Sort(StringComparer.OrdinalIgnoreCase);
+            return result;
+        }
+
+        private static string Rel(string folder)
+        {
+            string root = GameLibrary.Folder("ScummV7");
+            return (root != null && folder.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+                ? folder.Substring(root.Length).TrimStart('\\', '/')
+                : folder;
+        }
+    }
+}


### PR DESCRIPTION
## SCUMM v7 support — The Dig & Full Throttle (v4.0.0)

Extends the editor from v1–v6 to **v7** (The Dig, Full Throttle, 1995), with full feature parity to the v2–v6 games plus the v7-specific extras. The v7 engine is a direct extension of v5/v6 (same tagged IFF container), split across a separate index file (`.LA0`) and data file (`.LA1`).

All games are recognized **from the content of their data files alone**, never the game EXE. The container **round-trips byte-for-byte across all 24 editions** of the two games (every language release tested).

### What's included
- **Foundation** — `.LA0`/`.LA1` detection, gap-tolerant recursive IFF container walk, full block tree, 24/24 editions byte-identical round-trip (incl. the real on-disk save path).
- **Text translation** — names, verb/entry/exit/global scripts disassemble + export/import, tables and jump offsets remapped automatically; v6 disassembler completed for the v7-only opcodes (incl. the 2-byte local-script id).
- **Localized text** (the high-value feature) — exposes the on-screen text kept *outside* the container: The Dig's `LANGUAGE.BND` dialogue (deobfuscated) + both games' `.TRS` subtitle/UI text (plain or ETRS); new "Texts (localized)" node; **byte-identical round-trip**.
- **DOS code-page accents** — localized text transcoded in the original MS-DOS code page (CP850 for Western incl. Brazilian Portuguese).
- **Images** — backgrounds, objects, z-plane masks reuse the v5/v6 SMAP/BOMP codecs; view + export/import as lossless indexed PNGs.
- **Costumes (AKOS)** — the three codecs these games use (run-length, BOMP, MAJMIN); viewer + per-resource and batch PNG export/import.
- **Fonts** — in-container charsets + external `.NUT` SMUSH fonts; a re-encoded `.NUT` matches the exact layout the engine's loader expects (regression test reproduces ScummVM's two-pass `loadFont` walk + pixel decode).
- **Sound** — in-container iMUS/VOC, Full Throttle `MONSTER.SOU` (incl. VTLK wrapper), The Dig `.BUN` iMUSE bundles fully decompressed; play + export WAV. Import deferred (same as v4–v6).
- **Language detection** — automatic per v7 release.

### Validation
- **401/401 xUnit**; build warning-free.
- All 24 editions decoded through every viewer, no failures.
- Each game edited **end-to-end at once** and booted in **both ScummVM 2026.3.0 and DOSBox** — edits render, games run.
- Adversarial-review passes on substantive changes; per-node Export/Import parity.

### Known limitations
- Sound **import** not yet available (same as v4–v6).
- SMUSH `.SAN` cutscenes + original-DOS support binaries (ScummVM reimplements) listed but not edited.
- A size-changing edit changes the index checksum (ScummVM auto-detect may need it); a size-neutral edit keeps it identical.

### Version
Bumped **3.6.1 → 4.0.0** 